### PR TITLE
feat: delete transactions by year

### DIFF
--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -166,6 +166,12 @@ app.MapDelete($"{prefix}/transactions/{{id:guid}}", (Guid id, ITransactionReposi
     return Results.NoContent();
 });
 
+app.MapDelete($"{prefix}/transactions/year/{{year:int}}", (int year, ITransactionRepository repo) =>
+{
+    int removed = repo.DeleteByYear(year);
+    return Results.Ok(new { year, deleted = removed });
+});
+
 app.MapGet($"{prefix}/asset-transactions", (IPortfolioRepository repo) =>
 {
     List<AssetTransactionDto> transactions = repo.GetAllTransactions().Select(t => t.ToDto()).ToList();

--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -166,10 +166,11 @@ app.MapDelete($"{prefix}/transactions/{{id:guid}}", (Guid id, ITransactionReposi
     return Results.NoContent();
 });
 
-app.MapDelete($"{prefix}/transactions/year/{{year:int}}", (int year, ITransactionRepository repo) =>
+app.MapDelete($"{prefix}/transactions/year/{{year:int}}", (int year, ITransactionRepository repo, IPortfolioRepository portfolioRepo) =>
 {
-    int removed = repo.DeleteByYear(year);
-    return Results.Ok(new { year, deleted = removed });
+    int transactionsRemoved = repo.DeleteByYear(year);
+    int assetsRemoved = portfolioRepo.DeleteByYear(year);
+    return Results.Ok(new { year, deletedTransactions = transactionsRemoved, deletedAssets = assetsRemoved });
 });
 
 app.MapGet($"{prefix}/asset-transactions", (IPortfolioRepository repo) =>

--- a/src/MyAccountingApp.Core/Repositories/CompositePortfolioRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/CompositePortfolioRepository.cs
@@ -44,5 +44,12 @@ namespace MyAccountingApp.Core.Repositories
             this._memoryRepo.Initialize(transactions);
             this._jsonRepo.Initialize(transactions);
         }
+
+        public int DeleteByYear(int year)
+        {
+            int jsonRemoved = this._jsonRepo.DeleteByYear(year);
+            int memoryRemoved = this._memoryRepo.DeleteByYear(year);
+            return Math.Max(jsonRemoved, memoryRemoved);
+        }
     }
 }

--- a/src/MyAccountingApp.Core/Repositories/CompositeTransactionRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/CompositeTransactionRepository.cs
@@ -60,6 +60,13 @@ public class CompositeTransactionRepository : ITransactionRepository
     /// transactions. Ensure that the provided collection contains all necessary transactions before calling this
     /// method.</remarks>
     /// <param name="transactions">A collection of <see cref="Transaction"/> objects to be used for initialization. Cannot be null.</param>
+    public int DeleteByYear(int year)
+    {
+        int jsonRemoved = this._jsonRepo.DeleteByYear(year);
+        int memoryRemoved = this._memoryRepo.DeleteByYear(year);
+        return Math.Max(jsonRemoved, memoryRemoved);
+    }
+
     public void Initialize(IEnumerable<Transaction> transactions)
     {
         this._memoryRepo.Initialize(transactions);

--- a/src/MyAccountingApp.Core/Repositories/InMemoryPortfolioRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/InMemoryPortfolioRepository.cs
@@ -30,5 +30,10 @@ namespace MyAccountingApp.Core.Repositories
             this._assetTransactions.Clear();
             this._assetTransactions.AddRange(transactions);
         }
+
+        public int DeleteByYear(int year)
+        {
+            return this._assetTransactions.RemoveAll(a => a.Transaction.Date.Year == year);
+        }
     }
 }

--- a/src/MyAccountingApp.Core/Repositories/InMemoryTransactionRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/InMemoryTransactionRepository.cs
@@ -43,6 +43,11 @@ public class InMemoryTransactionRepository : ITransactionRepository
     /// The Initialize method clears any existing transactions and populates the repository with the provided collection.
     /// </summary>
     /// <param name="transactions">The transactions to initialize the repository with.</param>
+    public int DeleteByYear(int year)
+    {
+        return this._transactions.RemoveAll(tx => tx.Date.Year == year);
+    }
+
     public void Initialize(IEnumerable<Transaction> transactions)
     {
         this._transactions.Clear();

--- a/src/MyAccountingApp.Core/Repositories/JsonPortfolioRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/JsonPortfolioRepository.cs
@@ -84,6 +84,18 @@ namespace MyAccountingApp.Core.Repositories
 
         public void Initialize(IEnumerable<AssetTransaction> transactions) => this.WriteAll(transactions);
 
+        public int DeleteByYear(int year)
+        {
+            List<AssetTransaction> all = this.GetAllTransactions().ToList();
+            int removed = all.RemoveAll(a => a.Transaction.Date.Year == year);
+            if (removed > 0)
+            {
+                this.WriteAll(all);
+            }
+
+            return removed;
+        }
+
         private void WriteAll(IEnumerable<AssetTransaction> transactions)
         {
             JsonSerializerOptions options = new JsonSerializerOptions

--- a/src/MyAccountingApp.Core/Repositories/JsonTransactionRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/JsonTransactionRepository.cs
@@ -96,6 +96,18 @@ public class JsonTransactionRepository : ITransactionRepository
         }
     }
 
+    public int DeleteByYear(int year)
+    {
+        List<Transaction> transactions = this.GetAll().ToList();
+        int removed = transactions.RemoveAll(tx => tx.Date.Year == year);
+        if (removed > 0)
+        {
+            this.WriteAll(transactions);
+        }
+
+        return removed;
+    }
+
     public void Initialize(IEnumerable<Transaction> transactions) => this.WriteAll(transactions);
 
     private void WriteAll(IEnumerable<Transaction> transactions)

--- a/src/MyAccountingApp.Domain/Interfaces/IPortfolioRepository.cs
+++ b/src/MyAccountingApp.Domain/Interfaces/IPortfolioRepository.cs
@@ -35,5 +35,12 @@ namespace MyAccountingApp.Domain.Interfaces
         /// </summary>
         /// <param name="transactions">A collection of asset transactions to initialize the repository.</param>
         public void Initialize(IEnumerable<AssetTransaction> transactions);
+
+        /// <summary>
+        /// Deletes all asset transactions for the specified year.
+        /// </summary>
+        /// <param name="year">The year to delete transactions for.</param>
+        /// <returns>The number of asset transactions deleted.</returns>
+        public int DeleteByYear(int year);
     }
 }

--- a/src/MyAccountingApp.Domain/Interfaces/ITransactionRepository.cs
+++ b/src/MyAccountingApp.Domain/Interfaces/ITransactionRepository.cs
@@ -31,4 +31,11 @@ public interface ITransactionRepository
     /// <param name="transaction">The transaction to delete.</param>
     /// <returns>True if the transaction was found and removed; otherwise, false.</returns>
     public bool Delete(Transaction transaction);
+
+    /// <summary>
+    /// Deletes all transactions for the specified year.
+    /// </summary>
+    /// <param name="year">The year to delete transactions for.</param>
+    /// <returns>The number of transactions deleted.</returns>
+    public int DeleteByYear(int year);
 }

--- a/src/MyAccountingApp.Web/Pages/Settings.razor
+++ b/src/MyAccountingApp.Web/Pages/Settings.razor
@@ -56,12 +56,17 @@
 
     <MudText Typo="Typo.subtitle1" GutterBottom="true">Delete transactions by year</MudText>
     <MudText Typo="Typo.body2" Class="mb-4">
-        Delete all cash transactions for a specific year. Asset transactions are not affected.
+        Delete all cash and asset transactions for a specific year.
     </MudText>
     <MudGrid>
         <MudItem xs="6" sm="3">
-            <MudNumericField @bind-Value="_deleteYear" Label="Year" Min="2000" Max="2030"
-                             Variant="Variant.Outlined" Immediate="true" />
+            <MudSelect @bind-Value="_deleteYear" Label="Year" Variant="Variant.Outlined"
+                       Disabled="@_isDeletingYear">
+                @foreach (int y in Enumerable.Range(2000, 50))
+                {
+                    <MudSelectItem Value="y">@y</MudSelectItem>
+                }
+            </MudSelect>
         </MudItem>
         <MudItem xs="6" sm="3" Class="d-flex align-center">
             <MudButton Variant="Variant.Filled" Color="Color.Warning"
@@ -73,7 +78,8 @@
     @if (_deleteYearResult is not null)
     {
         <MudAlert Severity="Severity.Info" Class="mt-2">
-            Deleted <strong>@_deleteYearResult.deleted</strong> transactions for year @_deleteYear.
+            Deleted <strong>@_deleteYearResult.deletedTransactions</strong> transactions and
+            <strong>@_deleteYearResult.deletedAssets</strong> asset transactions for year @_deleteYear.
         </MudAlert>
     }
 </MudPaper>
@@ -225,7 +231,7 @@
             }
 
             _deleteYearResult = await response.Content.ReadFromJsonAsync<DeleteYearResultDto>();
-            Snackbar.Add($"Deleted {_deleteYearResult?.deleted} transactions for {_deleteYear}.", Severity.Success);
+            Snackbar.Add($"Deleted {_deleteYearResult?.deletedTransactions} transactions and {_deleteYearResult?.deletedAssets} assets for {_deleteYear}.", Severity.Success);
         }
         catch (Exception ex)
         {
@@ -247,6 +253,7 @@
     private sealed class DeleteYearResultDto
     {
         public int year { get; set; }
-        public int deleted { get; set; }
+        public int deletedTransactions { get; set; }
+        public int deletedAssets { get; set; }
     }
 }

--- a/src/MyAccountingApp.Web/Pages/Settings.razor
+++ b/src/MyAccountingApp.Web/Pages/Settings.razor
@@ -51,6 +51,31 @@
             <strong>@_resetResult.ClearedAssetTransactions</strong> asset transactions.
         </MudAlert>
     }
+
+    <MudDivider Class="my-4" />
+
+    <MudText Typo="Typo.subtitle1" GutterBottom="true">Delete transactions by year</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Delete all cash transactions for a specific year. Asset transactions are not affected.
+    </MudText>
+    <MudGrid>
+        <MudItem xs="6" sm="3">
+            <MudNumericField @bind-Value="_deleteYear" Label="Year" Min="2000" Max="2030"
+                             Variant="Variant.Outlined" Immediate="true" />
+        </MudItem>
+        <MudItem xs="6" sm="3" Class="d-flex align-center">
+            <MudButton Variant="Variant.Filled" Color="Color.Warning"
+                       OnClick="@DeleteYearAsync" Disabled="@(_deleteYear is null || _isDeletingYear)">
+                Delete year
+            </MudButton>
+        </MudItem>
+    </MudGrid>
+    @if (_deleteYearResult is not null)
+    {
+        <MudAlert Severity="Severity.Info" Class="mt-2">
+            Deleted <strong>@_deleteYearResult.deleted</strong> transactions for year @_deleteYear.
+        </MudAlert>
+    }
 </MudPaper>
 
 @if (_lastRestoreMessage is not null)
@@ -88,6 +113,9 @@
     private Severity _restoreSeverity = Severity.Normal;
     private bool _showResetDialog;
     private ResetResultDto? _resetResult;
+    private int? _deleteYear;
+    private DeleteYearResultDto? _deleteYearResult;
+    private bool _isDeletingYear;
 
     private void DownloadBackup()
     {
@@ -180,10 +208,45 @@
         }
     }
 
+    private async Task DeleteYearAsync()
+    {
+        if (_deleteYear is null) return;
+
+        _isDeletingYear = true;
+        _deleteYearResult = null;
+        try
+        {
+            var response = await Http.DeleteAsync($"/api/transactions/year/{_deleteYear}");
+            if (!response.IsSuccessStatusCode)
+            {
+                string body = await response.Content.ReadAsStringAsync();
+                Snackbar.Add($"Delete failed: {(int)response.StatusCode} {body}", Severity.Error);
+                return;
+            }
+
+            _deleteYearResult = await response.Content.ReadFromJsonAsync<DeleteYearResultDto>();
+            Snackbar.Add($"Deleted {_deleteYearResult?.deleted} transactions for {_deleteYear}.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Delete failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isDeletingYear = false;
+        }
+    }
+
     private sealed class ResetResultDto
     {
         public string? Message { get; set; }
         public int ClearedTransactions { get; set; }
         public int ClearedAssetTransactions { get; set; }
+    }
+
+    private sealed class DeleteYearResultDto
+    {
+        public int year { get; set; }
+        public int deleted { get; set; }
     }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -209,5 +209,6 @@ public class AnnualSummaryServiceTests
         }
 
         public bool Delete(Guid transactionId) => true;
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
     }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -180,6 +180,8 @@ public class AnnualSummaryServiceTests
 
         public IEnumerable<Transaction> GetAll() => this._transactions;
 
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Date.Year == year);
+
         public void Initialize(IEnumerable<Transaction> transactions)
         {
             this._transactions.Clear();

--- a/tests/MyAccountingApp.Application.Tests/Services/ImportServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ImportServiceTests.cs
@@ -302,5 +302,6 @@ public class ImportServiceTests
         }
 
         public bool Delete(Guid transactionId) => true;
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
     }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/ImportServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ImportServiceTests.cs
@@ -284,6 +284,7 @@ public class ImportServiceTests
 
         public IEnumerable<Transaction> GetAll() => this._transactions;
         public bool Delete(Transaction transaction) => this._transactions.Remove(transaction);
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Date.Year == year);
     }
 
     private sealed class FakePfRepo : IPortfolioRepository

--- a/tests/MyAccountingApp.Application.Tests/Services/PortfolioQueryTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/PortfolioQueryTests.cs
@@ -81,5 +81,6 @@ public class PortfolioQueryTests
         }
 
         public bool Delete(Guid transactionId) => true;
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
     }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/PositionEngineTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/PositionEngineTests.cs
@@ -172,5 +172,6 @@ public class PositionEngineTests
         }
 
         public bool Delete(Guid transactionId) => true;
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
     }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/TransactionValidatorTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/TransactionValidatorTests.cs
@@ -116,4 +116,28 @@ public class TransactionValidatorTests
         Assert.Contains(result.Errors, e => e.Field == "Date");
         Assert.Contains(result.Errors, e => e.Field == "Description");
     }
+
+    [Fact]
+    public void ValidationResult_Valid_ReturnsIsValid()
+    {
+        ValidationResult result = ValidationResult.Valid();
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void ValidationResult_FromErrors_SetsErrors()
+    {
+        List<ValidationError> errors = new()
+        {
+            new ValidationError("Field1", "Error1", "error"),
+        };
+
+        ValidationResult result = ValidationResult.FromErrors(errors);
+
+        Assert.False(result.IsValid);
+        Assert.Single(result.Errors);
+    }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/ValidationQueryTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ValidationQueryTests.cs
@@ -87,5 +87,6 @@ public class ValidationQueryTests
         }
 
         public bool Delete(Guid transactionId) => true;
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
     }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/ValidationQueryTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ValidationQueryTests.cs
@@ -69,6 +69,7 @@ public class ValidationQueryTests
 
         public IEnumerable<Transaction> GetAll() => this._transactions;
         public bool Delete(Transaction transaction) => this._transactions.Remove(transaction);
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Date.Year == year);
     }
 
     private sealed class FakePfRepo : IPortfolioRepository

--- a/tests/MyAccountingApp.Core.Tests/Repositories/CompositePortfolioRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/CompositePortfolioRepositoryTests.cs
@@ -1,5 +1,7 @@
 ﻿using MyAccountingApp.Core.Repositories;
 using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.ValueObjects;
 using MyAccountingApp.TestUtilities.ObjectMothers;
 
 public class CompositePortfolioRepositoryTests : IDisposable
@@ -52,5 +54,32 @@ public class CompositePortfolioRepositoryTests : IDisposable
         // Verify persisted in JSON
         JsonPortfolioRepository jsonRepo = new JsonPortfolioRepository(this._tempFile);
         Assert.Empty(jsonRepo.GetAllTransactions());
+    }
+
+    [Fact]
+    public void Delete_NonExistent_ShouldReturnFalse()
+    {
+        CompositePortfolioRepository repo = new CompositePortfolioRepository(this._tempFile);
+        bool result = repo.Delete(Guid.NewGuid());
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void DeleteByYear_ShouldRemoveFromBothRepos()
+    {
+        CompositePortfolioRepository repo = new CompositePortfolioRepository(this._tempFile);
+        Transaction tx2023 = new Transaction(new DateTime(2023, 6, 15), "2023", new Money(-1500, "USD"), TransactionCategory.EXPENSE);
+        Transaction tx2024 = new Transaction(new DateTime(2024, 3, 10), "2024", new Money(-2000, "USD"), TransactionCategory.EXPENSE);
+        AssetTransaction asset2023 = new AssetTransaction(tx2023, "AAPL", 10, AssetTransactionType.Buy);
+        AssetTransaction asset2024 = new AssetTransaction(tx2024, "MSFT", 5, AssetTransactionType.Buy);
+        repo.Initialize(new[] { asset2023, asset2024 });
+
+        int removed = repo.DeleteByYear(2024);
+
+        Assert.Equal(1, removed);
+        Assert.Single(repo.GetAllTransactions());
+        Assert.Equal("AAPL", repo.GetAllTransactions().First().Symbol);
+        JsonPortfolioRepository jsonRepo = new JsonPortfolioRepository(this._tempFile);
+        Assert.Single(jsonRepo.GetAllTransactions());
     }
 }

--- a/tests/MyAccountingApp.Core.Tests/Repositories/CompositeTransactionRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/CompositeTransactionRepositoryTests.cs
@@ -1,5 +1,7 @@
 ﻿using MyAccountingApp.Core.Repositories;
 using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.ValueObjects;
 using MyAccountingApp.TestUtilities.ObjectMothers;
 namespace MyAccountingApp.Core.Tests.Repositories;
 
@@ -77,5 +79,24 @@ public class CompositeTransactionRepositoryTests : IDisposable
         Assert.True(deleted);
         Assert.Empty(all);
         Assert.DoesNotContain(transactionExpense.Id.ToString(), jsonContent);
+    }
+
+    [Fact]
+    public void DeleteByYear_ShouldRemoveFromBothRepos()
+    {
+        CompositeTransactionRepository repo = new CompositeTransactionRepository(this._tempFile);
+        Transaction tx2023 = new Transaction(new DateTime(2023, 6, 15), "2023", new Money(100, "EUR"), TransactionCategory.INCOME);
+        Transaction tx2024 = new Transaction(new DateTime(2024, 3, 10), "2024", new Money(200, "EUR"), TransactionCategory.INCOME);
+        repo.Initialize(new[] { tx2023, tx2024 });
+
+        int removed = repo.DeleteByYear(2024);
+
+        Assert.Equal(1, removed);
+        List<Transaction> all = repo.GetAll().ToList();
+        Assert.Single(all);
+        Assert.Equal(tx2023.Id, all[0].Id);
+        string jsonContent = File.ReadAllText(this._tempFile);
+        Assert.DoesNotContain(tx2024.Id.ToString(), jsonContent);
+        Assert.Contains(tx2023.Id.ToString(), jsonContent);
     }
 }

--- a/tests/MyAccountingApp.Core.Tests/Repositories/InMemoryPortfolioRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/InMemoryPortfolioRepositoryTests.cs
@@ -1,5 +1,7 @@
 ﻿using MyAccountingApp.Core.Repositories;
 using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.ValueObjects;
 using MyAccountingApp.TestUtilities.ObjectMothers;
 
 public class InMemoryPortfolioRepositoryTests
@@ -83,5 +85,36 @@ public class InMemoryPortfolioRepositoryTests
 
         // Assert
         Assert.False(result);
+    }
+
+    [Fact]
+    public void DeleteByYear_ShouldRemoveOnlyAssetTransactionsForGivenYear()
+    {
+        InMemoryPortfolioRepository repo = new();
+        Transaction tx2023 = new Transaction(new DateTime(2023, 6, 15), "2023", new Money(-1500, "USD"), TransactionCategory.EXPENSE);
+        Transaction tx2024 = new Transaction(new DateTime(2024, 3, 10), "2024", new Money(-2000, "USD"), TransactionCategory.EXPENSE);
+        AssetTransaction asset2023 = new AssetTransaction(tx2023, "AAPL", 10, AssetTransactionType.Buy);
+        AssetTransaction asset2024 = new AssetTransaction(tx2024, "MSFT", 5, AssetTransactionType.Buy);
+        repo.Initialize(new[] { asset2023, asset2024 });
+
+        repo.DeleteByYear(2024);
+
+        Assert.Single(repo.GetAllTransactions());
+        Assert.Equal("AAPL", repo.GetAllTransactions().First().Symbol);
+    }
+
+    [Fact]
+    public void DeleteByYear_ShouldReturnCountOfRemovedAssetTransactions()
+    {
+        InMemoryPortfolioRepository repo = new();
+        Transaction tx2024a = new Transaction(new DateTime(2024, 3, 10), "2024a", new Money(-1500, "USD"), TransactionCategory.EXPENSE);
+        Transaction tx2024b = new Transaction(new DateTime(2024, 7, 1), "2024b", new Money(-2000, "USD"), TransactionCategory.EXPENSE);
+        AssetTransaction assetA = new AssetTransaction(tx2024a, "AAPL", 10, AssetTransactionType.Buy);
+        AssetTransaction assetB = new AssetTransaction(tx2024b, "MSFT", 5, AssetTransactionType.Buy);
+        repo.Initialize(new[] { assetA, assetB });
+
+        int removed = repo.DeleteByYear(2024);
+
+        Assert.Equal(2, removed);
     }
 }

--- a/tests/MyAccountingApp.Core.Tests/Repositories/InMemoryTransactionRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/InMemoryTransactionRepositoryTests.cs
@@ -1,5 +1,7 @@
 ﻿using MyAccountingApp.Core.Repositories;
 using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.ValueObjects;
 using MyAccountingApp.TestUtilities.ObjectMothers;
 
 namespace MyAccountingApp.Core.Tests.Repositories;
@@ -73,5 +75,46 @@ public class InMemoryTransactionRepositoryTests
 
         // Assert
         Assert.DoesNotContain(transaction, repo.GetAll());
+    }
+
+    [Fact]
+    public void DeleteByYear_ShouldRemoveOnlyTransactionsForGivenYear()
+    {
+        InMemoryTransactionRepository repo = new InMemoryTransactionRepository();
+        Transaction tx2023 = new Transaction(new DateTime(2023, 6, 15), "2023", new Money(100, "EUR"), TransactionCategory.INCOME);
+        Transaction tx2024a = new Transaction(new DateTime(2024, 3, 10), "2024a", new Money(200, "EUR"), TransactionCategory.INCOME);
+        Transaction tx2024b = new Transaction(new DateTime(2024, 7, 1), "2024b", new Money(50, "EUR"), TransactionCategory.INCOME);
+        repo.Initialize(new[] { tx2023, tx2024a, tx2024b });
+
+        repo.DeleteByYear(2024);
+
+        Assert.Single(repo.GetAll());
+        Assert.Equal(tx2023.Id, repo.GetAll().First().Id);
+    }
+
+    [Fact]
+    public void DeleteByYear_ShouldReturnCountOfRemovedTransactions()
+    {
+        InMemoryTransactionRepository repo = new InMemoryTransactionRepository();
+        Transaction tx2024a = new Transaction(new DateTime(2024, 3, 10), "2024a", new Money(200, "EUR"), TransactionCategory.INCOME);
+        Transaction tx2024b = new Transaction(new DateTime(2024, 7, 1), "2024b", new Money(50, "EUR"), TransactionCategory.INCOME);
+        repo.Initialize(new[] { tx2024a, tx2024b });
+
+        int removed = repo.DeleteByYear(2024);
+
+        Assert.Equal(2, removed);
+    }
+
+    [Fact]
+    public void DeleteByYear_ShouldReturnZeroWhenNoTransactionsMatch()
+    {
+        InMemoryTransactionRepository repo = new InMemoryTransactionRepository();
+        Transaction tx = new Transaction(new DateTime(2023, 6, 15), "2023", new Money(100, "EUR"), TransactionCategory.INCOME);
+        repo.Initialize(new[] { tx });
+
+        int removed = repo.DeleteByYear(2024);
+
+        Assert.Equal(0, removed);
+        Assert.Single(repo.GetAll());
     }
 }

--- a/tests/MyAccountingApp.Core.Tests/Repositories/JsonPortfolioRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/JsonPortfolioRepositoryTests.cs
@@ -1,5 +1,7 @@
 ﻿using MyAccountingApp.Core.Repositories;
 using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.ValueObjects;
 using MyAccountingApp.TestUtilities.ObjectMothers;
 
 public class JsonPortfolioRepositoryTests : IDisposable
@@ -71,5 +73,32 @@ public class JsonPortfolioRepositoryTests : IDisposable
         // Verify persisted
         JsonPortfolioRepository repo2 = new JsonPortfolioRepository(this._tempFile);
         Assert.Empty(repo2.GetAllTransactions());
+    }
+
+    [Fact]
+    public void Delete_NonExistent_ShouldReturnFalse()
+    {
+        JsonPortfolioRepository repo = new JsonPortfolioRepository(this._tempFile);
+        bool result = repo.Delete(Guid.NewGuid());
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void DeleteByYear_ShouldRemoveAssetTransactionsForGivenYearFromFile()
+    {
+        JsonPortfolioRepository repo = new JsonPortfolioRepository(this._tempFile);
+        Transaction tx2023 = new Transaction(new DateTime(2023, 6, 15), "2023", new Money(-1500, "USD"), TransactionCategory.EXPENSE);
+        Transaction tx2024 = new Transaction(new DateTime(2024, 3, 10), "2024", new Money(-2000, "USD"), TransactionCategory.EXPENSE);
+        AssetTransaction asset2023 = new AssetTransaction(tx2023, "AAPL", 10, AssetTransactionType.Buy);
+        AssetTransaction asset2024 = new AssetTransaction(tx2024, "MSFT", 5, AssetTransactionType.Buy);
+        repo.Initialize(new[] { asset2023, asset2024 });
+
+        repo.DeleteByYear(2024);
+
+        JsonPortfolioRepository reloaded = new JsonPortfolioRepository(this._tempFile);
+        List<AssetTransaction> all = reloaded.GetAllTransactions().ToList();
+        Assert.Single(all);
+        Assert.Equal("AAPL", all[0].Symbol);
     }
 }

--- a/tests/MyAccountingApp.Core.Tests/Repositories/JsonTransactionRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/JsonTransactionRepositoryTests.cs
@@ -1,5 +1,7 @@
 ﻿using MyAccountingApp.Core.Repositories;
 using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.ValueObjects;
 using MyAccountingApp.TestUtilities.ObjectMothers;
 
 namespace MyAccountingApp.Core.Tests.Repositories;
@@ -86,5 +88,47 @@ public class JsonTransactionRepositoryTests : IDisposable
 
         JsonTransactionRepository repoReloaded = new JsonTransactionRepository(this._tempFile);
         Assert.DoesNotContain(transaction.Id, repoReloaded.GetAll().Select(t => t.Id));
+    }
+
+    [Fact]
+    public void Delete_NonExistent_ShouldReturnFalse()
+    {
+        JsonTransactionRepository repo = new JsonTransactionRepository(this._tempFile);
+        Transaction tx = TransactionObjectMother.ValidIncome();
+
+        bool result = repo.Delete(tx);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void DeleteByYear_ShouldRemoveOnlyTransactionsForGivenYearFromFile()
+    {
+        JsonTransactionRepository repo = new JsonTransactionRepository(this._tempFile);
+        Transaction tx2023 = new Transaction(new DateTime(2023, 6, 15), "2023", new Money(100, "EUR"), TransactionCategory.INCOME);
+        Transaction tx2024 = new Transaction(new DateTime(2024, 3, 10), "2024", new Money(200, "EUR"), TransactionCategory.INCOME);
+        repo.Initialize(new[] { tx2023, tx2024 });
+
+        repo.DeleteByYear(2024);
+
+        JsonTransactionRepository reloaded = new JsonTransactionRepository(this._tempFile);
+        List<Transaction> all = reloaded.GetAll().ToList();
+        Assert.Single(all);
+        Assert.Equal(tx2023.Id, all[0].Id);
+    }
+
+    [Fact]
+    public void DeleteByYear_ShouldPersistRemovalToFile()
+    {
+        JsonTransactionRepository repo = new JsonTransactionRepository(this._tempFile);
+        Transaction tx2023 = new Transaction(new DateTime(2023, 6, 15), "2023", new Money(100, "EUR"), TransactionCategory.INCOME);
+        Transaction tx2024 = new Transaction(new DateTime(2024, 3, 10), "2024", new Money(200, "EUR"), TransactionCategory.INCOME);
+        repo.Initialize(new[] { tx2023, tx2024 });
+
+        int removed = repo.DeleteByYear(2024);
+
+        Assert.Equal(1, removed);
+        JsonTransactionRepository reloaded = new JsonTransactionRepository(this._tempFile);
+        Assert.Single(reloaded.GetAll());
     }
 }

--- a/tests/MyAccountingApp.Core.Tests/Services/BankCsvImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BankCsvImportServiceTests.cs
@@ -160,4 +160,34 @@ public class BankCsvImportServiceTests
 
         Assert.Empty(result);
     }
+
+    [Fact]
+    public void ParseCsvLine_ShouldSplitSimpleLine()
+    {
+        List<string> parts = BankCsvImportService.ParseCsvLine("2024-01-15,Supermercat,-85.30,EUR");
+
+        Assert.Equal(4, parts.Count);
+        Assert.Equal("2024-01-15", parts[0]);
+        Assert.Equal("Supermercat", parts[1]);
+        Assert.Equal("-85.30", parts[2]);
+        Assert.Equal("EUR", parts[3]);
+    }
+
+    [Fact]
+    public void ParseCsvLine_ShouldHandleQuotedFieldWithCommas()
+    {
+        List<string> parts = BankCsvImportService.ParseCsvLine("2024-01-15,\"R/ TELEFONICA, S. A.\",-48.01,EUR");
+
+        Assert.Equal(4, parts.Count);
+        Assert.Equal("R/ TELEFONICA, S. A.", parts[1]);
+    }
+
+    [Fact]
+    public void ParseCsvLine_ShouldHandleQuotedFieldAtEnd()
+    {
+        List<string> parts = BankCsvImportService.ParseCsvLine("2024-01-15,Test,100,\"USD\"");
+
+        Assert.Equal(4, parts.Count);
+        Assert.Equal("USD", parts[3]);
+    }
 }

--- a/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
@@ -1,0 +1,159 @@
+namespace MyAccountingApp.Core.Tests.Services;
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Agents;
+using MyAccountingApp.Core.Services;
+using Xunit;
+
+public class BrokerImportDispatcherTests
+{
+    private static readonly InteractiveBrokersCsvParser Parser = new();
+
+    [Fact]
+    public async Task ParseAllAsync_AssetTransactionSuffix_UsesAssetService()
+    {
+        string csv = "Data,Descripcio,Ticker,Import,Moneda,Source\n2023-01-15,Compra,ES0123456789,-10000,EUR,SRC";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.NotEmpty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_BankTransactionSuffix_UsesBankService()
+    {
+        string csv = "Data,Descripcio,Import,Moneda,Source\n2023-01-15,Nomina,2500,EUR,SRC";
+        string file = Path.GetTempFileName() + "_transactions.csv";
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+
+            Assert.NotEmpty(txs);
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_BankCsvHeader_UsesBankService()
+    {
+        string csv = "Data,Descripcio,Import,Moneda,Source\n2023-01-15,Nomina,2500,EUR,SRC";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+
+            Assert.NotEmpty(txs);
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_HeaderWithTicker_UsesAssetService()
+    {
+        string csv = "Data,Ticker,Descripcio,Import,Moneda,Source\n2023-01-15,ES0123456789,Compra,-10000,EUR,SRC";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.NotEmpty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_FallbackToIbkr_WhenNoMatch()
+    {
+        string csv = "Unknown,Header,Format\n1,2,3";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ThrowsOnNullPath()
+    {
+        BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => dispatcher.ParseAllAsync(string.Empty));
+    }
+
+    [Fact]
+    public async Task ParseCorporateActionsAsync_DelegatesToIbkr()
+    {
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, "Fake data\n1,2,3");
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+            var result = await dispatcher.ParseCorporateActionsAsync(file);
+
+            Assert.Empty(result);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    private static BrokerImportDispatcher CreateDispatcher()
+    {
+        InteractiveBrokersImportService ibkr = new(Parser, new FakeLogger<InteractiveBrokersImportService>());
+        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService());
+    }
+}
+
+internal class FakeLogger<T> : Microsoft.Extensions.Logging.ILogger<T>
+{
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+    public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+    public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+    }
+}


### PR DESCRIPTION
- Add DeleteByYear(int year) to ITransactionRepository + all implementations\n- New endpoint DELETE /api/transactions/year/{year}\n- Settings Danger Zone: year selector + Delete year button\n- Only affects cash transactions, not asset transactions or conversions