### PR TITLE
feat: transaction CRUD, backup/restore, settings page

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,6 +25,7 @@ dotnet_diagnostic.SA1309.severity = none   # Field names must not begin with an 
 dotnet_diagnostic.SA1310.severity = none   # Field names must not contain Hungarian notation
 dotnet_diagnostic.SA1602.severity = none   # Enumeration items must be documented
 dotnet_diagnostic.SA1011.severity = none   # Closing square bracket spacing (conflicts with nullable syntax)
+dotnet_diagnostic.SA1137.severity = none   # Elements should have the same indentation (conflicts with try-wrapped top-level statements)
 dotnet_diagnostic.SA1313.severity = none   # Parameter names must begin with lower-case letter (conflicts with record primary constructors)
 
 #### Example of keeping some useful rules active ####

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,73 @@
+# MyAccountingApp
+
+Personal finance tracking app. Import bank CSV + broker statements, FIFO cost basis, annual summaries, full CRUD via Blazor WASM UI.
+
+## Tech Stack
+- **Backend**: .NET 9 Minimal API (C#)
+- **Frontend**: Blazor WASM (MudBlazor 9.0.6)
+- **Data**: JSON files (`data/transactions.json`, `data/portfolio.json`, `data/conversions.json`)
+- **Infrastructure**: Docker multi-stage (WASM served from API `wwwroot/`)
+
+## Architecture
+
+```
+MyAccountingApp.Domain     → Entities, ValueObjects, Interfaces
+MyAccountingApp.Core       → Repositories (JSON, InMemory, Composite), Services, Agents
+MyAccountingApp.Application → DTOs, DTO mapper, Services (import, portfolio, summary)
+MyAccountingApp.Api       → Minimal API endpoints, DI setup
+MyAccountingApp.Web       → Blazor WASM UI (MudBlazor pages)
+```
+
+## Key Features
+- **Import**: Bank CSV + broker statements via folder scan or file upload (`POST /api/import/upload`)
+- **Transactions**: List with filters (year, category, search), sorting, pagination; full CRUD (create/edit/delete)
+- **Asset Transactions**: CRUD with Symbol, Quantity, Type fields
+- **Portfolio**: Positions table with expandable open lots, realized/unrealized P&L, coloring
+- **Annual Summary**: `GET /api/summary` and `GET /api/summary/{year}`
+- **Conversions**: Currency rate management
+- **Market Prices**: Yahoo Finance integration via `IMarketPriceService`
+- **Position Engine**: FIFO cost basis, P&L calculation
+
+## API Endpoints
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/transactions` | List all transactions |
+| POST | `/api/transactions` | Create transaction |
+| PUT | `/api/transactions/{id}` | Update transaction |
+| DELETE | `/api/transactions/{id}` | Delete transaction |
+| GET | `/api/asset-transactions` | List asset transactions |
+| POST | `/api/asset-transactions` | Create asset transaction |
+| PUT | `/api/asset-transactions/{id}` | Update asset transaction |
+| DELETE | `/api/asset-transactions/{id}` | Delete asset transaction |
+| GET | `/api/portfolio` | Portfolio positions |
+| GET | `/api/conversions` | Currency conversions |
+| GET | `/api/summary` | Annual summaries |
+| POST | `/api/import` | Folder import |
+| POST | `/api/import/upload` | CSV file upload |
+
+## Persistence
+- **JSON files** mounted as Docker volumes (`./data:/app/data`)
+- Atomic writes: write to `.tmp`, then `File.Move` (prevents corruption)
+- Auto-recovery: `GetAll()` truncates to last valid `}` if JSON is corrupted
+- Deduplication: `GetAll()` removes duplicate IDs on read
+
+## Running
+```bash
+docker compose up --build -d
+```
+- Container: `myaccountingapp-api`
+- URL: `http://localhost:8080`
+- Swagger: `http://localhost:8080/swagger`
+- Logs: mounted to `./logs/` (Serilog, 7-day retention)
+
+## Key Environment Variables
+- `CURRENCY_API_KEY` — API key for exchangerate.host
+
+## Current State (July 2026)
+- 134 tests, 81.94% combined coverage
+- Branch: `58-transaction-crud` (PR #5 open)
+- CI: GitHub Actions, Release build with `-warnaserror`
+
+## Known Issues
+- WASM browser cache: use Ctrl+F5 or incognito after rebuild
+- `data/transactions.json` had duplicates from old corruption recovery (now fixed with dedup)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,6 @@ services:
       - ./data:/app/data
       - ./csv:/app/csv
       - ./import:/app/import
+      - ./logs:/app/logs
     environment:
       - CURRENCY_API_KEY=${CURRENCY_API_KEY}

--- a/src/MyAccountingApp.Api/MyAccountingApp.Api.csproj
+++ b/src/MyAccountingApp.Api/MyAccountingApp.Api.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -333,10 +333,11 @@ app.MapGet($"{prefix}/summary/{{year:int}}", (int year, IAnnualSummaryService su
     return summary is not null ? Results.Ok(summary) : Results.NotFound(new { year, message = "No data found for this year" });
 });
 
-app.MapGet($"{prefix}/backup", async (ITransactionRepository txRepo, IPortfolioRepository pfRepo) =>
+app.MapGet($"{prefix}/backup", (ITransactionRepository txRepo, IPortfolioRepository pfRepo) =>
 {
     List<Transaction> transactions = txRepo.GetAll().ToList();
-    string json = JsonSerializer.Serialize(new { transactions }, new JsonSerializerOptions { WriteIndented = true });
+    List<AssetTransaction> assetTransactions = pfRepo.GetAllTransactions().ToList();
+    string json = JsonSerializer.Serialize(new { transactions, assetTransactions }, new JsonSerializerOptions { WriteIndented = true });
     byte[] bytes = Encoding.UTF8.GetBytes(json);
     return Results.File(bytes, "application/json", $"myaccounting-backup-{DateTime.Now:yyyyMMdd}.json");
 });
@@ -353,8 +354,12 @@ app.MapPost($"{prefix}/backup", async (HttpRequest request, ITransactionReposito
             return Results.BadRequest(new { error = "Invalid backup file format: 'transactions' array is required" });
 
         txRepo.Initialize(backup.Transactions);
-        logger.LogInformation("Backup restored: {Count} transactions", backup.Transactions.Count);
-        return Results.Ok(new { message = $"Restored {backup.Transactions.Count} transactions" });
+        if (backup.AssetTransactions is not null)
+            pfRepo.Initialize(backup.AssetTransactions);
+
+        logger.LogInformation("Backup restored: {Count} transactions, {Count2} asset transactions",
+            backup.Transactions.Count, backup.AssetTransactions?.Count ?? 0);
+        return Results.Ok(new { message = $"Restored {backup.Transactions.Count} transactions and {backup.AssetTransactions?.Count ?? 0} asset transactions" });
     }
     catch (JsonException ex)
     {
@@ -379,4 +384,4 @@ finally
 record ImportRequest(List<string> FolderPaths);
 record CreateTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category);
 record CreateAssetTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category, string Symbol, decimal Quantity, string Type);
-record BackupData(List<Transaction> Transactions);
+record BackupData(List<Transaction> Transactions, List<AssetTransaction>? AssetTransactions);

--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -4,8 +4,10 @@ using MyAccountingApp.Application.Services;
 using MyAccountingApp.Core.Agents;
 using MyAccountingApp.Core.Repositories;
 using MyAccountingApp.Core.Services;
+using MyAccountingApp.Domain.Entities;
 using MyAccountingApp.Domain.Enums;
 using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -80,6 +82,48 @@ app.MapGet($"{prefix}/transactions", (ITransactionRepository repo) =>
     return Results.Ok(transactions);
 });
 
+app.MapPost($"{prefix}/transactions", (CreateTransactionRequest request, ITransactionRepository repo, ITransactionValidator validator) =>
+{
+    Money money = new(request.Amount, request.Currency);
+    TransactionCategory category = Enum.Parse<TransactionCategory>(request.Category);
+    Transaction transaction = new(request.Date, request.Description, money, category);
+
+    ValidationResult validation = validator.Validate(transaction);
+    if (!validation.IsValid)
+        return Results.BadRequest(validation.Errors);
+
+    repo.AddOrUpdate(transaction);
+    return Results.Created($"/api/transactions/{transaction.Id}", transaction.ToDto());
+});
+
+app.MapPut($"{prefix}/transactions/{{id:guid}}", (Guid id, CreateTransactionRequest request, ITransactionRepository repo, ITransactionValidator validator) =>
+{
+    Transaction? existing = repo.GetAll().FirstOrDefault(t => t.Id == id);
+    if (existing is null)
+        return Results.NotFound(new { id, message = "Transaction not found" });
+
+    Money money = new(request.Amount, request.Currency);
+    TransactionCategory category = Enum.Parse<TransactionCategory>(request.Category);
+    Transaction transaction = new(id, request.Date, request.Description, money, category);
+
+    ValidationResult validation = validator.Validate(transaction);
+    if (!validation.IsValid)
+        return Results.BadRequest(validation.Errors);
+
+    repo.AddOrUpdate(transaction);
+    return Results.Ok(transaction.ToDto());
+});
+
+app.MapDelete($"{prefix}/transactions/{{id:guid}}", (Guid id, ITransactionRepository repo) =>
+{
+    Transaction? existing = repo.GetAll().FirstOrDefault(t => t.Id == id);
+    if (existing is null)
+        return Results.NotFound(new { id, message = "Transaction not found" });
+
+    repo.Delete(existing);
+    return Results.NoContent();
+});
+
 app.MapGet($"{prefix}/asset-transactions", (IPortfolioRepository repo) =>
 {
     List<AssetTransactionDto> transactions = repo.GetAllTransactions().Select(t => t.ToDto()).ToList();
@@ -90,6 +134,52 @@ app.MapGet($"{prefix}/asset-transactions/{{symbol}}", (string symbol, IPortfolio
 {
     List<AssetTransactionDto> transactions = repo.GetAssetTransactions(symbol).Select(t => t.ToDto()).ToList();
     return Results.Ok(transactions);
+});
+
+app.MapPost($"{prefix}/asset-transactions", (CreateAssetTransactionRequest request, IPortfolioRepository repo, ITransactionValidator validator) =>
+{
+    Money money = new(request.Amount, request.Currency);
+    TransactionCategory category = Enum.Parse<TransactionCategory>(request.Category);
+    Transaction transaction = new(request.Date, request.Description, money, category);
+
+    ValidationResult validation = validator.Validate(transaction);
+    if (!validation.IsValid)
+        return Results.BadRequest(validation.Errors);
+
+    AssetTransactionType type = Enum.Parse<AssetTransactionType>(request.Type);
+    AssetTransaction assetTx = new(transaction, request.Symbol, request.Quantity, type);
+    repo.AddOrUpdate(assetTx);
+    return Results.Created($"/api/asset-transactions/{transaction.Id}", assetTx.ToDto());
+});
+
+app.MapPut($"{prefix}/asset-transactions/{{id:guid}}", (Guid id, CreateAssetTransactionRequest request, IPortfolioRepository repo, ITransactionValidator validator) =>
+{
+    AssetTransaction? existing = repo.GetAllTransactions().FirstOrDefault(t => t.Transaction.Id == id);
+    if (existing is null)
+        return Results.NotFound(new { id, message = "Asset transaction not found" });
+
+    Money money = new(request.Amount, request.Currency);
+    TransactionCategory category = Enum.Parse<TransactionCategory>(request.Category);
+    Transaction transaction = new(id, request.Date, request.Description, money, category);
+
+    ValidationResult validation = validator.Validate(transaction);
+    if (!validation.IsValid)
+        return Results.BadRequest(validation.Errors);
+
+    AssetTransactionType type = Enum.Parse<AssetTransactionType>(request.Type);
+    AssetTransaction assetTx = new(transaction, request.Symbol, request.Quantity, type);
+    repo.AddOrUpdate(assetTx);
+    return Results.Ok(assetTx.ToDto());
+});
+
+app.MapDelete($"{prefix}/asset-transactions/{{id:guid}}", (Guid id, IPortfolioRepository repo) =>
+{
+    AssetTransaction? existing = repo.GetAllTransactions().FirstOrDefault(t => t.Transaction.Id == id);
+    if (existing is null)
+        return Results.NotFound(new { id, message = "Asset transaction not found" });
+
+    repo.Delete(id);
+    return Results.NoContent();
 });
 
 app.MapPost($"{prefix}/import", async (ImportRequest request, IImportService importService) =>
@@ -178,3 +268,5 @@ app.MapFallbackToFile("index.html");
 app.Run();
 
 record ImportRequest(List<string> FolderPaths);
+record CreateTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category);
+record CreateAssetTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category, string Symbol, decimal Quantity, string Type);

--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -259,6 +259,28 @@ app.MapPost($"{prefix}/import/upload", async (HttpContext http, IImportService i
     }
 });
 
+// Clears cash transactions and portfolio (asset) data. Does not touch currency conversions.
+app.MapPost($"{prefix}/data/reset", (ITransactionRepository transactionRepo, IPortfolioRepository portfolioRepo, ILogger<Program> logger) =>
+{
+    int transactionCount = transactionRepo.GetAll().Count();
+    int assetTransactionCount = portfolioRepo.GetAllTransactions().Count();
+
+    transactionRepo.Initialize(Array.Empty<Transaction>());
+    portfolioRepo.Initialize(Array.Empty<AssetTransaction>());
+
+    logger.LogWarning(
+        "Data reset: cleared {TransactionCount} transactions and {AssetTransactionCount} asset transactions",
+        transactionCount,
+        assetTransactionCount);
+
+    return Results.Ok(new
+    {
+        message = "Database reset completed",
+        clearedTransactions = transactionCount,
+        clearedAssetTransactions = assetTransactionCount,
+    });
+});
+
 app.MapGet($"{prefix}/portfolio", async (IPortfolioRepository repo, IPositionEngine positionEngine) =>
 {
     string[] symbols = repo.GetAllTransactions().Select(t => t.Symbol).Distinct().ToArray();

--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -5,6 +5,7 @@ using MyAccountingApp.Core.Agents;
 using MyAccountingApp.Core.Repositories;
 using MyAccountingApp.Core.Services;
 using MyAccountingApp.Domain.Entities;
+using Microsoft.AspNetCore.Diagnostics;
 using MyAccountingApp.Domain.Enums;
 using MyAccountingApp.Domain.Interfaces;
 using MyAccountingApp.Domain.ValueObjects;
@@ -106,7 +107,9 @@ app.MapPost($"{prefix}/transactions", (CreateTransactionRequest request, ITransa
 
     ValidationResult validation = validator.Validate(transaction);
     if (!validation.IsValid)
+    {
         return Results.BadRequest(validation.Errors);
+    }
 
     repo.AddOrUpdate(transaction);
     return Results.Created($"/api/transactions/{transaction.Id}", transaction.ToDto());
@@ -116,7 +119,9 @@ app.MapPut($"{prefix}/transactions/{{id:guid}}", (Guid id, CreateTransactionRequ
 {
     Transaction? existing = repo.GetAll().FirstOrDefault(t => t.Id == id);
     if (existing is null)
+    {
         return Results.NotFound(new { id, message = "Transaction not found" });
+    }
 
     Money money = new(request.Amount, request.Currency);
     TransactionCategory category = Enum.Parse<TransactionCategory>(request.Category);
@@ -124,7 +129,9 @@ app.MapPut($"{prefix}/transactions/{{id:guid}}", (Guid id, CreateTransactionRequ
 
     ValidationResult validation = validator.Validate(transaction);
     if (!validation.IsValid)
+    {
         return Results.BadRequest(validation.Errors);
+    }
 
     repo.AddOrUpdate(transaction);
     return Results.Ok(transaction.ToDto());
@@ -134,7 +141,9 @@ app.MapDelete($"{prefix}/transactions/{{id:guid}}", (Guid id, ITransactionReposi
 {
     Transaction? existing = repo.GetAll().FirstOrDefault(t => t.Id == id);
     if (existing is null)
+    {
         return Results.NotFound(new { id, message = "Transaction not found" });
+    }
 
     repo.Delete(existing);
     return Results.NoContent();
@@ -160,7 +169,9 @@ app.MapPost($"{prefix}/asset-transactions", (CreateAssetTransactionRequest reque
 
     ValidationResult validation = validator.Validate(transaction);
     if (!validation.IsValid)
+    {
         return Results.BadRequest(validation.Errors);
+    }
 
     AssetTransactionType type = Enum.Parse<AssetTransactionType>(request.Type);
     AssetTransaction assetTx = new(transaction, request.Symbol, request.Quantity, type);
@@ -172,7 +183,9 @@ app.MapPut($"{prefix}/asset-transactions/{{id:guid}}", (Guid id, CreateAssetTran
 {
     AssetTransaction? existing = repo.GetAllTransactions().FirstOrDefault(t => t.Transaction.Id == id);
     if (existing is null)
+    {
         return Results.NotFound(new { id, message = "Asset transaction not found" });
+    }
 
     Money money = new(request.Amount, request.Currency);
     TransactionCategory category = Enum.Parse<TransactionCategory>(request.Category);
@@ -180,7 +193,9 @@ app.MapPut($"{prefix}/asset-transactions/{{id:guid}}", (Guid id, CreateAssetTran
 
     ValidationResult validation = validator.Validate(transaction);
     if (!validation.IsValid)
+    {
         return Results.BadRequest(validation.Errors);
+    }
 
     AssetTransactionType type = Enum.Parse<AssetTransactionType>(request.Type);
     AssetTransaction assetTx = new(transaction, request.Symbol, request.Quantity, type);
@@ -192,7 +207,9 @@ app.MapDelete($"{prefix}/asset-transactions/{{id:guid}}", (Guid id, IPortfolioRe
 {
     AssetTransaction? existing = repo.GetAllTransactions().FirstOrDefault(t => t.Transaction.Id == id);
     if (existing is null)
+    {
         return Results.NotFound(new { id, message = "Asset transaction not found" });
+    }
 
     repo.Delete(id);
     return Results.NoContent();

--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -9,8 +9,18 @@ using Microsoft.AspNetCore.Diagnostics;
 using MyAccountingApp.Domain.Enums;
 using MyAccountingApp.Domain.Interfaces;
 using MyAccountingApp.Domain.ValueObjects;
+using Serilog;
 
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.File("logs/myaccountingapp-.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7)
+    .WriteTo.Console()
+    .CreateLogger();
+
+try
+{
+    Log.Information("Starting MyAccountingApp API");
+
+    WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 bool isDev = builder.Environment.IsDevelopment();
 
@@ -60,8 +70,11 @@ builder.Services.AddSingleton<IPositionEngine, PositionEngine>();
 builder.Services.AddSingleton<IValidationQuery, ValidationQuery>();
 builder.Services.AddSingleton<IAnnualSummaryService, AnnualSummaryService>();
 
+builder.Host.UseSerilog();
+
 WebApplication app = builder.Build();
 
+app.UseSerilogRequestLogging();
 app.UseExceptionHandler(exceptionHandlerApp =>
 {
     exceptionHandlerApp.Run(async context =>
@@ -299,6 +312,16 @@ app.MapGet($"{prefix}/summary/{{year:int}}", (int year, IAnnualSummaryService su
 app.MapFallbackToFile("index.html");
 
 app.Run();
+
+}
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Application terminated unexpectedly");
+}
+finally
+{
+    Log.CloseAndFlush();
+}
 
 record ImportRequest(List<string> FolderPaths);
 record CreateTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category);

--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -61,6 +61,22 @@ builder.Services.AddSingleton<IAnnualSummaryService, AnnualSummaryService>();
 
 WebApplication app = builder.Build();
 
+app.UseExceptionHandler(exceptionHandlerApp =>
+{
+    exceptionHandlerApp.Run(async context =>
+    {
+        context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+        context.Response.ContentType = "application/json";
+        var exceptionHandlerPathFeature = context.Features.Get<IExceptionHandlerPathFeature>();
+        var error = exceptionHandlerPathFeature?.Error;
+        await context.Response.WriteAsJsonAsync(new
+        {
+            error = error?.Message ?? "An unexpected error occurred",
+            type = error?.GetType().Name,
+        });
+    });
+});
+
 app.UseCors();
 app.UseSwagger();
 app.UseSwaggerUI();

--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -5,6 +5,8 @@ using MyAccountingApp.Core.Agents;
 using MyAccountingApp.Core.Repositories;
 using MyAccountingApp.Core.Services;
 using MyAccountingApp.Domain.Entities;
+using System.Text;
+using System.Text.Json;
 using Microsoft.AspNetCore.Diagnostics;
 using MyAccountingApp.Domain.Enums;
 using MyAccountingApp.Domain.Interfaces;

--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -331,6 +331,35 @@ app.MapGet($"{prefix}/summary/{{year:int}}", (int year, IAnnualSummaryService su
     return summary is not null ? Results.Ok(summary) : Results.NotFound(new { year, message = "No data found for this year" });
 });
 
+app.MapGet($"{prefix}/backup", async (ITransactionRepository txRepo, IPortfolioRepository pfRepo) =>
+{
+    List<Transaction> transactions = txRepo.GetAll().ToList();
+    string json = JsonSerializer.Serialize(new { transactions }, new JsonSerializerOptions { WriteIndented = true });
+    byte[] bytes = Encoding.UTF8.GetBytes(json);
+    return Results.File(bytes, "application/json", $"myaccounting-backup-{DateTime.Now:yyyyMMdd}.json");
+});
+
+app.MapPost($"{prefix}/backup", async (HttpRequest request, ITransactionRepository txRepo, IPortfolioRepository pfRepo, ILogger<Program> logger) =>
+{
+    using StreamReader reader = new(request.Body);
+    string body = await reader.ReadToEndAsync();
+
+    try
+    {
+        var backup = JsonSerializer.Deserialize<BackupData>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        if (backup?.Transactions is null)
+            return Results.BadRequest(new { error = "Invalid backup file format: 'transactions' array is required" });
+
+        txRepo.Initialize(backup.Transactions);
+        logger.LogInformation("Backup restored: {Count} transactions", backup.Transactions.Count);
+        return Results.Ok(new { message = $"Restored {backup.Transactions.Count} transactions" });
+    }
+    catch (JsonException ex)
+    {
+        return Results.BadRequest(new { error = $"Invalid JSON: {ex.Message}" });
+    }
+});
+
 app.MapFallbackToFile("index.html");
 
 app.Run();
@@ -348,3 +377,4 @@ finally
 record ImportRequest(List<string> FolderPaths);
 record CreateTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category);
 record CreateAssetTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category, string Symbol, decimal Quantity, string Type);
+record BackupData(List<Transaction> Transactions);

--- a/src/MyAccountingApp.Application/Services/ImportService.cs
+++ b/src/MyAccountingApp.Application/Services/ImportService.cs
@@ -33,6 +33,11 @@ public class ImportService : IImportService
     {
         ImportResult result = new ImportResult();
 
+        // Batch in memory, then persist once. Per-row AddOrUpdate rewrites the full JSON file
+        // each time and times out HttpClient (~100s) on ~2k-row imports.
+        List<Domain.Entities.Transaction> pendingTransactions = new List<Domain.Entities.Transaction>();
+        List<Domain.Entities.AssetTransaction> pendingAssets = new List<Domain.Entities.AssetTransaction>();
+
         foreach (string folderPath in folderPaths)
         {
             if (!Directory.Exists(folderPath))
@@ -61,7 +66,7 @@ public class ImportService : IImportService
                             result.ValidationWarnings.AddRange(vr.Warnings);
                             if (vr.IsValid)
                             {
-                                this._portfolioRepo.AddOrUpdate(tx);
+                                pendingAssets.Add(tx);
                             }
                         }
 
@@ -79,7 +84,7 @@ public class ImportService : IImportService
                             result.ValidationWarnings.AddRange(vr.Warnings);
                             if (vr.IsValid)
                             {
-                                this._transactionRepo.AddOrUpdate(tx);
+                                pendingTransactions.Add(tx);
                             }
                         }
 
@@ -90,7 +95,7 @@ public class ImportService : IImportService
                             result.ValidationWarnings.AddRange(vr.Warnings);
                             if (vr.IsValid)
                             {
-                                this._portfolioRepo.AddOrUpdate(tx);
+                                pendingAssets.Add(tx);
                             }
                         }
 
@@ -106,6 +111,57 @@ public class ImportService : IImportService
                     this._logger.LogError(ex, "Failed to process {CsvFile}", csvFile);
                 }
             }
+        }
+
+        if (pendingTransactions.Count > 0)
+        {
+            List<Domain.Entities.Transaction> merged = this._transactionRepo.GetAll().ToList();
+            Dictionary<Guid, int> indexById = new Dictionary<Guid, int>(merged.Count);
+            for (int i = 0; i < merged.Count; i++)
+            {
+                indexById[merged[i].Id] = i;
+            }
+
+            foreach (Domain.Entities.Transaction tx in pendingTransactions)
+            {
+                if (indexById.TryGetValue(tx.Id, out int index))
+                {
+                    merged[index] = tx;
+                }
+                else
+                {
+                    indexById[tx.Id] = merged.Count;
+                    merged.Add(tx);
+                }
+            }
+
+            this._transactionRepo.Initialize(merged);
+        }
+
+        if (pendingAssets.Count > 0)
+        {
+            List<Domain.Entities.AssetTransaction> mergedAssets = this._portfolioRepo.GetAllTransactions().ToList();
+            Dictionary<Guid, int> assetIndexById = new Dictionary<Guid, int>(mergedAssets.Count);
+            for (int i = 0; i < mergedAssets.Count; i++)
+            {
+                assetIndexById[mergedAssets[i].Transaction.Id] = i;
+            }
+
+            foreach (Domain.Entities.AssetTransaction tx in pendingAssets)
+            {
+                Guid id = tx.Transaction.Id;
+                if (assetIndexById.TryGetValue(id, out int index))
+                {
+                    mergedAssets[index] = tx;
+                }
+                else
+                {
+                    assetIndexById[id] = mergedAssets.Count;
+                    mergedAssets.Add(tx);
+                }
+            }
+
+            this._portfolioRepo.Initialize(mergedAssets);
         }
 
         int matchedPairs = this.MatchTransferPairs();
@@ -137,6 +193,7 @@ public class ImportService : IImportService
             .ToList();
 
         int matched = 0;
+        bool changed = false;
 
         foreach (Domain.Entities.Transaction expense in expenses)
         {
@@ -154,16 +211,25 @@ public class ImportService : IImportService
 
             if (match != null)
             {
-                this.UpdateCategory(expense, Domain.Enums.TransactionCategory.TRANSFER);
-                this.UpdateCategory(match, Domain.Enums.TransactionCategory.TRANSFER);
+                this.ReplaceCategoryInList(all, expense, Domain.Enums.TransactionCategory.TRANSFER);
+                this.ReplaceCategoryInList(all, match, Domain.Enums.TransactionCategory.TRANSFER);
                 matched++;
+                changed = true;
             }
+        }
+
+        if (changed)
+        {
+            this._transactionRepo.Initialize(all);
         }
 
         return matched;
     }
 
-    private void UpdateCategory(Domain.Entities.Transaction transaction, Domain.Enums.TransactionCategory newCategory)
+    private void ReplaceCategoryInList(
+        List<Domain.Entities.Transaction> all,
+        Domain.Entities.Transaction transaction,
+        Domain.Enums.TransactionCategory newCategory)
     {
         Domain.Entities.Transaction updated = new Domain.Entities.Transaction(
             transaction.Id,
@@ -172,6 +238,10 @@ public class ImportService : IImportService
             transaction.Money,
             newCategory);
 
-        this._transactionRepo.AddOrUpdate(updated);
+        int index = all.FindIndex(t => t.Id == transaction.Id);
+        if (index >= 0)
+        {
+            all[index] = updated;
+        }
     }
 }

--- a/src/MyAccountingApp.Core/Repositories/CompositePortfolioRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/CompositePortfolioRepository.cs
@@ -23,6 +23,12 @@ namespace MyAccountingApp.Core.Repositories
             this._jsonRepo.AddOrUpdate(assetTransaction);
         }
 
+        public bool Delete(Guid transactionId)
+        {
+            this._jsonRepo.Delete(transactionId);
+            return this._memoryRepo.Delete(transactionId);
+        }
+
         public IEnumerable<AssetTransaction> GetAssetTransactions(string symbol)
         {
             return this._memoryRepo.GetAssetTransactions(symbol);

--- a/src/MyAccountingApp.Core/Repositories/InMemoryPortfolioRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/InMemoryPortfolioRepository.cs
@@ -13,6 +13,11 @@ namespace MyAccountingApp.Core.Repositories
             this._assetTransactions.Add(assetTransaction);
         }
 
+        public bool Delete(Guid transactionId)
+        {
+            return this._assetTransactions.RemoveAll(t => t.Transaction.Id == transactionId) > 0;
+        }
+
         public IEnumerable<AssetTransaction> GetAssetTransactions(string symbol)
         {
             return this._assetTransactions.Where(t => t.Symbol.Equals(symbol, StringComparison.OrdinalIgnoreCase));

--- a/src/MyAccountingApp.Core/Repositories/JsonPortfolioRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/JsonPortfolioRepository.cs
@@ -22,6 +22,18 @@ namespace MyAccountingApp.Core.Repositories
             this.Initialize(transactions);
         }
 
+        public bool Delete(Guid transactionId)
+        {
+            List<AssetTransaction> transactions = this.GetAllTransactions().ToList();
+            int removed = transactions.RemoveAll(t => t.Transaction.Id == transactionId);
+            if (removed > 0)
+            {
+                this.Initialize(transactions);
+            }
+
+            return removed > 0;
+        }
+
         public IEnumerable<AssetTransaction> GetAssetTransactions(string symbol)
         {
             return this.GetAllTransactions()

--- a/src/MyAccountingApp.Core/Repositories/JsonPortfolioRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/JsonPortfolioRepository.cs
@@ -19,7 +19,7 @@ namespace MyAccountingApp.Core.Repositories
             List<AssetTransaction> transactions = this.GetAllTransactions().ToList();
             transactions.RemoveAll(t => t.Transaction.Id == assetTransaction.Transaction.Id);
             transactions.Add(assetTransaction);
-            this.Initialize(transactions);
+            this.WriteAll(transactions);
         }
 
         public bool Delete(Guid transactionId)
@@ -28,7 +28,7 @@ namespace MyAccountingApp.Core.Repositories
             int removed = transactions.RemoveAll(t => t.Transaction.Id == transactionId);
             if (removed > 0)
             {
-                this.Initialize(transactions);
+                this.WriteAll(transactions);
             }
 
             return removed > 0;
@@ -42,26 +42,49 @@ namespace MyAccountingApp.Core.Repositories
 
         public IEnumerable<AssetTransaction> GetAllTransactions()
         {
-            if (File.Exists(this._filePath) && new FileInfo(this._filePath).Length > 0)
+            if (!File.Exists(this._filePath) || new FileInfo(this._filePath).Length == 0)
             {
-                string json = File.ReadAllText(this._filePath);
-                JsonSerializerOptions options = new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true,
-                    Converters = { new JsonStringEnumConverter() },
-                };
-
-                List<AssetTransaction>? transactions = JsonSerializer.Deserialize<List<AssetTransaction>>(json, options);
-                if (transactions != null)
-                {
-                    return transactions;
-                }
+                return new List<AssetTransaction>();
             }
 
-            return new List<AssetTransaction>();
+            string json = File.ReadAllText(this._filePath);
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                Converters = { new JsonStringEnumConverter() },
+            };
+
+            try
+            {
+                return JsonSerializer.Deserialize<List<AssetTransaction>>(json, options) ?? new List<AssetTransaction>();
+            }
+            catch (JsonException)
+            {
+                int lastBrace = json.LastIndexOf('}');
+                if (lastBrace > 0)
+                {
+                    string repaired = json[.. (lastBrace + 1)] + "]";
+                    try
+                    {
+                        List<AssetTransaction>? recovered = JsonSerializer.Deserialize<List<AssetTransaction>>(repaired, options);
+                        if (recovered is not null)
+                        {
+                            this.WriteAll(recovered);
+                            return recovered;
+                        }
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                return new List<AssetTransaction>();
+            }
         }
 
-        public void Initialize(IEnumerable<AssetTransaction> transactions)
+        public void Initialize(IEnumerable<AssetTransaction> transactions) => this.WriteAll(transactions);
+
+        private void WriteAll(IEnumerable<AssetTransaction> transactions)
         {
             JsonSerializerOptions options = new JsonSerializerOptions
             {
@@ -69,8 +92,9 @@ namespace MyAccountingApp.Core.Repositories
                 Converters = { new JsonStringEnumConverter() },
             };
             string json = JsonSerializer.Serialize(transactions, options);
-
-            File.WriteAllText(this._filePath, json);
+            string tempPath = this._filePath + ".tmp";
+            File.WriteAllText(tempPath, json);
+            File.Move(tempPath, this._filePath, overwrite: true);
         }
     }
 }

--- a/src/MyAccountingApp.Core/Repositories/JsonTransactionRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/JsonTransactionRepository.cs
@@ -5,39 +5,23 @@ using MyAccountingApp.Domain.Interfaces;
 
 namespace MyAccountingApp.Core.Repositories;
 
-/// <summary>
-/// Repository for storing and retrieving transactions using a JSON file.
-/// </summary>
 public class JsonTransactionRepository : ITransactionRepository
 {
     private readonly string _filePath;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="JsonTransactionRepository"/> class.
-    /// </summary>
-    /// <param name="filePath">The path to the JSON file.</param>
     public JsonTransactionRepository(string filePath)
     {
         this._filePath = filePath;
     }
 
-    /// <summary>
-    /// Adds a new transaction to the repository.
-    /// </summary>
-    /// <param name="transaction">The transaction to add.</param>
     public void AddOrUpdate(Transaction transaction)
     {
         List<Transaction> transactions = this.GetAll().ToList();
         _ = this.Delete(transaction);
         transactions.Add(transaction);
-        this.Initialize(transactions);
+        this.WriteAll(transactions);
     }
 
-    /// <summary>
-    /// Deletes a transaction from the repository by its unique identifier.
-    /// </summary>
-    /// <param name="transaction">The transaction to delete.</param>
-    /// <returns>True if the transaction was found and removed; otherwise, false.</returns>
     public bool Delete(Transaction transaction)
     {
         List<Transaction> transactions = this.GetAll().ToList();
@@ -48,47 +32,62 @@ public class JsonTransactionRepository : ITransactionRepository
         }
 
         transactions.RemoveAll(tx => tx.Id == transaction.Id);
-        this.Initialize(transactions);
+        this.WriteAll(transactions);
 
         return true;
     }
 
-    /// <summary>
-    /// Gets all transactions stored in the repository.
-    /// </summary>
-    /// <returns>An enumerable of all transactions.</returns>
     public IEnumerable<Transaction> GetAll()
     {
-        if (File.Exists(this._filePath) && new FileInfo(this._filePath).Length > 0)
+        if (!File.Exists(this._filePath) || new FileInfo(this._filePath).Length == 0)
         {
-            string json = File.ReadAllText(this._filePath);
-
-            JsonSerializerOptions options = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-                Converters = { new JsonStringEnumConverter() },
-            };
-
-            List<Transaction>? transactions = JsonSerializer.Deserialize<List<Transaction>>(json, options);
-
-            if (transactions is not null)
-            {
-                return transactions;
-            }
+            return new List<Transaction>();
         }
 
-        return new List<Transaction>();
+        string json = File.ReadAllText(this._filePath);
+
+        JsonSerializerOptions options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter() },
+        };
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<Transaction>>(json, options) ?? new List<Transaction>();
+        }
+        catch (JsonException)
+        {
+            int lastBrace = json.LastIndexOf('}');
+            if (lastBrace > 0)
+            {
+                string repaired = json[.. (lastBrace + 1)] + "]";
+                try
+                {
+                    List<Transaction>? recovered = JsonSerializer.Deserialize<List<Transaction>>(repaired, options);
+                    if (recovered is not null)
+                    {
+                        this.WriteAll(recovered);
+                        return recovered;
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            return new List<Transaction>();
+        }
     }
 
-    /// <summary>
-    /// Saves the transactions to the JSON file.
-    /// </summary>
-    /// <param name="transactions">The transactions to save.</param>
-    public void Initialize(IEnumerable<Transaction> transactions)
-    {
-        JsonSerializerOptions options = new() { WriteIndented = true, Converters = { new JsonStringEnumConverter() }, };
+    public void Initialize(IEnumerable<Transaction> transactions) => this.WriteAll(transactions);
 
+    private void WriteAll(IEnumerable<Transaction> transactions)
+    {
+        JsonSerializerOptions options = new() { WriteIndented = true, Converters = { new JsonStringEnumConverter() } };
         string json = JsonSerializer.Serialize(transactions, options);
-        File.WriteAllText(this._filePath, json);
+        string tempPath = this._filePath + ".tmp";
+        File.WriteAllText(tempPath, json);
+        File.Move(tempPath, this._filePath, overwrite: true);
     }
 }

--- a/src/MyAccountingApp.Core/Repositories/JsonTransactionRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/JsonTransactionRepository.cs
@@ -17,7 +17,7 @@ public class JsonTransactionRepository : ITransactionRepository
     public void AddOrUpdate(Transaction transaction)
     {
         List<Transaction> transactions = this.GetAll().ToList();
-        _ = this.Delete(transaction);
+        transactions.RemoveAll(tx => tx.Id == transaction.Id);
         transactions.Add(transaction);
         this.WriteAll(transactions);
     }
@@ -54,7 +54,23 @@ public class JsonTransactionRepository : ITransactionRepository
 
         try
         {
-            return JsonSerializer.Deserialize<List<Transaction>>(json, options) ?? new List<Transaction>();
+            List<Transaction>? transactions = JsonSerializer.Deserialize<List<Transaction>>(json, options);
+            if (transactions is null || transactions.Count == 0)
+                return new List<Transaction>();
+
+            var seen = new HashSet<Guid>();
+            var deduplicated = new List<Transaction>(transactions.Count);
+            for (int i = transactions.Count - 1; i >= 0; i--)
+            {
+                if (seen.Add(transactions[i].Id))
+                    deduplicated.Add(transactions[i]);
+            }
+
+            deduplicated.Reverse();
+            if (deduplicated.Count != transactions.Count)
+                this.WriteAll(deduplicated);
+
+            return deduplicated;
         }
         catch (JsonException)
         {

--- a/src/MyAccountingApp.Domain/Interfaces/IPortfolioRepository.cs
+++ b/src/MyAccountingApp.Domain/Interfaces/IPortfolioRepository.cs
@@ -24,6 +24,13 @@ namespace MyAccountingApp.Domain.Interfaces
         public IEnumerable<AssetTransaction> GetAllTransactions();
 
         /// <summary>
+        /// Deletes an asset transaction by its transaction ID.
+        /// </summary>
+        /// <param name="transactionId">The transaction ID of the asset transaction to delete.</param>
+        /// <returns>True if the transaction was found and removed; otherwise, false.</returns>
+        public bool Delete(Guid transactionId);
+
+        /// <summary>
         /// Initializes the repository with a collection of asset transactions.
         /// </summary>
         /// <param name="transactions">A collection of asset transactions to initialize the repository.</param>

--- a/src/MyAccountingApp.Web/Layout/NavMenu.razor
+++ b/src/MyAccountingApp.Web/Layout/NavMenu.razor
@@ -6,4 +6,5 @@
     <MudNavLink Href="asset-transactions" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.TrendingUp">Asset Transactions</MudNavLink>
     <MudNavLink Href="portfolio" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.AccountBalance">Portfolio</MudNavLink>
     <MudNavLink Href="import" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.FileUpload">Import</MudNavLink>
+    <MudNavLink Href="settings" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Settings">Settings</MudNavLink>
 </MudNavMenu>

--- a/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
+++ b/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
@@ -44,6 +44,10 @@ else
         <ToolBarContent>
             <MudText Typo="Typo.subtitle1">@_filteredTransactions.Count transactions</MudText>
             <MudSpacer />
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                       OnClick="@OpenCreateDialog" StartIcon="@Icons.Material.Filled.Add">
+                New
+            </MudButton>
             <MudIconButton Icon="@Icons.Material.Filled.Refresh" OnClick="@LoadDataAsync" Size="Size.Small" />
         </ToolBarContent>
         <ColGroup>
@@ -52,6 +56,7 @@ else
             <col />
             <col style="width: 80px" />
             <col style="width: 100px" />
+            <col style="width: 80px" />
             <col style="width: 80px" />
             <col style="width: 80px" />
         </ColGroup>
@@ -63,6 +68,7 @@ else
             <MudTh><MudTableSortLabel SortBy="new Func<AssetTransactionDto, object>(t => t.Transaction.Money.Amount)">Amount</MudTableSortLabel></MudTh>
             <MudTh>Curr.</MudTh>
             <MudTh><MudTableSortLabel SortBy="new Func<AssetTransactionDto, object>(t => t.Type)">Type</MudTableSortLabel></MudTh>
+            <MudTh>Actions</MudTh>
         </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="Date">@context.Transaction.Date.ToString("yyyy-MM-dd")</MudTd>
@@ -74,11 +80,97 @@ else
             <MudTd DataLabel="Amount">@context.Transaction.Money.Amount.ToString("N2")</MudTd>
             <MudTd DataLabel="Curr.">@context.Transaction.Money.Currency</MudTd>
             <MudTd DataLabel="Type">@context.Type</MudTd>
+            <MudTd DataLabel="Actions">
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="@(() => OpenEditDialog(context))" />
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error" OnClick="@(() => OpenDeleteDialog(context))" />
+            </MudTd>
         </RowTemplate>
         <PagerContent>
             <MudTablePager PageSizeOptions="@(new int[]{25, 50, 100})" />
         </PagerContent>
     </MudTable>
+}
+
+@if (_showFormDialog)
+{
+    <MudDialog @bind-Visible="_showFormDialog">
+        <TitleContent>
+            <MudText Typo="Typo.h6">@(_editingId is null ? "New Asset Transaction" : "Edit Asset Transaction")</MudText>
+        </TitleContent>
+        <DialogContent>
+            <MudGrid>
+                <MudItem xs="12">
+                    <MudDatePicker @bind-Date="_formDate" Label="Date" Variant="Variant.Outlined" />
+                </MudItem>
+                <MudItem xs="12">
+                    <MudTextField @bind-Value="_formDescription" Label="Description" Variant="Variant.Outlined" />
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudTextField @bind-Value="_formSymbol" Label="Symbol" Variant="Variant.Outlined" />
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudNumericField T="decimal" @bind-Value="_formQuantity" Label="Quantity" Variant="Variant.Outlined" Min="@(0.01m)" />
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudNumericField T="decimal" @bind-Value="_formAmount" Label="Amount" Variant="Variant.Outlined" Min="@(0.01m)" />
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudSelect @bind-Value="_formCurrency" Label="Currency" Variant="Variant.Outlined">
+                        <MudSelectItem Value="@("EUR")">EUR</MudSelectItem>
+                        <MudSelectItem Value="@("USD")">USD</MudSelectItem>
+                        <MudSelectItem Value="@("GBP")">GBP</MudSelectItem>
+                        <MudSelectItem Value="@("CHF")">CHF</MudSelectItem>
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudSelect @bind-Value="_formCategory" Label="Category" Variant="Variant.Outlined">
+                        @foreach (var cat in _categories)
+                        {
+                            <MudSelectItem Value="cat">@cat</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudSelect @bind-Value="_formType" Label="Type" Variant="Variant.Outlined">
+                        @foreach (var type in _types)
+                        {
+                            <MudSelectItem Value="type">@type</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+            </MudGrid>
+        </DialogContent>
+        <DialogActions>
+            <MudButton OnClick="@CloseFormDialog">Cancel</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@SaveAsync"
+                       Disabled="@IsFormInvalid()">
+                Save
+            </MudButton>
+        </DialogActions>
+    </MudDialog>
+}
+
+@if (_showDeleteDialog)
+{
+    <MudDialog @bind-Visible="_showDeleteDialog">
+        <TitleContent>
+            <MudText Typo="Typo.h6">Delete Asset Transaction</MudText>
+        </TitleContent>
+        <DialogContent>
+            <MudText>Are you sure you want to delete this asset transaction?</MudText>
+            @if (_deletingTx is not null)
+            {
+                <MudText Typo="Typo.body2" Class="mt-2">
+                    @_deletingTx.Transaction.Date.ToString("yyyy-MM-dd") — @_deletingTx.Symbol @_deletingTx.Type
+                    (@_deletingTx.Transaction.Money.Amount.ToString("N2") @_deletingTx.Transaction.Money.Currency)
+                </MudText>
+            }
+        </DialogContent>
+        <DialogActions>
+            <MudButton OnClick="@CloseDeleteDialog">Cancel</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@ConfirmDeleteAsync">Delete</MudButton>
+        </DialogActions>
+    </MudDialog>
 }
 
 @code {
@@ -92,7 +184,24 @@ else
     private string? _selectedSymbol { get; set; }
     private string? _selectedType { get; set; }
 
+    private bool IsFormInvalid() => string.IsNullOrWhiteSpace(_formDescription) || string.IsNullOrWhiteSpace(_formSymbol) || _formAmount <= 0 || _formQuantity <= 0;
+
+    private static readonly string[] _categories = { "INCOME", "EXPENSE", "TRANSFER", "DEPOSIT" };
     private static readonly string[] _types = { "Buy", "Sell", "CorporateAction" };
+
+    private bool _showFormDialog;
+    private bool _showDeleteDialog;
+    private Guid? _editingId;
+    private AssetTransactionDto? _deletingTx;
+
+    private DateTime? _formDate;
+    private string _formDescription = "";
+    private string _formSymbol = "";
+    private decimal _formQuantity;
+    private decimal _formAmount;
+    private string _formCurrency = "EUR";
+    private string _formCategory = "EXPENSE";
+    private string _formType = "Buy";
 
     protected override async Task OnInitializedAsync()
     {
@@ -137,5 +246,99 @@ else
             query = query.Where(t => t.Type == _selectedType);
 
         _filteredTransactions = query.ToList();
+    }
+
+    private void OpenCreateDialog()
+    {
+        _editingId = null;
+        _formDate = DateTime.Today;
+        _formDescription = "";
+        _formSymbol = "";
+        _formQuantity = 0;
+        _formAmount = 0;
+        _formCurrency = "EUR";
+        _formCategory = "EXPENSE";
+        _formType = "Buy";
+        _showFormDialog = true;
+    }
+
+    private void OpenEditDialog(AssetTransactionDto atx)
+    {
+        _editingId = atx.Transaction.Id;
+        _formDate = atx.Transaction.Date;
+        _formDescription = atx.Transaction.Description;
+        _formSymbol = atx.Symbol;
+        _formQuantity = atx.Quantity;
+        _formAmount = atx.Transaction.Money.Amount;
+        _formCurrency = atx.Transaction.Money.Currency;
+        _formCategory = atx.Transaction.Category;
+        _formType = atx.Type;
+        _showFormDialog = true;
+    }
+
+    private void CloseFormDialog()
+    {
+        _showFormDialog = false;
+    }
+
+    private async Task SaveAsync()
+    {
+        var payload = new
+        {
+            Date = _formDate ?? DateTime.Today,
+            Description = _formDescription,
+            Amount = _formAmount,
+            Currency = _formCurrency,
+            Category = _formCategory,
+            Symbol = _formSymbol,
+            Quantity = _formQuantity,
+            Type = _formType,
+        };
+
+        HttpResponseMessage response;
+        if (_editingId is null)
+        {
+            response = await Http.PostAsJsonAsync("/api/asset-transactions", payload);
+        }
+        else
+        {
+            response = await Http.PutAsJsonAsync($"/api/asset-transactions/{_editingId}", payload);
+        }
+
+        if (response.IsSuccessStatusCode)
+        {
+            _showFormDialog = false;
+            await LoadDataAsync();
+        }
+        else
+        {
+            _showFormDialog = false;
+        }
+    }
+
+    private void OpenDeleteDialog(AssetTransactionDto atx)
+    {
+        _deletingTx = atx;
+        _showDeleteDialog = true;
+    }
+
+    private void CloseDeleteDialog()
+    {
+        _showDeleteDialog = false;
+        _deletingTx = null;
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        if (_deletingTx is null) return;
+
+        HttpResponseMessage response = await Http.DeleteAsync($"/api/asset-transactions/{_deletingTx.Transaction.Id}");
+        _showDeleteDialog = false;
+        _deletingTx = null;
+
+        if (response.IsSuccessStatusCode || response.StatusCode == System.Net.HttpStatusCode.NoContent)
+        {
+            await LoadDataAsync();
+        }
     }
 }

--- a/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
+++ b/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
@@ -92,87 +92,81 @@ else
     </MudTable>
 }
 
-@if (_showFormDialog)
-{
-    <MudDialog @bind-Visible="_showFormDialog">
-        <TitleContent>
-            <MudText Typo="Typo.h6">@(_editingId is null ? "New Asset Transaction" : "Edit Asset Transaction")</MudText>
-        </TitleContent>
-        <DialogContent>
-            <MudGrid>
-                <MudItem xs="12">
-                    <MudDatePicker @bind-Date="_formDate" Label="Date" Variant="Variant.Outlined" />
-                </MudItem>
-                <MudItem xs="12">
-                    <MudTextField @bind-Value="_formDescription" Label="Description" Variant="Variant.Outlined" />
-                </MudItem>
-                <MudItem xs="12" sm="6">
-                    <MudTextField @bind-Value="_formSymbol" Label="Symbol" Variant="Variant.Outlined" />
-                </MudItem>
-                <MudItem xs="12" sm="6">
-                    <MudNumericField T="decimal" @bind-Value="_formQuantity" Label="Quantity" Variant="Variant.Outlined" Min="@(0.01m)" />
-                </MudItem>
-                <MudItem xs="12" sm="6">
-                    <MudNumericField T="decimal" @bind-Value="_formAmount" Label="Amount" Variant="Variant.Outlined" Min="@(0.01m)" />
-                </MudItem>
-                <MudItem xs="12" sm="6">
-                    <MudSelect @bind-Value="_formCurrency" Label="Currency" Variant="Variant.Outlined">
-                        <MudSelectItem Value="@("EUR")">EUR</MudSelectItem>
-                        <MudSelectItem Value="@("USD")">USD</MudSelectItem>
-                        <MudSelectItem Value="@("GBP")">GBP</MudSelectItem>
-                        <MudSelectItem Value="@("CHF")">CHF</MudSelectItem>
-                    </MudSelect>
-                </MudItem>
-                <MudItem xs="12" sm="6">
-                    <MudSelect @bind-Value="_formCategory" Label="Category" Variant="Variant.Outlined">
-                        @foreach (var cat in _categories)
-                        {
-                            <MudSelectItem Value="cat">@cat</MudSelectItem>
-                        }
-                    </MudSelect>
-                </MudItem>
-                <MudItem xs="12" sm="6">
-                    <MudSelect @bind-Value="_formType" Label="Type" Variant="Variant.Outlined">
-                        @foreach (var type in _types)
-                        {
-                            <MudSelectItem Value="type">@type</MudSelectItem>
-                        }
-                    </MudSelect>
-                </MudItem>
-            </MudGrid>
-        </DialogContent>
-        <DialogActions>
-            <MudButton OnClick="@CloseFormDialog">Cancel</MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@SaveAsync"
-                       Disabled="@IsFormInvalid()">
-                Save
-            </MudButton>
-        </DialogActions>
-    </MudDialog>
-}
+<MudDialog @bind-Visible="_showFormDialog">
+    <TitleContent>
+        <MudText Typo="Typo.h6">@(_editingId is null ? "New Asset Transaction" : "Edit Asset Transaction")</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudGrid>
+            <MudItem xs="12">
+                <MudDatePicker @bind-Date="_formDate" Label="Date" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_formDescription" Label="Description" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudTextField @bind-Value="_formSymbol" Label="Symbol" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudNumericField T="decimal" @bind-Value="_formQuantity" Label="Quantity" Variant="Variant.Outlined" Min="@(0.01m)" />
+            </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudNumericField T="decimal" @bind-Value="_formAmount" Label="Amount" Variant="Variant.Outlined" Min="@(0.01m)" />
+            </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudSelect @bind-Value="_formCurrency" Label="Currency" Variant="Variant.Outlined">
+                    <MudSelectItem Value="@("EUR")">EUR</MudSelectItem>
+                    <MudSelectItem Value="@("USD")">USD</MudSelectItem>
+                    <MudSelectItem Value="@("GBP")">GBP</MudSelectItem>
+                    <MudSelectItem Value="@("CHF")">CHF</MudSelectItem>
+                </MudSelect>
+            </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudSelect @bind-Value="_formCategory" Label="Category" Variant="Variant.Outlined">
+                    @foreach (var cat in _categories)
+                    {
+                        <MudSelectItem Value="cat">@cat</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudSelect @bind-Value="_formType" Label="Type" Variant="Variant.Outlined">
+                    @foreach (var type in _types)
+                    {
+                        <MudSelectItem Value="type">@type</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
+        </MudGrid>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseFormDialog">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@SaveAsync"
+                   Disabled="@IsFormInvalid()">
+            Save
+        </MudButton>
+    </DialogActions>
+</MudDialog>
 
-@if (_showDeleteDialog)
-{
-    <MudDialog @bind-Visible="_showDeleteDialog">
-        <TitleContent>
-            <MudText Typo="Typo.h6">Delete Asset Transaction</MudText>
-        </TitleContent>
-        <DialogContent>
-            <MudText>Are you sure you want to delete this asset transaction?</MudText>
-            @if (_deletingTx is not null)
-            {
-                <MudText Typo="Typo.body2" Class="mt-2">
-                    @_deletingTx.Transaction.Date.ToString("yyyy-MM-dd") — @_deletingTx.Symbol @_deletingTx.Type
-                    (@_deletingTx.Transaction.Money.Amount.ToString("N2") @_deletingTx.Transaction.Money.Currency)
-                </MudText>
-            }
-        </DialogContent>
-        <DialogActions>
-            <MudButton OnClick="@CloseDeleteDialog">Cancel</MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@ConfirmDeleteAsync">Delete</MudButton>
-        </DialogActions>
-    </MudDialog>
-}
+<MudDialog @bind-Visible="_showDeleteDialog">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Delete Asset Transaction</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText>Are you sure you want to delete this asset transaction?</MudText>
+        @if (_deletingTx is not null)
+        {
+            <MudText Typo="Typo.body2" Class="mt-2">
+                @_deletingTx.Transaction.Date.ToString("yyyy-MM-dd") — @_deletingTx.Symbol @_deletingTx.Type
+                (@_deletingTx.Transaction.Money.Amount.ToString("N2") @_deletingTx.Transaction.Money.Currency)
+            </MudText>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseDeleteDialog">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@ConfirmDeleteAsync">Delete</MudButton>
+    </DialogActions>
+</MudDialog>
 
 @code {
     private List<AssetTransactionDto> _allTransactions = new();

--- a/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
+++ b/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
@@ -1,5 +1,6 @@
 @page "/asset-transactions"
 @inject HttpClient Http
+@inject ISnackbar Snackbar
 
 <PageTitle>Asset Transactions</PageTitle>
 
@@ -283,36 +284,45 @@ else
 
     private async Task SaveAsync()
     {
-        var payload = new
+        try
         {
-            Date = _formDate ?? DateTime.Today,
-            Description = _formDescription,
-            Amount = _formAmount,
-            Currency = _formCurrency,
-            Category = _formCategory,
-            Symbol = _formSymbol,
-            Quantity = _formQuantity,
-            Type = _formType,
-        };
+            var payload = new
+            {
+                Date = _formDate ?? DateTime.Today,
+                Description = _formDescription,
+                Amount = _formAmount,
+                Currency = _formCurrency,
+                Category = _formCategory,
+                Symbol = _formSymbol,
+                Quantity = _formQuantity,
+                Type = _formType,
+            };
 
-        HttpResponseMessage response;
-        if (_editingId is null)
-        {
-            response = await Http.PostAsJsonAsync("/api/asset-transactions", payload);
-        }
-        else
-        {
-            response = await Http.PutAsJsonAsync($"/api/asset-transactions/{_editingId}", payload);
-        }
+            HttpResponseMessage response;
+            if (_editingId is null)
+            {
+                response = await Http.PostAsJsonAsync("/api/asset-transactions", payload);
+            }
+            else
+            {
+                response = await Http.PutAsJsonAsync($"/api/asset-transactions/{_editingId}", payload);
+            }
 
-        if (response.IsSuccessStatusCode)
-        {
-            _showFormDialog = false;
-            await LoadDataAsync();
+            if (response.IsSuccessStatusCode)
+            {
+                _showFormDialog = false;
+                Snackbar.Add(_editingId is null ? "Asset transaction created" : "Asset transaction updated", Severity.Success);
+                await LoadDataAsync();
+            }
+            else
+            {
+                string error = await response.Content.ReadAsStringAsync();
+                Snackbar.Add($"Failed to save: {error}", Severity.Error);
+            }
         }
-        else
+        catch (Exception ex)
         {
-            _showFormDialog = false;
+            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
         }
     }
 
@@ -332,13 +342,26 @@ else
     {
         if (_deletingTx is null) return;
 
-        HttpResponseMessage response = await Http.DeleteAsync($"/api/asset-transactions/{_deletingTx.Transaction.Id}");
-        _showDeleteDialog = false;
-        _deletingTx = null;
-
-        if (response.IsSuccessStatusCode || response.StatusCode == System.Net.HttpStatusCode.NoContent)
+        try
         {
-            await LoadDataAsync();
+            HttpResponseMessage response = await Http.DeleteAsync($"/api/asset-transactions/{_deletingTx.Transaction.Id}");
+            _showDeleteDialog = false;
+            _deletingTx = null;
+
+            if (response.IsSuccessStatusCode || response.StatusCode == System.Net.HttpStatusCode.NoContent)
+            {
+                Snackbar.Add("Asset transaction deleted", Severity.Success);
+                await LoadDataAsync();
+            }
+            else
+            {
+                string error = await response.Content.ReadAsStringAsync();
+                Snackbar.Add($"Failed to delete: {error}", Severity.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
         }
     }
 }

--- a/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
+++ b/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
@@ -240,7 +240,7 @@ else
         if (!string.IsNullOrWhiteSpace(_selectedType))
             query = query.Where(t => t.Type == _selectedType);
 
-        _filteredTransactions = query.ToList();
+        _filteredTransactions = query.OrderByDescending(t => t.Transaction.Date).ToList();
     }
 
     private void OpenCreateDialog()

--- a/src/MyAccountingApp.Web/Pages/Import.razor
+++ b/src/MyAccountingApp.Web/Pages/Import.razor
@@ -30,25 +30,7 @@
     }
 </MudPaper>
 
-<MudPaper Class="pa-6 mb-4" Outlined="true" Style="border-color: var(--mud-palette-error);">
-    <MudText Typo="Typo.h6" GutterBottom="true" Color="Color.Error">Danger zone</MudText>
-    <MudText Typo="Typo.body2" Class="mb-4">
-        Reset the database: deletes <strong>all cash transactions</strong> and <strong>all portfolio / asset transactions</strong>.
-        Currency conversions are kept. This cannot be undone from the UI — make a backup of <code>data/</code> first if needed.
-    </MudText>
-    <MudButton Variant="Variant.Filled" Color="Color.Error" Size="Size.Large"
-               OnClick="@OpenResetDialog" Disabled="@_loading"
-               StartIcon="@Icons.Material.Filled.DeleteForever">
-        Reset database
-    </MudButton>
-    @if (_resetResult is not null)
-    {
-        <MudAlert Severity="Severity.Info" Class="mt-4">
-            Cleared <strong>@_resetResult.ClearedTransactions</strong> transactions and
-            <strong>@_resetResult.ClearedAssetTransactions</strong> asset transactions.
-        </MudAlert>
-    }
-</MudPaper>
+
 
 @if (_loading)
 {
@@ -109,77 +91,15 @@
     }
 }
 
-<MudDialog @bind-Visible="_showResetDialog">
-    <TitleContent>
-        <MudText Typo="Typo.h6">Reset database?</MudText>
-    </TitleContent>
-    <DialogContent>
-        <MudText>
-            This will permanently delete all cash transactions and all portfolio / asset transactions.
-            Currency conversions will not be deleted.
-        </MudText>
-        <MudText Class="mt-2" Typo="Typo.body2">
-            Prefer a backup of <code>data/transactions.json</code> and <code>data/portfolio.json</code> before continuing.
-        </MudText>
-    </DialogContent>
-    <DialogActions>
-        <MudButton OnClick="@CloseResetDialog" Disabled="@_loading">Cancel</MudButton>
-        <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@ConfirmResetAsync" Disabled="@_loading">
-            Yes, reset database
-        </MudButton>
-    </DialogActions>
-</MudDialog>
-
 @code {
     private ImportResultDto? _result;
-    private ResetResultDto? _resetResult;
     private bool _loading;
-    private bool _showResetDialog;
     private IBrowserFile? _selectedFile;
 
     private void OnFileSelected(InputFileChangeEventArgs args)
     {
         _selectedFile = args.File;
         _result = null;
-    }
-
-    private void OpenResetDialog()
-    {
-        _showResetDialog = true;
-    }
-
-    private void CloseResetDialog()
-    {
-        _showResetDialog = false;
-    }
-
-    private async Task ConfirmResetAsync()
-    {
-        _loading = true;
-        _result = null;
-        _resetResult = null;
-        try
-        {
-            var response = await Http.PostAsync("/api/data/reset", null);
-            if (!response.IsSuccessStatusCode)
-            {
-                string body = await response.Content.ReadAsStringAsync();
-                Snackbar.Add($"Reset failed: {(int)response.StatusCode} {body}", Severity.Error);
-                return;
-            }
-
-            _resetResult = await response.Content.ReadFromJsonAsync<ResetResultDto>();
-            _showResetDialog = false;
-            Snackbar.Add("Database reset completed.", Severity.Success);
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Reset failed: {ex.Message}", Severity.Error);
-        }
-        finally
-        {
-            _loading = false;
-        }
     }
 
     private async Task UploadAndImportAsync()
@@ -209,10 +129,4 @@
         }
     }
 
-    private sealed class ResetResultDto
-    {
-        public string? Message { get; set; }
-        public int ClearedTransactions { get; set; }
-        public int ClearedAssetTransactions { get; set; }
-    }
 }

--- a/src/MyAccountingApp.Web/Pages/Import.razor
+++ b/src/MyAccountingApp.Web/Pages/Import.razor
@@ -7,18 +7,6 @@
 <MudText Typo="Typo.h3" GutterBottom="true">Import Data</MudText>
 
 <MudPaper Class="pa-6 mb-4" Outlined="true">
-    <MudText Typo="Typo.h6" GutterBottom="true">Import from folder</MudText>
-    <MudText Typo="Typo.body2" Class="mb-4">
-        Load all CSV files from the configured folders (<code>import/historical</code>).
-    </MudText>
-    <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large"
-               OnClick="@RunImportAsync" Disabled="@_loading"
-               StartIcon="@Icons.Material.Filled.FolderOpen">
-        @(_loading ? "Importing..." : "Run Import")
-    </MudButton>
-</MudPaper>
-
-<MudPaper Class="pa-6 mb-4" Outlined="true">
     <MudText Typo="Typo.h6" GutterBottom="true">Upload a CSV file</MudText>
     <MudText Typo="Typo.body2" Class="mb-4">
         Select a CSV file from your computer to import. Supported formats are detected automatically.
@@ -39,6 +27,26 @@
     @if (_selectedFile is not null)
     {
         <MudText Typo="Typo.body2" Class="mt-2 mud-text-secondary">Selected: @_selectedFile.Name</MudText>
+    }
+</MudPaper>
+
+<MudPaper Class="pa-6 mb-4" Outlined="true" Style="border-color: var(--mud-palette-error);">
+    <MudText Typo="Typo.h6" GutterBottom="true" Color="Color.Error">Danger zone</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Reset the database: deletes <strong>all cash transactions</strong> and <strong>all portfolio / asset transactions</strong>.
+        Currency conversions are kept. This cannot be undone from the UI — make a backup of <code>data/</code> first if needed.
+    </MudText>
+    <MudButton Variant="Variant.Filled" Color="Color.Error" Size="Size.Large"
+               OnClick="@OpenResetDialog" Disabled="@_loading"
+               StartIcon="@Icons.Material.Filled.DeleteForever">
+        Reset database
+    </MudButton>
+    @if (_resetResult is not null)
+    {
+        <MudAlert Severity="Severity.Info" Class="mt-4">
+            Cleared <strong>@_resetResult.ClearedTransactions</strong> transactions and
+            <strong>@_resetResult.ClearedAssetTransactions</strong> asset transactions.
+        </MudAlert>
     }
 </MudPaper>
 
@@ -101,9 +109,32 @@
     }
 }
 
+<MudDialog @bind-Visible="_showResetDialog">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Reset database?</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText>
+            This will permanently delete all cash transactions and all portfolio / asset transactions.
+            Currency conversions will not be deleted.
+        </MudText>
+        <MudText Class="mt-2" Typo="Typo.body2">
+            Prefer a backup of <code>data/transactions.json</code> and <code>data/portfolio.json</code> before continuing.
+        </MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseResetDialog" Disabled="@_loading">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@ConfirmResetAsync" Disabled="@_loading">
+            Yes, reset database
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
 @code {
     private ImportResultDto? _result;
+    private ResetResultDto? _resetResult;
     private bool _loading;
+    private bool _showResetDialog;
     private IBrowserFile? _selectedFile;
 
     private void OnFileSelected(InputFileChangeEventArgs args)
@@ -112,19 +143,38 @@
         _result = null;
     }
 
-    private async Task RunImportAsync()
+    private void OpenResetDialog()
+    {
+        _showResetDialog = true;
+    }
+
+    private void CloseResetDialog()
+    {
+        _showResetDialog = false;
+    }
+
+    private async Task ConfirmResetAsync()
     {
         _loading = true;
         _result = null;
+        _resetResult = null;
         try
         {
-            var response = await Http.PostAsJsonAsync("/api/import", new { folderPaths = new[] { "import/historical" } });
-            _result = await response.Content.ReadFromJsonAsync<ImportResultDto>();
-            Snackbar.Add("Import completed.", Severity.Success);
+            var response = await Http.PostAsync("/api/data/reset", null);
+            if (!response.IsSuccessStatusCode)
+            {
+                string body = await response.Content.ReadAsStringAsync();
+                Snackbar.Add($"Reset failed: {(int)response.StatusCode} {body}", Severity.Error);
+                return;
+            }
+
+            _resetResult = await response.Content.ReadFromJsonAsync<ResetResultDto>();
+            _showResetDialog = false;
+            Snackbar.Add("Database reset completed.", Severity.Success);
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Import failed: {ex.Message}", Severity.Error);
+            Snackbar.Add($"Reset failed: {ex.Message}", Severity.Error);
         }
         finally
         {
@@ -157,5 +207,12 @@
         {
             _loading = false;
         }
+    }
+
+    private sealed class ResetResultDto
+    {
+        public string? Message { get; set; }
+        public int ClearedTransactions { get; set; }
+        public int ClearedAssetTransactions { get; set; }
     }
 }

--- a/src/MyAccountingApp.Web/Pages/Settings.razor
+++ b/src/MyAccountingApp.Web/Pages/Settings.razor
@@ -1,0 +1,100 @@
+@page "/settings"
+@inject HttpClient Http
+@inject ISnackbar Snackbar
+@inject NavigationManager Navigation
+@inject IJSRuntime JS
+
+<PageTitle>Settings</PageTitle>
+
+<MudText Typo="Typo.h3" GutterBottom="true">Settings</MudText>
+
+<MudText Typo="Typo.h6" Class="mb-4">Database Backup</MudText>
+
+<MudPaper Class="pa-4 mb-4" Outlined="true">
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Download a full backup of all transactions and asset transactions as a JSON file.
+        Use the restore feature to reload the backup after a hard reset.
+    </MudText>
+
+    <MudButton Variant="Variant.Filled" Color="Color.Primary"
+               OnClick="@DownloadBackup" StartIcon="@Icons.Material.Filled.Download"
+               Class="mr-4">
+        Download Backup
+    </MudButton>
+
+    <MudButton Variant="Variant.Outlined" Color="Color.Warning"
+               OnClick="@TriggerRestore" StartIcon="@Icons.Material.Filled.Upload"
+               Disabled="@_isRestoring">
+        @(_isRestoring ? "Restoring..." : "Restore Backup")
+    </MudButton>
+
+    <div id="restore-upload" style="display:none">
+        <InputFile OnChange="@UploadBackup" />
+    </div>
+</MudPaper>
+
+@if (_lastRestoreMessage is not null)
+{
+    <MudAlert Severity="@_restoreSeverity" Class="mb-4" Dismissible="true">
+        @_lastRestoreMessage
+    </MudAlert>
+}
+
+@code {
+    private bool _isRestoring;
+    private string? _lastRestoreMessage;
+    private Severity _restoreSeverity = Severity.Normal;
+
+    private void DownloadBackup()
+    {
+        Navigation.NavigateTo("/api/backup", forceLoad: true);
+    }
+
+    private async Task TriggerRestore()
+    {
+        await JS.InvokeVoidAsync("eval", "document.querySelector('#restore-upload input').click()");
+    }
+
+    private async Task UploadBackup(InputFileChangeEventArgs e)
+    {
+        _isRestoring = true;
+        try
+        {
+            var file = e.File;
+            if (file is null) return;
+
+            using Stream content = file.OpenReadStream(maxAllowedSize: 50 * 1024 * 1024);
+            using MemoryStream ms = new();
+            await content.CopyToAsync(ms);
+            byte[] bytes = ms.ToArray();
+
+            HttpContent httpContent = new ByteArrayContent(bytes);
+            httpContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+            HttpResponseMessage response = await Http.PostAsync("/api/backup", httpContent);
+
+            if (response.IsSuccessStatusCode)
+            {
+                _lastRestoreMessage = "Backup restored successfully";
+                _restoreSeverity = Severity.Success;
+                Snackbar.Add("Backup restored successfully", Severity.Success);
+            }
+            else
+            {
+                string error = await response.Content.ReadAsStringAsync();
+                _lastRestoreMessage = $"Restore failed: {error}";
+                _restoreSeverity = Severity.Error;
+                Snackbar.Add($"Restore failed: {error}", Severity.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            _lastRestoreMessage = $"Error: {ex.Message}";
+            _restoreSeverity = Severity.Error;
+            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isRestoring = false;
+        }
+    }
+}

--- a/src/MyAccountingApp.Web/Pages/Settings.razor
+++ b/src/MyAccountingApp.Web/Pages/Settings.razor
@@ -33,6 +33,26 @@
     </div>
 </MudPaper>
 
+<MudPaper Class="pa-4 mb-4" Outlined="true" Style="border-color: var(--mud-palette-error);">
+    <MudText Typo="Typo.h6" GutterBottom="true" Color="Color.Error">Danger Zone</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Reset the database: deletes <strong>all cash transactions</strong> and <strong>all portfolio / asset transactions</strong>.
+        Currency conversions are kept. This cannot be undone — make a backup first if needed.
+    </MudText>
+    <MudButton Variant="Variant.Filled" Color="Color.Error" Size="Size.Large"
+               OnClick="@OpenResetDialog" Disabled="@_isResetting"
+               StartIcon="@Icons.Material.Filled.DeleteForever">
+        Reset database
+    </MudButton>
+    @if (_resetResult is not null)
+    {
+        <MudAlert Severity="Severity.Info" Class="mt-4">
+            Cleared <strong>@_resetResult.ClearedTransactions</strong> transactions and
+            <strong>@_resetResult.ClearedAssetTransactions</strong> asset transactions.
+        </MudAlert>
+    }
+</MudPaper>
+
 @if (_lastRestoreMessage is not null)
 {
     <MudAlert Severity="@_restoreSeverity" Class="mb-4" Dismissible="true">
@@ -40,10 +60,34 @@
     </MudAlert>
 }
 
+<MudDialog @bind-Visible="_showResetDialog">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Reset database?</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText>
+            This will permanently delete all cash transactions and all portfolio / asset transactions.
+            Currency conversions will not be deleted.
+        </MudText>
+        <MudText Class="mt-2" Typo="Typo.body2">
+            Prefer a backup of <code>data/transactions.json</code> and <code>data/portfolio.json</code> before continuing.
+        </MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseResetDialog" Disabled="@_isResetting">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@ConfirmResetAsync" Disabled="@_isResetting">
+            Yes, reset database
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
 @code {
     private bool _isRestoring;
+    private bool _isResetting;
     private string? _lastRestoreMessage;
     private Severity _restoreSeverity = Severity.Normal;
+    private bool _showResetDialog;
+    private ResetResultDto? _resetResult;
 
     private void DownloadBackup()
     {
@@ -96,5 +140,50 @@
         {
             _isRestoring = false;
         }
+    }
+
+    private void OpenResetDialog()
+    {
+        _showResetDialog = true;
+    }
+
+    private void CloseResetDialog()
+    {
+        _showResetDialog = false;
+    }
+
+    private async Task ConfirmResetAsync()
+    {
+        _isResetting = true;
+        _resetResult = null;
+        try
+        {
+            var response = await Http.PostAsync("/api/data/reset", null);
+            if (!response.IsSuccessStatusCode)
+            {
+                string body = await response.Content.ReadAsStringAsync();
+                Snackbar.Add($"Reset failed: {(int)response.StatusCode} {body}", Severity.Error);
+                return;
+            }
+
+            _resetResult = await response.Content.ReadFromJsonAsync<ResetResultDto>();
+            _showResetDialog = false;
+            Snackbar.Add("Database reset completed.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Reset failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isResetting = false;
+        }
+    }
+
+    private sealed class ResetResultDto
+    {
+        public string? Message { get; set; }
+        public int ClearedTransactions { get; set; }
+        public int ClearedAssetTransactions { get; set; }
     }
 }

--- a/src/MyAccountingApp.Web/Pages/Transactions.razor
+++ b/src/MyAccountingApp.Web/Pages/Transactions.razor
@@ -1,8 +1,6 @@
 @page "/transactions"
 @inject HttpClient Http
 @inject ISnackbar Snackbar
-@inject NavigationManager Navigation
-@inject IJSRuntime JS
 
 <PageTitle>Transactions</PageTitle>
 
@@ -57,14 +55,6 @@ else
                 New
             </MudButton>
             <MudIconButton Icon="@Icons.Material.Filled.Refresh" OnClick="@LoadDataAsync" Size="Size.Small" Title="Refresh" />
-            <MudIconButton Icon="@Icons.Material.Filled.Download" OnClick="@DownloadBackup" Size="Size.Small" Title="Download backup" />
-            <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Default"
-                       OnClick="@TriggerRestore" StartIcon="@Icons.Material.Filled.Upload">
-                Restore
-            </MudButton>
-            <div id="restore-upload" style="display:none">
-                <InputFile OnChange="@UploadBackup" />
-            </div>
         </ToolBarContent>
         <ColGroup>
             <col style="width: 120px" />
@@ -350,49 +340,6 @@ else
             {
                 string error = await response.Content.ReadAsStringAsync();
                 Snackbar.Add($"Failed to delete: {error}", Severity.Error);
-            }
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
-        }
-    }
-
-    private void DownloadBackup()
-    {
-        Navigation.NavigateTo("/api/backup", forceLoad: true);
-    }
-
-    private async Task TriggerRestore()
-    {
-        await JS.InvokeVoidAsync("eval", "document.querySelector('#restore-upload input').click()");
-    }
-
-    private async Task UploadBackup(InputFileChangeEventArgs e)
-    {
-        try
-        {
-            var file = e.File;
-            if (file is null) return;
-
-            using Stream content = file.OpenReadStream(maxAllowedSize: 50 * 1024 * 1024);
-            using MemoryStream ms = new();
-            await content.CopyToAsync(ms);
-            byte[] bytes = ms.ToArray();
-
-            HttpContent httpContent = new ByteArrayContent(bytes);
-            httpContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            HttpResponseMessage response = await Http.PostAsync("/api/backup", httpContent);
-
-            if (response.IsSuccessStatusCode)
-            {
-                Snackbar.Add("Backup restored successfully", Severity.Success);
-                await LoadDataAsync();
-            }
-            else
-            {
-                string error = await response.Content.ReadAsStringAsync();
-                Snackbar.Add($"Restore failed: {error}", Severity.Error);
             }
         }
         catch (Exception ex)

--- a/src/MyAccountingApp.Web/Pages/Transactions.razor
+++ b/src/MyAccountingApp.Web/Pages/Transactions.razor
@@ -39,6 +39,10 @@ else
         <ToolBarContent>
             <MudText Typo="Typo.subtitle1">@_filteredTransactions.Count transactions</MudText>
             <MudSpacer />
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                       OnClick="@OpenCreateDialog" StartIcon="@Icons.Material.Filled.Add">
+                New
+            </MudButton>
             <MudIconButton Icon="@Icons.Material.Filled.Refresh" OnClick="@LoadDataAsync" Size="Size.Small" />
         </ToolBarContent>
         <ColGroup>
@@ -47,6 +51,7 @@ else
             <col style="width: 100px" />
             <col style="width: 80px" />
             <col style="width: 100px" />
+            <col style="width: 80px" />
         </ColGroup>
         <HeaderContent>
             <MudTh><MudTableSortLabel SortBy="new Func<TransactionDto, object>(t => t.Date)">Date</MudTableSortLabel></MudTh>
@@ -54,6 +59,7 @@ else
             <MudTh><MudTableSortLabel SortBy="new Func<TransactionDto, object>(t => t.Money.Amount)">Amount</MudTableSortLabel></MudTh>
             <MudTh>Curr.</MudTh>
             <MudTh><MudTableSortLabel SortBy="new Func<TransactionDto, object>(t => t.Category)">Category</MudTableSortLabel></MudTh>
+            <MudTh>Actions</MudTh>
         </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="Date">@context.Date.ToString("yyyy-MM-dd")</MudTd>
@@ -63,11 +69,79 @@ else
             <MudTd DataLabel="Category">
                 <MudChip T="string" Size="Size.Small" Color="@GetCategoryColor(context.Category)">@context.Category</MudChip>
             </MudTd>
+            <MudTd DataLabel="Actions">
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="@(() => OpenEditDialog(context))" />
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error" OnClick="@(() => OpenDeleteDialog(context))" />
+            </MudTd>
         </RowTemplate>
         <PagerContent>
             <MudTablePager PageSizeOptions="@(new int[]{25, 50, 100})" />
         </PagerContent>
     </MudTable>
+}
+
+@if (_showFormDialog)
+{
+    <MudDialog @bind-Visible="_showFormDialog">
+        <TitleContent>
+            <MudText Typo="Typo.h6">@(_editingId is null ? "New Transaction" : "Edit Transaction")</MudText>
+        </TitleContent>
+        <DialogContent>
+            <MudGrid>
+                <MudItem xs="12">
+                    <MudDatePicker @bind-Date="_formDate" Label="Date" Variant="Variant.Outlined" />
+                </MudItem>
+                <MudItem xs="12">
+                    <MudTextField @bind-Value="_formDescription" Label="Description" Variant="Variant.Outlined" />
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudNumericField T="decimal" @bind-Value="_formAmount" Label="Amount" Variant="Variant.Outlined" Min="@(0.01m)" />
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudSelect @bind-Value="_formCurrency" Label="Currency" Variant="Variant.Outlined">
+                        <MudSelectItem Value="@("EUR")">EUR</MudSelectItem>
+                        <MudSelectItem Value="@("USD")">USD</MudSelectItem>
+                        <MudSelectItem Value="@("GBP")">GBP</MudSelectItem>
+                        <MudSelectItem Value="@("CHF")">CHF</MudSelectItem>
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12">
+                    <MudSelect @bind-Value="_formCategory" Label="Category" Variant="Variant.Outlined">
+                        @foreach (var cat in _categories)
+                        {
+                            <MudSelectItem Value="cat">@cat</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+            </MudGrid>
+        </DialogContent>
+        <DialogActions>
+            <MudButton OnClick="@CloseFormDialog">Cancel</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@SaveAsync" Disabled="@IsFormInvalid()">
+                Save
+            </MudButton>
+        </DialogActions>
+    </MudDialog>
+}
+
+@if (_showDeleteDialog)
+{
+    <MudDialog @bind-Visible="_showDeleteDialog">
+        <TitleContent>
+            <MudText Typo="Typo.h6">Delete Transaction</MudText>
+        </TitleContent>
+        <DialogContent>
+            <MudText>Are you sure you want to delete this transaction?</MudText>
+            @if (_deletingTx is not null)
+            {
+                <MudText Typo="Typo.body2" Class="mt-2">@_deletingTx.Date.ToString("yyyy-MM-dd") — @_deletingTx.Description (@_deletingTx.Money.Amount.ToString("N2") @_deletingTx.Money.Currency)</MudText>
+            }
+        </DialogContent>
+        <DialogActions>
+            <MudButton OnClick="@CloseDeleteDialog">Cancel</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@ConfirmDeleteAsync">Delete</MudButton>
+        </DialogActions>
+    </MudDialog>
 }
 
 @code {
@@ -81,6 +155,17 @@ else
     private string? _searchText { get; set; }
 
     private static readonly string[] _categories = { "INCOME", "EXPENSE", "TRANSFER", "DEPOSIT" };
+
+    private bool _showFormDialog;
+    private bool _showDeleteDialog;
+    private Guid? _editingId;
+    private TransactionDto? _deletingTx;
+
+    private DateTime? _formDate;
+    private string _formDescription = "";
+    private decimal _formAmount;
+    private string _formCurrency = "EUR";
+    private string _formCategory = "EXPENSE";
 
     protected override async Task OnInitializedAsync()
     {
@@ -122,6 +207,8 @@ else
         _filteredTransactions = query.ToList();
     }
 
+    private bool IsFormInvalid() => string.IsNullOrWhiteSpace(_formDescription) || _formAmount <= 0;
+
     private static Color GetCategoryColor(string category) => category switch
     {
         "INCOME" => Color.Success,
@@ -130,4 +217,90 @@ else
         "DEPOSIT" => Color.Info,
         _ => Color.Default,
     };
+
+    private void OpenCreateDialog()
+    {
+        _editingId = null;
+        _formDate = DateTime.Today;
+        _formDescription = "";
+        _formAmount = 0;
+        _formCurrency = "EUR";
+        _formCategory = "EXPENSE";
+        _showFormDialog = true;
+    }
+
+    private void OpenEditDialog(TransactionDto tx)
+    {
+        _editingId = tx.Id;
+        _formDate = tx.Date;
+        _formDescription = tx.Description;
+        _formAmount = tx.Money.Amount;
+        _formCurrency = tx.Money.Currency;
+        _formCategory = tx.Category;
+        _showFormDialog = true;
+    }
+
+    private void CloseFormDialog()
+    {
+        _showFormDialog = false;
+    }
+
+    private async Task SaveAsync()
+    {
+        var payload = new
+        {
+            Date = _formDate ?? DateTime.Today,
+            Description = _formDescription,
+            Amount = _formAmount,
+            Currency = _formCurrency,
+            Category = _formCategory,
+        };
+
+        HttpResponseMessage response;
+        if (_editingId is null)
+        {
+            response = await Http.PostAsJsonAsync("/api/transactions", payload);
+        }
+        else
+        {
+            response = await Http.PutAsJsonAsync($"/api/transactions/{_editingId}", payload);
+        }
+
+        if (response.IsSuccessStatusCode)
+        {
+            _showFormDialog = false;
+            await LoadDataAsync();
+        }
+        else
+        {
+            string error = await response.Content.ReadAsStringAsync();
+            _showFormDialog = false;
+        }
+    }
+
+    private void OpenDeleteDialog(TransactionDto tx)
+    {
+        _deletingTx = tx;
+        _showDeleteDialog = true;
+    }
+
+    private void CloseDeleteDialog()
+    {
+        _showDeleteDialog = false;
+        _deletingTx = null;
+    }
+
+    private async Task ConfirmDeleteAsync()
+    {
+        if (_deletingTx is null) return;
+
+        HttpResponseMessage response = await Http.DeleteAsync($"/api/transactions/{_deletingTx.Id}");
+        _showDeleteDialog = false;
+        _deletingTx = null;
+
+        if (response.IsSuccessStatusCode || response.StatusCode == System.Net.HttpStatusCode.NoContent)
+        {
+            await LoadDataAsync();
+        }
+    }
 }

--- a/src/MyAccountingApp.Web/Pages/Transactions.razor
+++ b/src/MyAccountingApp.Web/Pages/Transactions.razor
@@ -1,6 +1,8 @@
 @page "/transactions"
 @inject HttpClient Http
 @inject ISnackbar Snackbar
+@inject NavigationManager Navigation
+@inject IJSRuntime JS
 
 <PageTitle>Transactions</PageTitle>
 
@@ -54,7 +56,15 @@ else
                        OnClick="@OpenCreateDialog" StartIcon="@Icons.Material.Filled.Add">
                 New
             </MudButton>
-            <MudIconButton Icon="@Icons.Material.Filled.Refresh" OnClick="@LoadDataAsync" Size="Size.Small" />
+            <MudIconButton Icon="@Icons.Material.Filled.Refresh" OnClick="@LoadDataAsync" Size="Size.Small" Title="Refresh" />
+            <MudIconButton Icon="@Icons.Material.Filled.Download" OnClick="@DownloadBackup" Size="Size.Small" Title="Download backup" />
+            <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Default"
+                       OnClick="@TriggerRestore" StartIcon="@Icons.Material.Filled.Upload">
+                Restore
+            </MudButton>
+            <div id="restore-upload" style="display:none">
+                <InputFile OnChange="@UploadBackup" />
+            </div>
         </ToolBarContent>
         <ColGroup>
             <col style="width: 120px" />
@@ -340,6 +350,49 @@ else
             {
                 string error = await response.Content.ReadAsStringAsync();
                 Snackbar.Add($"Failed to delete: {error}", Severity.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private void DownloadBackup()
+    {
+        Navigation.NavigateTo("/api/backup", forceLoad: true);
+    }
+
+    private async Task TriggerRestore()
+    {
+        await JS.InvokeVoidAsync("eval", "document.querySelector('#restore-upload input').click()");
+    }
+
+    private async Task UploadBackup(InputFileChangeEventArgs e)
+    {
+        try
+        {
+            var file = e.File;
+            if (file is null) return;
+
+            using Stream content = file.OpenReadStream(maxAllowedSize: 50 * 1024 * 1024);
+            using MemoryStream ms = new();
+            await content.CopyToAsync(ms);
+            byte[] bytes = ms.ToArray();
+
+            HttpContent httpContent = new ByteArrayContent(bytes);
+            httpContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+            HttpResponseMessage response = await Http.PostAsync("/api/backup", httpContent);
+
+            if (response.IsSuccessStatusCode)
+            {
+                Snackbar.Add("Backup restored successfully", Severity.Success);
+                await LoadDataAsync();
+            }
+            else
+            {
+                string error = await response.Content.ReadAsStringAsync();
+                Snackbar.Add($"Restore failed: {error}", Severity.Error);
             }
         }
         catch (Exception ex)

--- a/src/MyAccountingApp.Web/Pages/Transactions.razor
+++ b/src/MyAccountingApp.Web/Pages/Transactions.razor
@@ -81,69 +81,63 @@ else
     </MudTable>
 }
 
-@if (_showFormDialog)
-{
-    <MudDialog @bind-Visible="_showFormDialog">
-        <TitleContent>
-            <MudText Typo="Typo.h6">@(_editingId is null ? "New Transaction" : "Edit Transaction")</MudText>
-        </TitleContent>
-        <DialogContent>
-            <MudGrid>
-                <MudItem xs="12">
-                    <MudDatePicker @bind-Date="_formDate" Label="Date" Variant="Variant.Outlined" />
-                </MudItem>
-                <MudItem xs="12">
-                    <MudTextField @bind-Value="_formDescription" Label="Description" Variant="Variant.Outlined" />
-                </MudItem>
-                <MudItem xs="12" sm="6">
-                    <MudNumericField T="decimal" @bind-Value="_formAmount" Label="Amount" Variant="Variant.Outlined" Min="@(0.01m)" />
-                </MudItem>
-                <MudItem xs="12" sm="6">
-                    <MudSelect @bind-Value="_formCurrency" Label="Currency" Variant="Variant.Outlined">
-                        <MudSelectItem Value="@("EUR")">EUR</MudSelectItem>
-                        <MudSelectItem Value="@("USD")">USD</MudSelectItem>
-                        <MudSelectItem Value="@("GBP")">GBP</MudSelectItem>
-                        <MudSelectItem Value="@("CHF")">CHF</MudSelectItem>
-                    </MudSelect>
-                </MudItem>
-                <MudItem xs="12">
-                    <MudSelect @bind-Value="_formCategory" Label="Category" Variant="Variant.Outlined">
-                        @foreach (var cat in _categories)
-                        {
-                            <MudSelectItem Value="cat">@cat</MudSelectItem>
-                        }
-                    </MudSelect>
-                </MudItem>
-            </MudGrid>
-        </DialogContent>
-        <DialogActions>
-            <MudButton OnClick="@CloseFormDialog">Cancel</MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@SaveAsync" Disabled="@IsFormInvalid()">
-                Save
-            </MudButton>
-        </DialogActions>
-    </MudDialog>
-}
+<MudDialog @bind-Visible="_showFormDialog">
+    <TitleContent>
+        <MudText Typo="Typo.h6">@(_editingId is null ? "New Transaction" : "Edit Transaction")</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudGrid>
+            <MudItem xs="12">
+                <MudDatePicker @bind-Date="_formDate" Label="Date" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12">
+                <MudTextField @bind-Value="_formDescription" Label="Description" Variant="Variant.Outlined" />
+            </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudNumericField T="decimal" @bind-Value="_formAmount" Label="Amount" Variant="Variant.Outlined" Min="@(0.01m)" />
+            </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudSelect @bind-Value="_formCurrency" Label="Currency" Variant="Variant.Outlined">
+                    <MudSelectItem Value="@("EUR")">EUR</MudSelectItem>
+                    <MudSelectItem Value="@("USD")">USD</MudSelectItem>
+                    <MudSelectItem Value="@("GBP")">GBP</MudSelectItem>
+                    <MudSelectItem Value="@("CHF")">CHF</MudSelectItem>
+                </MudSelect>
+            </MudItem>
+            <MudItem xs="12">
+                <MudSelect @bind-Value="_formCategory" Label="Category" Variant="Variant.Outlined">
+                    @foreach (var cat in _categories)
+                    {
+                        <MudSelectItem Value="cat">@cat</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
+        </MudGrid>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseFormDialog">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@SaveAsync" Disabled="@IsFormInvalid()">
+            Save
+        </MudButton>
+    </DialogActions>
+</MudDialog>
 
-@if (_showDeleteDialog)
-{
-    <MudDialog @bind-Visible="_showDeleteDialog">
-        <TitleContent>
-            <MudText Typo="Typo.h6">Delete Transaction</MudText>
-        </TitleContent>
-        <DialogContent>
-            <MudText>Are you sure you want to delete this transaction?</MudText>
-            @if (_deletingTx is not null)
-            {
-                <MudText Typo="Typo.body2" Class="mt-2">@_deletingTx.Date.ToString("yyyy-MM-dd") — @_deletingTx.Description (@_deletingTx.Money.Amount.ToString("N2") @_deletingTx.Money.Currency)</MudText>
-            }
-        </DialogContent>
-        <DialogActions>
-            <MudButton OnClick="@CloseDeleteDialog">Cancel</MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@ConfirmDeleteAsync">Delete</MudButton>
-        </DialogActions>
-    </MudDialog>
-}
+<MudDialog @bind-Visible="_showDeleteDialog">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Delete Transaction</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText>Are you sure you want to delete this transaction?</MudText>
+        @if (_deletingTx is not null)
+        {
+            <MudText Typo="Typo.body2" Class="mt-2">@_deletingTx.Date.ToString("yyyy-MM-dd") — @_deletingTx.Description (@_deletingTx.Money.Amount.ToString("N2") @_deletingTx.Money.Currency)</MudText>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseDeleteDialog">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@ConfirmDeleteAsync">Delete</MudButton>
+    </DialogActions>
+</MudDialog>
 
 @code {
     private List<TransactionDto> _allTransactions = new();

--- a/src/MyAccountingApp.Web/Pages/Transactions.razor
+++ b/src/MyAccountingApp.Web/Pages/Transactions.razor
@@ -1,5 +1,6 @@
 @page "/transactions"
 @inject HttpClient Http
+@inject ISnackbar Snackbar
 
 <PageTitle>Transactions</PageTitle>
 
@@ -247,34 +248,42 @@ else
 
     private async Task SaveAsync()
     {
-        var payload = new
+        try
         {
-            Date = _formDate ?? DateTime.Today,
-            Description = _formDescription,
-            Amount = _formAmount,
-            Currency = _formCurrency,
-            Category = _formCategory,
-        };
+            var payload = new
+            {
+                Date = _formDate ?? DateTime.Today,
+                Description = _formDescription,
+                Amount = _formAmount,
+                Currency = _formCurrency,
+                Category = _formCategory,
+            };
 
-        HttpResponseMessage response;
-        if (_editingId is null)
-        {
-            response = await Http.PostAsJsonAsync("/api/transactions", payload);
-        }
-        else
-        {
-            response = await Http.PutAsJsonAsync($"/api/transactions/{_editingId}", payload);
-        }
+            HttpResponseMessage response;
+            if (_editingId is null)
+            {
+                response = await Http.PostAsJsonAsync("/api/transactions", payload);
+            }
+            else
+            {
+                response = await Http.PutAsJsonAsync($"/api/transactions/{_editingId}", payload);
+            }
 
-        if (response.IsSuccessStatusCode)
-        {
-            _showFormDialog = false;
-            await LoadDataAsync();
+            if (response.IsSuccessStatusCode)
+            {
+                _showFormDialog = false;
+                Snackbar.Add(_editingId is null ? "Transaction created" : "Transaction updated", Severity.Success);
+                await LoadDataAsync();
+            }
+            else
+            {
+                string error = await response.Content.ReadAsStringAsync();
+                Snackbar.Add($"Failed to save: {error}", Severity.Error);
+            }
         }
-        else
+        catch (Exception ex)
         {
-            string error = await response.Content.ReadAsStringAsync();
-            _showFormDialog = false;
+            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
         }
     }
 
@@ -294,13 +303,26 @@ else
     {
         if (_deletingTx is null) return;
 
-        HttpResponseMessage response = await Http.DeleteAsync($"/api/transactions/{_deletingTx.Id}");
-        _showDeleteDialog = false;
-        _deletingTx = null;
-
-        if (response.IsSuccessStatusCode || response.StatusCode == System.Net.HttpStatusCode.NoContent)
+        try
         {
-            await LoadDataAsync();
+            HttpResponseMessage response = await Http.DeleteAsync($"/api/transactions/{_deletingTx.Id}");
+            _showDeleteDialog = false;
+            _deletingTx = null;
+
+            if (response.IsSuccessStatusCode || response.StatusCode == System.Net.HttpStatusCode.NoContent)
+            {
+                Snackbar.Add("Transaction deleted", Severity.Success);
+                await LoadDataAsync();
+            }
+            else
+            {
+                string error = await response.Content.ReadAsStringAsync();
+                Snackbar.Add($"Failed to delete: {error}", Severity.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
         }
     }
 }

--- a/src/MyAccountingApp.Web/Pages/Transactions.razor
+++ b/src/MyAccountingApp.Web/Pages/Transactions.razor
@@ -8,15 +8,25 @@
 
 <MudPaper Class="pa-4 mb-4" Outlined="true">
     <MudGrid>
-        <MudItem xs="12" sm="4">
-            <MudSelect T="int?" @bind-Value="_selectedYear" @bind-Value:after="ApplyFilters" Label="Year" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
+        <MudItem xs="12" sm="6" md="3">
+            <MudSelect T="int?" @bind-Value="_selectedYear" @bind-Value:after="OnYearChanged" Label="Year" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
                 @foreach (var year in _availableYears)
                 {
                     <MudSelectItem T="int?" Value="@((int?)year)">@year</MudSelectItem>
                 }
             </MudSelect>
         </MudItem>
-        <MudItem xs="12" sm="4">
+        <MudItem xs="12" sm="6" md="3">
+            <MudSelect T="int?" @bind-Value="_selectedMonth" @bind-Value:after="ApplyFilters" Label="Month" Variant="Variant.Outlined" FullWidth="true" Clearable="true"
+                       Disabled="@(!_selectedYear.HasValue)">
+                @for (int m = 1; m <= 12; m++)
+                {
+                    var month = m;
+                    <MudSelectItem T="int?" Value="@((int?)month)">@_monthNames[month - 1]</MudSelectItem>
+                }
+            </MudSelect>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="3">
             <MudSelect @bind-Value="_selectedCategory" @bind-Value:after="ApplyFilters" Label="Category" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
                 @foreach (var cat in _categories)
                 {
@@ -24,7 +34,7 @@
                 }
             </MudSelect>
         </MudItem>
-        <MudItem xs="12" sm="4">
+        <MudItem xs="12" sm="6" md="3">
             <MudTextField @bind-Value="_searchText" @bind-Value:after="ApplyFilters" Label="Search description" Variant="Variant.Outlined" FullWidth="true" Immediate="true" Placeholder="Type to search..." />
         </MudItem>
     </MudGrid>
@@ -146,10 +156,16 @@ else
     private bool _loading = true;
 
     private int? _selectedYear { get; set; }
+    private int? _selectedMonth { get; set; }
     private string? _selectedCategory { get; set; }
     private string? _searchText { get; set; }
 
     private static readonly string[] _categories = { "INCOME", "EXPENSE", "TRANSFER", "DEPOSIT" };
+    private static readonly string[] _monthNames =
+    {
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December",
+    };
 
     private bool _showFormDialog;
     private bool _showDeleteDialog;
@@ -186,6 +202,14 @@ else
         }
     }
 
+    private void OnYearChanged()
+    {
+        if (!_selectedYear.HasValue)
+            _selectedMonth = null;
+
+        ApplyFilters();
+    }
+
     private void ApplyFilters()
     {
         var query = _allTransactions.AsEnumerable();
@@ -193,13 +217,17 @@ else
         if (_selectedYear.HasValue)
             query = query.Where(t => t.Date.Year == _selectedYear.Value);
 
+        // Month only applies together with a year (no "all years for this month").
+        if (_selectedYear.HasValue && _selectedMonth.HasValue)
+            query = query.Where(t => t.Date.Month == _selectedMonth.Value);
+
         if (!string.IsNullOrWhiteSpace(_selectedCategory))
             query = query.Where(t => t.Category == _selectedCategory);
 
         if (!string.IsNullOrWhiteSpace(_searchText))
             query = query.Where(t => t.Description.Contains(_searchText, StringComparison.OrdinalIgnoreCase));
 
-        _filteredTransactions = query.ToList();
+        _filteredTransactions = query.OrderByDescending(t => t.Date).ToList();
     }
 
     private bool IsFormInvalid() => string.IsNullOrWhiteSpace(_formDescription) || _formAmount <= 0;

--- a/src/MyAccountingApp.Web/Program.cs
+++ b/src/MyAccountingApp.Web/Program.cs
@@ -9,6 +9,11 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddMudServices();
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+// Import of multi-year CSVs can exceed the default 100s timeout if the API is slow.
+builder.Services.AddScoped(sp => new HttpClient
+{
+    BaseAddress = new Uri(builder.HostEnvironment.BaseAddress),
+    Timeout = TimeSpan.FromMinutes(10),
+});
 
 await builder.Build().RunAsync();

--- a/tests/MyAccountingApp.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -175,5 +175,7 @@ public class AnnualSummaryServiceTests
             this._transactions.Clear();
             this._transactions.AddRange(transactions);
         }
+
+        public bool Delete(Guid transactionId) => true;
     }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/ImportServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ImportServiceTests.cs
@@ -299,5 +299,7 @@ public class ImportServiceTests
             this._transactions.Clear();
             this._transactions.AddRange(transactions);
         }
+
+        public bool Delete(Guid transactionId) => true;
     }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/PortfolioQueryTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/PortfolioQueryTests.cs
@@ -79,5 +79,7 @@ public class PortfolioQueryTests
             this._transactions.Clear();
             this._transactions.AddRange(transactions);
         }
+
+        public bool Delete(Guid transactionId) => true;
     }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/PositionEngineTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/PositionEngineTests.cs
@@ -170,5 +170,7 @@ public class PositionEngineTests
             this._transactions.Clear();
             this._transactions.AddRange(transactions);
         }
+
+        public bool Delete(Guid transactionId) => true;
     }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/ValidationQueryTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ValidationQueryTests.cs
@@ -84,5 +84,7 @@ public class ValidationQueryTests
             this._transactions.Clear();
             this._transactions.AddRange(transactions);
         }
+
+        public bool Delete(Guid transactionId) => true;
     }
 }

--- a/tests/MyAccountingApp.Core.Tests/Repositories/CompositePortfolioRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/CompositePortfolioRepositoryTests.cs
@@ -33,4 +33,24 @@ public class CompositePortfolioRepositoryTests : IDisposable
         // Assert
         Assert.Single(all);
     }
+
+    [Fact]
+    public void Delete_ShouldRemoveFromBothRepositories()
+    {
+        // Arrange
+        CompositePortfolioRepository repo = new CompositePortfolioRepository(this._tempFile);
+        AssetTransaction tx = AssetTransactionObjectMother.CreateBuy();
+        repo.AddOrUpdate(tx);
+
+        // Act
+        bool result = repo.Delete(tx.Transaction.Id);
+
+        // Assert
+        Assert.True(result);
+        Assert.Empty(repo.GetAllTransactions());
+
+        // Verify persisted in JSON
+        JsonPortfolioRepository jsonRepo = new JsonPortfolioRepository(this._tempFile);
+        Assert.Empty(jsonRepo.GetAllTransactions());
+    }
 }

--- a/tests/MyAccountingApp.Core.Tests/Repositories/InMemoryPortfolioRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/InMemoryPortfolioRepositoryTests.cs
@@ -55,4 +55,33 @@ public class InMemoryPortfolioRepositoryTests
         Assert.Single(aaplTransactions);
         Assert.Equal("AAPL", aaplTransactions.First().Symbol);
     }
+
+    [Fact]
+    public void Delete_ShouldRemoveTransaction()
+    {
+        // Arrange
+        InMemoryPortfolioRepository repo = new();
+        AssetTransaction tx = AssetTransactionObjectMother.CreateBuy();
+        repo.AddOrUpdate(tx);
+
+        // Act
+        bool result = repo.Delete(tx.Transaction.Id);
+
+        // Assert
+        Assert.True(result);
+        Assert.Empty(repo.GetAllTransactions());
+    }
+
+    [Fact]
+    public void Delete_NonExistent_ShouldReturnFalse()
+    {
+        // Arrange
+        InMemoryPortfolioRepository repo = new();
+
+        // Act
+        bool result = repo.Delete(Guid.NewGuid());
+
+        // Assert
+        Assert.False(result);
+    }
 }

--- a/tests/MyAccountingApp.Core.Tests/Repositories/JsonPortfolioRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/JsonPortfolioRepositoryTests.cs
@@ -52,4 +52,24 @@ public class JsonPortfolioRepositoryTests : IDisposable
 
         Assert.Equal(2, all.Count);
     }
+
+    [Fact]
+    public void Delete_ShouldRemoveFromJson()
+    {
+        // Arrange
+        JsonPortfolioRepository repo = new JsonPortfolioRepository(this._tempFile);
+        AssetTransaction tx = AssetTransactionObjectMother.CreateBuy();
+        repo.AddOrUpdate(tx);
+
+        // Act
+        bool result = repo.Delete(tx.Transaction.Id);
+
+        // Assert
+        Assert.True(result);
+        Assert.Empty(repo.GetAllTransactions());
+
+        // Verify persisted
+        JsonPortfolioRepository repo2 = new JsonPortfolioRepository(this._tempFile);
+        Assert.Empty(repo2.GetAllTransactions());
+    }
 }


### PR DESCRIPTION
- POST/PUT/DELETE for transactions and asset transactions
- Backup/restore (GET/POST /api/backup) and reset (POST /api/data/reset)
- Settings page: download/restore backup, reset database
- Default sort by date descending + month filter on transactions
- Atomic JSON writes (temp file + rename) preventing corruption
- Auto-recovery on JSON parse errors + deduplication on read
- Serilog file logging (7-day retention)
- Fixed missing braces and using directives for Release CI