### PR TITLE
feat: monthly breakdown in summary and CSV date parsing fix

### DIFF
--- a/src/MyAccountingApp.Application/DTOs/AnnualSummaryDto.cs
+++ b/src/MyAccountingApp.Application/DTOs/AnnualSummaryDto.cs
@@ -1,5 +1,15 @@
 namespace MyAccountingApp.Application.DTOs;
 
+public record MonthlySummaryDto(
+    int Month,
+    decimal Expenses,
+    decimal Income,
+    decimal InvestmentPurchases,
+    decimal InvestmentSales,
+    decimal NetCashFlow,
+    int TransactionCount,
+    int AssetTransactionCount);
+
 public record AnnualSummaryDto(
     int Year,
     decimal Expenses,
@@ -8,4 +18,5 @@ public record AnnualSummaryDto(
     decimal InvestmentSales,
     decimal NetCashFlow,
     int TransactionCount,
-    int AssetTransactionCount);
+    int AssetTransactionCount,
+    List<MonthlySummaryDto> Months);

--- a/src/MyAccountingApp.Application/Services/AnnualSummaryService.cs
+++ b/src/MyAccountingApp.Application/Services/AnnualSummaryService.cs
@@ -87,6 +87,8 @@ public class AnnualSummaryService : IAnnualSummaryService
 
         decimal netCashFlow = income + investmentSales - expenses - investmentPurchases;
 
+        List<MonthlySummaryDto> months = this.BuildMonthlySummaries(year, yearTxs, yearAssetTxs);
+
         return new AnnualSummaryDto(
             year,
             Math.Round(expenses, 2),
@@ -95,6 +97,61 @@ public class AnnualSummaryService : IAnnualSummaryService
             Math.Round(investmentSales, 2),
             Math.Round(netCashFlow, 2),
             yearTxs.Count,
-            yearAssetTxs.Count);
+            yearAssetTxs.Count,
+            months);
+    }
+
+    private List<MonthlySummaryDto> BuildMonthlySummaries(
+        int year,
+        List<Domain.Entities.Transaction> yearTxs,
+        List<Domain.Entities.AssetTransaction> yearAssetTxs)
+    {
+        List<MonthlySummaryDto> result = new List<MonthlySummaryDto>(12);
+
+        for (int month = 1; month <= 12; month++)
+        {
+            List<Domain.Entities.Transaction> monthTxs = yearTxs
+                .Where(t => t.Date.Month == month)
+                .ToList();
+
+            List<Domain.Entities.AssetTransaction> monthAssetTxs = yearAssetTxs
+                .Where(a => a.Transaction.Date.Month == month)
+                .ToList();
+
+            if (monthTxs.Count == 0 && monthAssetTxs.Count == 0)
+            {
+                continue;
+            }
+
+            decimal expenses = monthTxs
+                .Where(t => t.Category == TransactionCategory.EXPENSE)
+                .Sum(t => t.Money.Amount);
+
+            decimal income = monthTxs
+                .Where(t => t.Category == TransactionCategory.INCOME)
+                .Sum(t => t.Money.Amount);
+
+            decimal investmentPurchases = monthAssetTxs
+                .Where(a => a.Type == AssetTransactionType.Buy)
+                .Sum(a => a.Transaction.Money.Amount);
+
+            decimal investmentSales = monthAssetTxs
+                .Where(a => a.Type == AssetTransactionType.Sell)
+                .Sum(a => a.Transaction.Money.Amount);
+
+            decimal netCashFlow = income + investmentSales - expenses - investmentPurchases;
+
+            result.Add(new MonthlySummaryDto(
+                month,
+                Math.Round(expenses, 2),
+                Math.Round(income, 2),
+                Math.Round(investmentPurchases, 2),
+                Math.Round(investmentSales, 2),
+                Math.Round(netCashFlow, 2),
+                monthTxs.Count,
+                monthAssetTxs.Count));
+        }
+
+        return result;
     }
 }

--- a/src/MyAccountingApp.Core/Services/AssetTransactionCsvImportService.cs
+++ b/src/MyAccountingApp.Core/Services/AssetTransactionCsvImportService.cs
@@ -39,7 +39,11 @@ public class AssetTransactionCsvImportService : IBrokerImportService
                     continue;
                 }
 
-                DateTime date = DateTime.Parse(fields[0], CultureInfo.InvariantCulture);
+                DateTime date;
+                if (!DateTime.TryParse(fields[0], CultureInfo.CreateSpecificCulture("ca-ES"), DateTimeStyles.None, out date))
+                {
+                    date = DateTime.Parse(fields[0], CultureInfo.InvariantCulture);
+                }
                 string description = fields[1];
                 string ticker = fields[2];
                 decimal import = decimal.Parse(fields[3], NumberStyles.Any, CultureInfo.InvariantCulture);

--- a/src/MyAccountingApp.Core/Services/BankCsvImportService.cs
+++ b/src/MyAccountingApp.Core/Services/BankCsvImportService.cs
@@ -86,7 +86,11 @@ public class BankCsvImportService : IBrokerImportService
                     continue;
                 }
 
-                DateTime date = DateTime.Parse(fields[0], CultureInfo.InvariantCulture);
+                DateTime date;
+                if (!DateTime.TryParse(fields[0], CultureInfo.CreateSpecificCulture("ca-ES"), DateTimeStyles.None, out date))
+                {
+                    date = DateTime.Parse(fields[0], CultureInfo.InvariantCulture);
+                }
                 string description = fields[1];
                 decimal amount = decimal.Parse(fields[2], NumberStyles.Any, CultureInfo.InvariantCulture);
                 string currency = fields[3];

--- a/src/MyAccountingApp.Web/Models/AnnualSummaryDto.cs
+++ b/src/MyAccountingApp.Web/Models/AnnualSummaryDto.cs
@@ -1,5 +1,17 @@
 namespace MyAccountingApp.Web.Models;
 
+public class MonthlySummaryDto
+{
+    public int Month { get; set; }
+    public decimal Expenses { get; set; }
+    public decimal Income { get; set; }
+    public decimal InvestmentPurchases { get; set; }
+    public decimal InvestmentSales { get; set; }
+    public decimal NetCashFlow { get; set; }
+    public int TransactionCount { get; set; }
+    public int AssetTransactionCount { get; set; }
+}
+
 public class AnnualSummaryDto
 {
     public int Year { get; set; }
@@ -10,4 +22,5 @@ public class AnnualSummaryDto
     public decimal NetCashFlow { get; set; }
     public int TransactionCount { get; set; }
     public int AssetTransactionCount { get; set; }
+    public List<MonthlySummaryDto>? Months { get; set; }
 }

--- a/src/MyAccountingApp.Web/Pages/Summary.razor
+++ b/src/MyAccountingApp.Web/Pages/Summary.razor
@@ -2,6 +2,7 @@
 @page "/summary/{Year:int}"
 @inject HttpClient Http
 @inject NavigationManager Navigation
+@using System.Globalization
 
 <PageTitle>Summary</PageTitle>
 
@@ -32,6 +33,49 @@ else if (Year.HasValue)
             </MudGrid>
         </MudCardContent>
     </MudCard>
+
+    @if (_summary?.Months is { Count: > 0 })
+    {
+        <MudText Typo="Typo.h5" GutterBottom="true" Class="mt-8">Monthly Breakdown</MudText>
+        <MudTable Items="@_summary.Months" Dense="true" Hover="true" Striped="true" Class="mt-4">
+            <ColGroup>
+                <col style="width: 12%" />
+                <col style="width: 16%" />
+                <col style="width: 16%" />
+                <col style="width: 16%" />
+                <col style="width: 16%" />
+                <col style="width: 12%" />
+                <col style="width: 12%" />
+            </ColGroup>
+            <HeaderContent>
+                <MudTh>Month</MudTh>
+                <MudTh><MudText Color="Color.Success">Income</MudText></MudTh>
+                <MudTh><MudText Color="Color.Error">Expenses</MudText></MudTh>
+                <MudTh>Net Cash Flow</MudTh>
+                <MudTh>Purchases</MudTh>
+                <MudTh>Sales</MudTh>
+                <MudTh>Tx</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Month">@GetMonthName(context.Month)</MudTd>
+                <MudTd DataLabel="Income"><MudText Color="Color.Success">@context.Income.ToString("N2") €</MudText></MudTd>
+                <MudTd DataLabel="Expenses"><MudText Color="Color.Error">@context.Expenses.ToString("N2") €</MudText></MudTd>
+                <MudTd DataLabel="Net Cash Flow"><MudText Color="@NetColor(context.NetCashFlow)">@context.NetCashFlow.ToString("N2") €</MudText></MudTd>
+                <MudTd DataLabel="Purchases">@context.InvestmentPurchases.ToString("N2") €</MudTd>
+                <MudTd DataLabel="Sales">@context.InvestmentSales.ToString("N2") €</MudTd>
+                <MudTd DataLabel="Tx">@context.TransactionCount / @context.AssetTransactionCount</MudTd>
+            </RowTemplate>
+            <FooterContent>
+                <MudTd><MudText Typo="Typo.subtitle2">Total</MudText></MudTd>
+                <MudTd><MudText Typo="Typo.subtitle2" Color="Color.Success">@_summary?.Income.ToString("N2") €</MudText></MudTd>
+                <MudTd><MudText Typo="Typo.subtitle2" Color="Color.Error">@_summary?.Expenses.ToString("N2") €</MudText></MudTd>
+                <MudTd><MudText Typo="Typo.subtitle2" Color="@NetCashFlowColor">@_summary?.NetCashFlow.ToString("N2") €</MudText></MudTd>
+                <MudTd><MudText Typo="Typo.subtitle2">@_summary?.InvestmentPurchases.ToString("N2") €</MudText></MudTd>
+                <MudTd><MudText Typo="Typo.subtitle2">@_summary?.InvestmentSales.ToString("N2") €</MudText></MudTd>
+                <MudTd><MudText Typo="Typo.subtitle2">@_summary?.TransactionCount / @_summary?.AssetTransactionCount</MudText></MudTd>
+            </FooterContent>
+        </MudTable>
+    }
 }
 else
 {
@@ -69,8 +113,11 @@ else
 
     private Color NetCashFlowColor => (_summary?.NetCashFlow ?? 0) >= 0 ? Color.Success : Color.Error;
     private Color GetNetColor(decimal net) => net >= 0 ? Color.Success : Color.Error;
+    private static Color NetColor(decimal net) => net >= 0 ? Color.Success : Color.Error;
 
     private void NavigateToYear(int year) => Navigation.NavigateTo($"/summary/{year}");
+
+    private static string GetMonthName(int month) => CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(month);
 
     protected override async Task OnInitializedAsync()
     {

--- a/tests/MyAccountingApp.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -60,6 +60,14 @@ public class AnnualSummaryServiceTests
         Assert.Equal(350m, result.NetCashFlow);
         Assert.Equal(2, result.TransactionCount);
         Assert.Equal(2, result.AssetTransactionCount);
+        Assert.NotEmpty(result.Months);
+        MonthlySummaryDto month = Assert.Single(result.Months);
+        Assert.Equal(6, month.Month);
+        Assert.Equal(500m, month.Expenses);
+        Assert.Equal(1000m, month.Income);
+        Assert.Equal(300m, month.InvestmentPurchases);
+        Assert.Equal(150m, month.InvestmentSales);
+        Assert.Equal(350m, month.NetCashFlow);
     }
 
     [Fact]
@@ -83,6 +91,28 @@ public class AnnualSummaryServiceTests
     }
 
     [Fact]
+    public void GetByYear_ReturnsMultipleMonths()
+    {
+        Transaction[] txs = new Transaction[]
+        {
+            Tx(2024, 3000, TransactionCategory.INCOME, 1),
+            Tx(2024, 1000, TransactionCategory.EXPENSE, 1),
+            Tx(2024, 2000, TransactionCategory.INCOME, 3),
+            Tx(2024, 500, TransactionCategory.EXPENSE, 3),
+        };
+        var svc = CreateService(txs, Array.Empty<AssetTransaction>());
+
+        AnnualSummaryDto? result = svc.GetByYear(2024);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Months.Count);
+        Assert.Equal(1, result.Months[0].Month);
+        Assert.Equal(2000m, result.Months[0].NetCashFlow);
+        Assert.Equal(3, result.Months[1].Month);
+        Assert.Equal(1500m, result.Months[1].NetCashFlow);
+    }
+
+    [Fact]
     public void NetCashFlow_IsCorrect()
     {
         Transaction[] txs = new Transaction[]
@@ -103,11 +133,11 @@ public class AnnualSummaryServiceTests
         Assert.Equal(2800m, result.NetCashFlow);
     }
 
-    private static Transaction Tx(int year, decimal amount, TransactionCategory category = TransactionCategory.INCOME)
+    private static Transaction Tx(int year, decimal amount, TransactionCategory category = TransactionCategory.INCOME, int month = 6)
     {
         return new Transaction(
             Guid.NewGuid(),
-            new DateTime(year, 6, 1),
+            new DateTime(year, month, 1),
             "Test",
             new Money(amount, "EUR"),
             category);


### PR DESCRIPTION
- Add MonthlySummaryDto with monthly income/expenses/purchases/sales/net-cash-flow\n- Group transactions by month in AnnualSummaryService\n- Display monthly breakdown table in Summary.razor with totals footer\n- Fix CSV date parsing: ca-ES culture (dd/MM/yyyy) with InvariantCulture fallback\n\nFixes incorrect month assignment when importing bank CSVs (01/02/2015 was parsed as Jan 2 instead of Feb 1)