### PR TITLE
fix: fingerprint off, restore clears assets, summary Transfer/Deposit, delete year confirmation

### DIFF
--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -173,6 +173,13 @@ app.MapDelete($"{prefix}/transactions/year/{{year:int}}", (int year, ITransactio
     return Results.Ok(new { year, deletedTransactions = transactionsRemoved, deletedAssets = assetsRemoved });
 });
 
+app.MapGet($"{prefix}/transactions/year/{{year:int}}/count", (int year, ITransactionRepository repo, IPortfolioRepository portfolioRepo) =>
+{
+    int transactions = repo.GetAll().Count(t => t.Date.Year == year);
+    int assets = portfolioRepo.GetAllTransactions().Count(a => a.Transaction.Date.Year == year);
+    return Results.Ok(new { year, transactions, assets });
+});
+
 app.MapGet($"{prefix}/asset-transactions", (IPortfolioRepository repo) =>
 {
     List<AssetTransactionDto> transactions = repo.GetAllTransactions().Select(t => t.ToDto()).ToList();
@@ -243,6 +250,12 @@ app.MapDelete($"{prefix}/asset-transactions/year/{{year:int}}", (int year, IPort
 {
     int removed = portfolioRepo.DeleteByYear(year);
     return Results.Ok(new { year, deletedAssets = removed });
+});
+
+app.MapGet($"{prefix}/asset-transactions/year/{{year:int}}/count", (int year, IPortfolioRepository portfolioRepo) =>
+{
+    int assets = portfolioRepo.GetAllTransactions().Count(a => a.Transaction.Date.Year == year);
+    return Results.Ok(new { year, assets });
 });
 
 app.MapPost($"{prefix}/import", async (ImportRequest request, IImportService importService) =>
@@ -461,8 +474,7 @@ app.MapPost($"{prefix}/backup", async (HttpRequest request, ITransactionReposito
             return Results.BadRequest(new { error = "Invalid backup file format: 'transactions' array is required" });
 
         txRepo.Initialize(backup.Transactions);
-        if (backup.AssetTransactions is not null)
-            pfRepo.Initialize(backup.AssetTransactions);
+        pfRepo.Initialize(backup.AssetTransactions ?? Array.Empty<AssetTransaction>());
 
         logger.LogInformation("Backup restored: {Count} transactions, {Count2} asset transactions",
             backup.Transactions.Count, backup.AssetTransactions?.Count ?? 0);

--- a/src/MyAccountingApp.Application/DTOs/AnnualSummaryDto.cs
+++ b/src/MyAccountingApp.Application/DTOs/AnnualSummaryDto.cs
@@ -8,7 +8,9 @@ public record MonthlySummaryDto(
     decimal InvestmentSales,
     decimal NetCashFlow,
     int TransactionCount,
-    int AssetTransactionCount);
+    int AssetTransactionCount,
+    decimal Transfers,
+    decimal Deposits);
 
 public record AnnualSummaryDto(
     int Year,
@@ -19,4 +21,6 @@ public record AnnualSummaryDto(
     decimal NetCashFlow,
     int TransactionCount,
     int AssetTransactionCount,
-    List<MonthlySummaryDto> Months);
+    List<MonthlySummaryDto> Months,
+    decimal Transfers,
+    decimal Deposits);

--- a/src/MyAccountingApp.Application/Services/AnnualSummaryService.cs
+++ b/src/MyAccountingApp.Application/Services/AnnualSummaryService.cs
@@ -77,6 +77,14 @@ public class AnnualSummaryService : IAnnualSummaryService
             .Where(t => t.Category == TransactionCategory.INCOME)
             .Sum(t => t.Money.Amount);
 
+        decimal transfers = yearTxs
+            .Where(t => t.Category == TransactionCategory.TRANSFER)
+            .Sum(t => t.Money.Amount);
+
+        decimal deposits = yearTxs
+            .Where(t => t.Category == TransactionCategory.DEPOSIT)
+            .Sum(t => t.Money.Amount);
+
         decimal investmentPurchases = yearAssetTxs
             .Where(a => a.Type == AssetTransactionType.Buy)
             .Sum(a => a.Transaction.Money.Amount);
@@ -98,7 +106,9 @@ public class AnnualSummaryService : IAnnualSummaryService
             Math.Round(netCashFlow, 2),
             yearTxs.Count,
             yearAssetTxs.Count,
-            months);
+            months,
+            Math.Round(transfers, 2),
+            Math.Round(deposits, 2));
     }
 
     private List<MonthlySummaryDto> BuildMonthlySummaries(
@@ -131,6 +141,14 @@ public class AnnualSummaryService : IAnnualSummaryService
                 .Where(t => t.Category == TransactionCategory.INCOME)
                 .Sum(t => t.Money.Amount);
 
+            decimal transfers = monthTxs
+                .Where(t => t.Category == TransactionCategory.TRANSFER)
+                .Sum(t => t.Money.Amount);
+
+            decimal deposits = monthTxs
+                .Where(t => t.Category == TransactionCategory.DEPOSIT)
+                .Sum(t => t.Money.Amount);
+
             decimal investmentPurchases = monthAssetTxs
                 .Where(a => a.Type == AssetTransactionType.Buy)
                 .Sum(a => a.Transaction.Money.Amount);
@@ -149,7 +167,9 @@ public class AnnualSummaryService : IAnnualSummaryService
                 Math.Round(investmentSales, 2),
                 Math.Round(netCashFlow, 2),
                 monthTxs.Count,
-                monthAssetTxs.Count));
+                monthAssetTxs.Count,
+                Math.Round(transfers, 2),
+                Math.Round(deposits, 2)));
         }
 
         return result;

--- a/src/MyAccountingApp.Application/Services/ImportService.cs
+++ b/src/MyAccountingApp.Application/Services/ImportService.cs
@@ -116,34 +116,8 @@ public class ImportService : IImportService
 
         if (pendingTransactions.Count > 0)
         {
-            int dupsSkipped = DeduplicateByFingerprint(pendingTransactions, out List<Domain.Entities.Transaction> deduped);
-
-            if (dupsSkipped > 0)
-            {
-                this._logger.LogInformation("Skipped {Count} duplicate transactions by content fingerprint", dupsSkipped);
-            }
-
             List<Domain.Entities.Transaction> merged = this._transactionRepo.GetAll().ToList();
-            HashSet<TransactionFingerprint> existingFingerprints = new HashSet<TransactionFingerprint>(
-                merged.Select(t => t.GetFingerprint()));
-
-            int skippedAgainstExisting = 0;
-            foreach (Domain.Entities.Transaction tx in deduped)
-            {
-                if (!existingFingerprints.Add(tx.GetFingerprint()))
-                {
-                    skippedAgainstExisting++;
-                    continue;
-                }
-
-                merged.Add(tx);
-            }
-
-            if (skippedAgainstExisting > 0)
-            {
-                this._logger.LogInformation("Skipped {Count} transactions already present in store", skippedAgainstExisting);
-            }
-
+            merged.AddRange(pendingTransactions);
             this._transactionRepo.Initialize(merged);
         }
 

--- a/src/MyAccountingApp.Web/Models/AnnualSummaryDto.cs
+++ b/src/MyAccountingApp.Web/Models/AnnualSummaryDto.cs
@@ -17,6 +17,8 @@ public class MonthlySummaryDto
     public decimal NetCashFlow { get; set; }
     public int TransactionCount { get; set; }
     public int AssetTransactionCount { get; set; }
+    public decimal Transfers { get; set; }
+    public decimal Deposits { get; set; }
 }
 
 public class AnnualSummaryDto
@@ -30,4 +32,6 @@ public class AnnualSummaryDto
     public int TransactionCount { get; set; }
     public int AssetTransactionCount { get; set; }
     public List<MonthlySummaryDto>? Months { get; set; }
+    public decimal Transfers { get; set; }
+    public decimal Deposits { get; set; }
 }

--- a/src/MyAccountingApp.Web/Pages/Settings.razor
+++ b/src/MyAccountingApp.Web/Pages/Settings.razor
@@ -142,6 +142,39 @@
     </DialogActions>
 </MudDialog>
 
+<MudDialog @bind-Visible="_showDeleteYearDialog">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Delete year @_deleteYear?</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText>
+            This will remove <strong>@_deleteYearPreviewTransactions</strong> cash and
+            <strong>@_deleteYearPreviewAssets</strong> asset transactions for year @_deleteYear.
+        </MudText>
+        <MudText Class="mt-2" Typo="Typo.body2">This cannot be undone.</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseDeleteYearDialog">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@ConfirmDeleteYearAsync" Disabled="@_isDeletingYear">Yes, delete @_deleteYear</MudButton>
+    </DialogActions>
+</MudDialog>
+
+<MudDialog @bind-Visible="_showDeleteAssetYearDialog">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Delete asset transactions for @_deleteAssetYear?</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText>
+            This will remove <strong>@_deleteAssetYearPreviewAssets</strong> asset transactions for year @_deleteAssetYear.
+        </MudText>
+        <MudText Class="mt-2" Typo="Typo.body2">This cannot be undone.</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseDeleteAssetYearDialog">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="@ConfirmDeleteAssetYearAsync" Disabled="@_isDeletingAssetYear">Yes, delete @_deleteAssetYear</MudButton>
+    </DialogActions>
+</MudDialog>
+
 @code {
     private bool _isRestoring;
     private bool _isResetting;
@@ -155,6 +188,11 @@
     private int? _deleteAssetYear;
     private DeleteAssetYearResultDto? _deleteAssetYearResult;
     private bool _isDeletingAssetYear;
+    private bool _showDeleteYearDialog;
+    private int _deleteYearPreviewTransactions;
+    private int _deleteYearPreviewAssets;
+    private bool _showDeleteAssetYearDialog;
+    private int _deleteAssetYearPreviewAssets;
 
     private void DownloadBackup()
     {
@@ -255,6 +293,39 @@
         _deleteYearResult = null;
         try
         {
+            var preview = await Http.GetFromJsonAsync<DeleteYearCountDto>($"/api/transactions/year/{_deleteYear}/count");
+            if (preview is null)
+            {
+                Snackbar.Add("Failed to load preview counts.", Severity.Error);
+                return;
+            }
+
+            _deleteYearPreviewTransactions = preview.transactions;
+            _deleteYearPreviewAssets = preview.assets;
+            _showDeleteYearDialog = true;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to load preview: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isDeletingYear = false;
+        }
+    }
+
+    private void CloseDeleteYearDialog()
+    {
+        _showDeleteYearDialog = false;
+    }
+
+    private async Task ConfirmDeleteYearAsync()
+    {
+        if (_deleteYear is null) return;
+
+        _isDeletingYear = true;
+        try
+        {
             var response = await Http.DeleteAsync($"/api/transactions/year/{_deleteYear}");
             if (!response.IsSuccessStatusCode)
             {
@@ -264,6 +335,7 @@
             }
 
             _deleteYearResult = await response.Content.ReadFromJsonAsync<DeleteYearResultDto>();
+            _showDeleteYearDialog = false;
             Snackbar.Add($"Deleted {_deleteYearResult?.deletedTransactions} transactions and {_deleteYearResult?.deletedAssets} assets for {_deleteYear}.", Severity.Success);
         }
         catch (Exception ex)
@@ -296,12 +368,57 @@
         public int deletedAssets { get; set; }
     }
 
+    private sealed class DeleteYearCountDto
+    {
+        public int year { get; set; }
+        public int transactions { get; set; }
+        public int assets { get; set; }
+    }
+
+    private sealed class DeleteAssetYearCountDto
+    {
+        public int year { get; set; }
+        public int assets { get; set; }
+    }
+
     private async Task DeleteAssetYearAsync()
     {
         if (_deleteAssetYear is null) return;
 
         _isDeletingAssetYear = true;
         _deleteAssetYearResult = null;
+        try
+        {
+            var preview = await Http.GetFromJsonAsync<DeleteAssetYearCountDto>($"/api/asset-transactions/year/{_deleteAssetYear}/count");
+            if (preview is null)
+            {
+                Snackbar.Add("Failed to load preview counts.", Severity.Error);
+                return;
+            }
+
+            _deleteAssetYearPreviewAssets = preview.assets;
+            _showDeleteAssetYearDialog = true;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to load preview: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isDeletingAssetYear = false;
+        }
+    }
+
+    private void CloseDeleteAssetYearDialog()
+    {
+        _showDeleteAssetYearDialog = false;
+    }
+
+    private async Task ConfirmDeleteAssetYearAsync()
+    {
+        if (_deleteAssetYear is null) return;
+
+        _isDeletingAssetYear = true;
         try
         {
             var response = await Http.DeleteAsync($"/api/asset-transactions/year/{_deleteAssetYear}");
@@ -313,6 +430,7 @@
             }
 
             _deleteAssetYearResult = await response.Content.ReadFromJsonAsync<DeleteAssetYearResultDto>();
+            _showDeleteAssetYearDialog = false;
             Snackbar.Add($"Deleted {_deleteAssetYearResult?.deletedAssets} asset transactions for {_deleteAssetYear}.", Severity.Success);
         }
         catch (Exception ex)

--- a/src/MyAccountingApp.Web/Pages/Summary.razor
+++ b/src/MyAccountingApp.Web/Pages/Summary.razor
@@ -25,6 +25,8 @@ else if (Year.HasValue)
             <MudGrid>
                 <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Income</MudText><MudText Typo="Typo.h5" Color="Color.Success">@_summary?.Income.ToString("N2") €</MudText></MudItem>
                 <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Expenses</MudText><MudText Typo="Typo.h5" Color="Color.Error">@_summary?.Expenses.ToString("N2") €</MudText></MudItem>
+                <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Transfers</MudText><MudText Typo="Typo.h5">@_summary?.Transfers.ToString("N2") €</MudText></MudItem>
+                <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Deposits</MudText><MudText Typo="Typo.h5" Color="Color.Success">@_summary?.Deposits.ToString("N2") €</MudText></MudItem>
                 <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Net Cash Flow</MudText><MudText Typo="Typo.h5" Color="@NetCashFlowColor">@_summary?.NetCashFlow.ToString("N2") €</MudText></MudItem>
                 <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Transactions</MudText><MudText Typo="Typo.h5">@_summary?.TransactionCount</MudText></MudItem>
                 <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Investment Purchases</MudText><MudText Typo="Typo.h5">@_summary?.InvestmentPurchases.ToString("N2") €</MudText></MudItem>
@@ -39,18 +41,22 @@ else if (Year.HasValue)
         <MudText Typo="Typo.h5" GutterBottom="true" Class="mt-8">Monthly Breakdown</MudText>
         <MudTable Items="@_summary.Months" Dense="true" Hover="true" Striped="true" Class="mt-4">
             <ColGroup>
-                <col style="width: 12%" />
-                <col style="width: 16%" />
-                <col style="width: 16%" />
-                <col style="width: 16%" />
-                <col style="width: 16%" />
-                <col style="width: 12%" />
-                <col style="width: 12%" />
+                <col style="width: 10%" />
+                <col style="width: 13%" />
+                <col style="width: 13%" />
+                <col style="width: 11%" />
+                <col style="width: 11%" />
+                <col style="width: 13%" />
+                <col style="width: 13%" />
+                <col style="width: 8%" />
+                <col style="width: 8%" />
             </ColGroup>
             <HeaderContent>
                 <MudTh>Month</MudTh>
                 <MudTh><MudText Color="Color.Success">Income</MudText></MudTh>
                 <MudTh><MudText Color="Color.Error">Expenses</MudText></MudTh>
+                <MudTh>Transfers</MudTh>
+                <MudTh>Deposits</MudTh>
                 <MudTh>Net Cash Flow</MudTh>
                 <MudTh>Purchases</MudTh>
                 <MudTh>Sales</MudTh>
@@ -60,6 +66,8 @@ else if (Year.HasValue)
                 <MudTd DataLabel="Month">@GetMonthName(context.Month)</MudTd>
                 <MudTd DataLabel="Income"><MudText Color="Color.Success">@context.Income.ToString("N2") €</MudText></MudTd>
                 <MudTd DataLabel="Expenses"><MudText Color="Color.Error">@context.Expenses.ToString("N2") €</MudText></MudTd>
+                <MudTd DataLabel="Transfers">@context.Transfers.ToString("N2") €</MudTd>
+                <MudTd DataLabel="Deposits">@context.Deposits.ToString("N2") €</MudTd>
                 <MudTd DataLabel="Net Cash Flow"><MudText Color="@NetColor(context.NetCashFlow)">@context.NetCashFlow.ToString("N2") €</MudText></MudTd>
                 <MudTd DataLabel="Purchases">@context.InvestmentPurchases.ToString("N2") €</MudTd>
                 <MudTd DataLabel="Sales">@context.InvestmentSales.ToString("N2") €</MudTd>
@@ -69,6 +77,8 @@ else if (Year.HasValue)
                 <MudTd><MudText Typo="Typo.subtitle2">Total</MudText></MudTd>
                 <MudTd><MudText Typo="Typo.subtitle2" Color="Color.Success">@_summary?.Income.ToString("N2") €</MudText></MudTd>
                 <MudTd><MudText Typo="Typo.subtitle2" Color="Color.Error">@_summary?.Expenses.ToString("N2") €</MudText></MudTd>
+                <MudTd><MudText Typo="Typo.subtitle2">@_summary?.Transfers.ToString("N2") €</MudText></MudTd>
+                <MudTd><MudText Typo="Typo.subtitle2" Color="Color.Success">@_summary?.Deposits.ToString("N2") €</MudText></MudTd>
                 <MudTd><MudText Typo="Typo.subtitle2" Color="@NetCashFlowColor">@_summary?.NetCashFlow.ToString("N2") €</MudText></MudTd>
                 <MudTd><MudText Typo="Typo.subtitle2">@_summary?.InvestmentPurchases.ToString("N2") €</MudText></MudTd>
                 <MudTd><MudText Typo="Typo.subtitle2">@_summary?.InvestmentSales.ToString("N2") €</MudText></MudTd>

--- a/tests/MyAccountingApp.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -60,6 +60,8 @@ public class AnnualSummaryServiceTests
         Assert.Equal(350m, result.NetCashFlow);
         Assert.Equal(2, result.TransactionCount);
         Assert.Equal(2, result.AssetTransactionCount);
+        Assert.Equal(0, result.Transfers);
+        Assert.Equal(0, result.Deposits);
         Assert.NotEmpty(result.Months);
         MonthlySummaryDto month = Assert.Single(result.Months);
         Assert.Equal(6, month.Month);
@@ -68,6 +70,8 @@ public class AnnualSummaryServiceTests
         Assert.Equal(300m, month.InvestmentPurchases);
         Assert.Equal(150m, month.InvestmentSales);
         Assert.Equal(350m, month.NetCashFlow);
+        Assert.Equal(0, month.Transfers);
+        Assert.Equal(0, month.Deposits);
     }
 
     [Fact]
@@ -131,6 +135,32 @@ public class AnnualSummaryServiceTests
 
         Assert.NotNull(result);
         Assert.Equal(2800m, result.NetCashFlow);
+    }
+
+    [Fact]
+    public void GetByYear_IncludesTransfersAndDeposits()
+    {
+        Transaction[] txs = new Transaction[]
+        {
+            Tx(2024, 3000, TransactionCategory.INCOME),
+            Tx(2024, 1000, TransactionCategory.EXPENSE),
+            Tx(2024, 500, TransactionCategory.TRANSFER),
+            Tx(2024, 200, TransactionCategory.DEPOSIT),
+        };
+        var svc = CreateService(txs, Array.Empty<AssetTransaction>());
+
+        AnnualSummaryDto? result = svc.GetByYear(2024);
+
+        Assert.NotNull(result);
+        Assert.Equal(3000m, result.Income);
+        Assert.Equal(1000m, result.Expenses);
+        Assert.Equal(500m, result.Transfers);
+        Assert.Equal(200m, result.Deposits);
+        Assert.Equal(2000m, result.NetCashFlow);
+
+        MonthlySummaryDto month = Assert.Single(result.Months);
+        Assert.Equal(500m, month.Transfers);
+        Assert.Equal(200m, month.Deposits);
     }
 
     private static Transaction Tx(int year, decimal amount, TransactionCategory category = TransactionCategory.INCOME, int month = 6)


### PR DESCRIPTION
## Changes

1. **Fingerprint off per defecte** — ImportService ja no fa dedup per fingerprint; totes les transactions shi afegeixen sense filtrar
2. **Restore atòmic** — pfRepo.Initialize sempre es crida (buidant si el backup no te assets)
3. **Summary amb Transfer/Deposit** — DTOs, service i UI mostren Transfers i Deposits separats (no dins Income)
4. **Count endpoints** — GET /api/transactions/year/{year}/count i GET /api/asset-transactions/year/{year}/count
5. **Confirmació delete year** — Dialog amb recomptes (X cash + Y assets) abans desesborrar, tant per transactions com per asset transactions

Closes revisio items: fingerprint, restore, summary, delete confirmation