### PR TITLE
feat: add DeGiro CSV import service for asset transactions and dividends

### DIFF
--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -63,6 +63,7 @@ builder.Services.AddSingleton<InteractiveBrokersImportService>(sp =>
 });
 builder.Services.AddSingleton<BankCsvImportService>();
 builder.Services.AddSingleton<AssetTransactionCsvImportService>();
+builder.Services.AddSingleton<DegiroImportService>();
 builder.Services.AddSingleton<IBrokerImportService, BrokerImportDispatcher>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -474,7 +475,7 @@ app.MapPost($"{prefix}/backup", async (HttpRequest request, ITransactionReposito
             return Results.BadRequest(new { error = "Invalid backup file format: 'transactions' array is required" });
 
         txRepo.Initialize(backup.Transactions);
-        pfRepo.Initialize(backup.AssetTransactions ?? Array.Empty<AssetTransaction>());
+        pfRepo.Initialize(backup.AssetTransactions ?? []);
 
         logger.LogInformation("Backup restored: {Count} transactions, {Count2} asset transactions",
             backup.Transactions.Count, backup.AssetTransactions?.Count ?? 0);

--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -64,6 +64,7 @@ builder.Services.AddSingleton<InteractiveBrokersImportService>(sp =>
 builder.Services.AddSingleton<BankCsvImportService>();
 builder.Services.AddSingleton<AssetTransactionCsvImportService>();
 builder.Services.AddSingleton<DegiroImportService>();
+builder.Services.AddSingleton<DegiroTransactionImportService>();
 builder.Services.AddSingleton<IBrokerImportService, BrokerImportDispatcher>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -487,6 +487,42 @@ app.MapPost($"{prefix}/backup", async (HttpRequest request, ITransactionReposito
     }
 });
 
+// Yahoo Finance symbol lookup by company name
+app.MapGet($"{prefix}/symbol-lookup", async (string name) =>
+{
+    if (string.IsNullOrWhiteSpace(name))
+        return Results.BadRequest(new { error = "Company name is required" });
+
+    using HttpClient client = new();
+    string url = $"https://query1.finance.yahoo.com/v1/finance/search?q={Uri.EscapeDataString(name)}&quotesCount=10";
+
+    try
+    {
+        string json = await client.GetStringAsync(url);
+        using JsonDocument doc = JsonDocument.Parse(json);
+        List<object> results = new();
+
+        foreach (JsonElement quote in doc.RootElement.GetProperty("quotes").EnumerateArray())
+        {
+            string? symbol = quote.TryGetProperty("symbol", out JsonElement s) ? s.GetString() : null;
+            string? longName = quote.TryGetProperty("longname", out JsonElement ln) ? ln.GetString() : null;
+            string? exchange = quote.TryGetProperty("exchange", out JsonElement ex) ? ex.GetString() : null;
+            string? quoteType = quote.TryGetProperty("quoteType", out JsonElement qt) ? qt.GetString() : null;
+
+            if (symbol is not null)
+            {
+                results.Add(new { symbol, name = longName ?? symbol, exchange = exchange ?? string.Empty, type = quoteType ?? string.Empty });
+            }
+        }
+
+        return Results.Ok(results);
+    }
+    catch (Exception ex)
+    {
+        return Results.Ok(new List<object>());
+    }
+});
+
 app.MapFallbackToFile("index.html");
 
 app.Run();

--- a/src/MyAccountingApp.Core/Services/BrokerImportDispatcher.cs
+++ b/src/MyAccountingApp.Core/Services/BrokerImportDispatcher.cs
@@ -14,22 +14,26 @@ public class BrokerImportDispatcher : IBrokerImportService
 {
     private const string BankCsvHeader = "Data,Descripcio,Import,Moneda,Source";
     private const string DegiroCsvHeaderPrefix = "Fecha,Hora,Fecha valor";
+    private const string DegiroTransactionCsvHeaderPrefix = "Fecha,Hora,Producto,ISIN,Bolsa";
 
     private readonly InteractiveBrokersImportService ibkrService;
     private readonly BankCsvImportService bankService;
     private readonly AssetTransactionCsvImportService assetService;
     private readonly DegiroImportService degiroService;
+    private readonly DegiroTransactionImportService degiroTransactionService;
 
     public BrokerImportDispatcher(
         InteractiveBrokersImportService ibkrService,
         BankCsvImportService bankService,
         AssetTransactionCsvImportService assetService,
-        DegiroImportService degiroService)
+        DegiroImportService degiroService,
+        DegiroTransactionImportService degiroTransactionService)
     {
         this.ibkrService = ibkrService ?? throw new ArgumentNullException(nameof(ibkrService));
         this.bankService = bankService ?? throw new ArgumentNullException(nameof(bankService));
         this.assetService = assetService ?? throw new ArgumentNullException(nameof(assetService));
         this.degiroService = degiroService ?? throw new ArgumentNullException(nameof(degiroService));
+        this.degiroTransactionService = degiroTransactionService ?? throw new ArgumentNullException(nameof(degiroTransactionService));
     }
 
     public Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions)> ParseAllAsync(
@@ -87,6 +91,11 @@ public class BrokerImportDispatcher : IBrokerImportService
             if (header.Contains("Ticker", StringComparison.OrdinalIgnoreCase))
             {
                 return this.assetService;
+            }
+
+            if (header.StartsWith(DegiroTransactionCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return this.degiroTransactionService;
             }
 
             if (header.StartsWith(DegiroCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))

--- a/src/MyAccountingApp.Core/Services/BrokerImportDispatcher.cs
+++ b/src/MyAccountingApp.Core/Services/BrokerImportDispatcher.cs
@@ -13,19 +13,23 @@ using MyAccountingApp.Domain.Interfaces;
 public class BrokerImportDispatcher : IBrokerImportService
 {
     private const string BankCsvHeader = "Data,Descripcio,Import,Moneda,Source";
+    private const string DegiroCsvHeaderPrefix = "Fecha,Hora,Fecha valor";
 
     private readonly InteractiveBrokersImportService ibkrService;
     private readonly BankCsvImportService bankService;
     private readonly AssetTransactionCsvImportService assetService;
+    private readonly DegiroImportService degiroService;
 
     public BrokerImportDispatcher(
         InteractiveBrokersImportService ibkrService,
         BankCsvImportService bankService,
-        AssetTransactionCsvImportService assetService)
+        AssetTransactionCsvImportService assetService,
+        DegiroImportService degiroService)
     {
         this.ibkrService = ibkrService ?? throw new ArgumentNullException(nameof(ibkrService));
         this.bankService = bankService ?? throw new ArgumentNullException(nameof(bankService));
         this.assetService = assetService ?? throw new ArgumentNullException(nameof(assetService));
+        this.degiroService = degiroService ?? throw new ArgumentNullException(nameof(degiroService));
     }
 
     public Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions)> ParseAllAsync(
@@ -83,6 +87,11 @@ public class BrokerImportDispatcher : IBrokerImportService
             if (header.Contains("Ticker", StringComparison.OrdinalIgnoreCase))
             {
                 return this.assetService;
+            }
+
+            if (header.StartsWith(DegiroCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return this.degiroService;
             }
         }
 

--- a/src/MyAccountingApp.Core/Services/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroImportService.cs
@@ -193,19 +193,34 @@ public partial class DegiroImportService : IBrokerImportService
     private static Transaction? CreateCashTransaction(
         DateTime date, string description, decimal amount, string currency)
     {
-        TransactionCategory category = ClassifyDescription(description, amount);
-        if (category == TransactionCategory.DEPOSIT)
+        TransactionCategory? category = ClassifyDescription(description, amount);
+        if (category is null)
         {
             return null;
         }
 
         Money money = new Money(Math.Abs(amount), currency);
-        return new Transaction(date, description, money, category);
+        return new Transaction(date, description, money, category.Value);
     }
 
-    private static TransactionCategory ClassifyDescription(string description, decimal amount)
+    private static TransactionCategory? ClassifyDescription(string description, decimal amount)
     {
         string upper = description.ToUpperInvariant();
+
+        if (upper.Contains("CASH SWEEP") || upper.Contains("CASH SWEEP TRANSFER"))
+        {
+            return null;
+        }
+
+        if (upper.Contains("TRANSFERIR") && upper.Contains("CUENTA DE EFECTIVO"))
+        {
+            return null;
+        }
+
+        if (upper.Contains("CAMBIO DE DIVISA") || upper == "FX")
+        {
+            return null;
+        }
 
         if (upper.Contains("DIVIDENDO") || upper.Contains("DIVIDEND"))
         {
@@ -242,22 +257,12 @@ public partial class DegiroImportService : IBrokerImportService
             return TransactionCategory.EXPENSE;
         }
 
-        if (upper.Contains("CASH SWEEP") || upper.Contains("TRANSFERIR") || upper.Contains("TRANSFER"))
-        {
-            return TransactionCategory.DEPOSIT;
-        }
-
-        if (upper.Contains("DEPOSIT") || upper.Contains("WITHDRAWAL"))
-        {
-            return TransactionCategory.DEPOSIT;
-        }
-
         if (upper.Contains("FLATEX"))
         {
             return TransactionCategory.DEPOSIT;
         }
 
-        if (upper.Contains("CAMBIO DE DIVISA") || upper.Contains("FX") || upper.Contains("EXCHANGE"))
+        if (upper.Contains("DEPOSIT"))
         {
             return TransactionCategory.DEPOSIT;
         }

--- a/src/MyAccountingApp.Core/Services/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroImportService.cs
@@ -223,6 +223,11 @@ public partial class DegiroImportService : IBrokerImportService
             return null;
         }
 
+        if (upper == "INGRESO")
+        {
+            return TransactionCategory.DEPOSIT;
+        }
+
         if (upper.Contains("DIVIDENDO") || upper.Contains("DIVIDEND"))
         {
             return amount >= 0 ? TransactionCategory.INCOME : TransactionCategory.EXPENSE;

--- a/src/MyAccountingApp.Core/Services/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroImportService.cs
@@ -258,9 +258,14 @@ public partial class DegiroImportService : IBrokerImportService
 
         if (upper.Contains("FLATEX") || upper.Contains("DEPOSIT"))
         {
-            if (upper.Contains("WITHDRAWAL") || upper.Contains("PROCESSED"))
+            if (upper.Contains("PROCESSED"))
             {
                 return null;
+            }
+
+            if (upper.Contains("WITHDRAWAL"))
+            {
+                return TransactionCategory.TRANSFER;
             }
 
             return TransactionCategory.DEPOSIT;

--- a/src/MyAccountingApp.Core/Services/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroImportService.cs
@@ -41,6 +41,7 @@ public partial class DegiroImportService : IBrokerImportService
                 }
 
                 DateTime date = ParseDate(fields[0]);
+                string producto = fields[3];
                 string description = fields[5];
                 string isin = fields[4];
                 string currency = NormalizeCurrency(fields[7], fields[9]);
@@ -53,7 +54,7 @@ public partial class DegiroImportService : IBrokerImportService
 
                 if (IsBuySell(description))
                 {
-                    var (assetTx, cashTx) = CreateAssetTransaction(date, description, isin, amount, currency);
+                    var (assetTx, cashTx) = CreateAssetTransaction(date, description, isin, producto, amount, currency);
                     assetTransactions.Add(assetTx);
                     if (cashTx is not null)
                     {
@@ -141,15 +142,48 @@ public partial class DegiroImportService : IBrokerImportService
     [GeneratedRegex(@"^(?:Compra|Venta)\s+(\d+)\s", RegexOptions.IgnoreCase, 1000)]
     private static partial Regex QuantityPattern();
 
+    private static string ExtractSymbol(string producto, string isin)
+    {
+        if (string.IsNullOrWhiteSpace(producto))
+        {
+            return string.IsNullOrWhiteSpace(isin) ? "UNKNOWN" : isin;
+        }
+
+        string trimmed = producto.TrimStart();
+
+        if (trimmed.StartsWith("ADR ", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("ADR/GDR ", StringComparison.OrdinalIgnoreCase))
+        {
+            int spaceIdx = trimmed.IndexOf(' ');
+            if (spaceIdx > 0)
+            {
+                string rest = trimmed[(spaceIdx + 1)..].TrimStart();
+                if (rest.StartsWith("ON ", StringComparison.OrdinalIgnoreCase))
+                {
+                    rest = rest[3..].TrimStart();
+                }
+
+                if (rest.Length > 0)
+                {
+                    int nextSpace = rest.IndexOf(' ');
+                    return nextSpace > 0 ? rest[..nextSpace].ToUpperInvariant() : rest.ToUpperInvariant();
+                }
+            }
+        }
+
+        int firstSpace = trimmed.IndexOf(' ');
+        return firstSpace > 0 ? trimmed[..firstSpace].ToUpperInvariant() : trimmed.ToUpperInvariant();
+    }
+
     private static (AssetTransaction, Transaction?) CreateAssetTransaction(
-        DateTime date, string description, string isin, decimal amount, string currency)
+        DateTime date, string description, string isin, string producto, decimal amount, string currency)
     {
         bool isBuy = description.StartsWith("Compra ", StringComparison.OrdinalIgnoreCase);
         int quantity = ExtractQuantity(description);
         AssetTransactionType type = isBuy ? AssetTransactionType.Buy : AssetTransactionType.Sell;
         TransactionCategory category = isBuy ? TransactionCategory.EXPENSE : TransactionCategory.INCOME;
 
-        string symbol = string.IsNullOrWhiteSpace(isin) ? "UNKNOWN" : isin;
+        string symbol = ExtractSymbol(producto, isin);
         Money money = new Money(Math.Abs(amount), currency);
         Transaction transaction = new Transaction(date, description, money, category);
         AssetTransaction assetTx = new AssetTransaction(transaction, symbol, quantity, type);

--- a/src/MyAccountingApp.Core/Services/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroImportService.cs
@@ -157,7 +157,8 @@ public partial class DegiroImportService : IBrokerImportService
             int spaceIdx = trimmed.IndexOf(' ');
             if (spaceIdx > 0)
             {
-                string rest = trimmed[(spaceIdx + 1)..].TrimStart();
+                                int afterPrefix = spaceIdx + 1;
+                string rest = trimmed[afterPrefix..].TrimStart();
                 if (rest.StartsWith("ON ", StringComparison.OrdinalIgnoreCase))
                 {
                     rest = rest[3..].TrimStart();

--- a/src/MyAccountingApp.Core/Services/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroImportService.cs
@@ -54,20 +54,13 @@ public partial class DegiroImportService : IBrokerImportService
 
                 if (IsBuySell(description))
                 {
-                    var (assetTx, cashTx) = CreateAssetTransaction(date, description, isin, producto, amount, currency);
-                    assetTransactions.Add(assetTx);
-                    if (cashTx is not null)
-                    {
-                        transactions.Add(cashTx);
-                    }
+                    continue;
                 }
-                else
+
+                Transaction? tx = CreateCashTransaction(date, description, amount, currency);
+                if (tx is not null)
                 {
-                    Transaction? tx = CreateCashTransaction(date, description, amount, currency);
-                    if (tx is not null)
-                    {
-                        transactions.Add(tx);
-                    }
+                    transactions.Add(tx);
                 }
             }
             catch

--- a/src/MyAccountingApp.Core/Services/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroImportService.cs
@@ -1,0 +1,187 @@
+namespace MyAccountingApp.Core.Services;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+public partial class DegiroImportService : IBrokerImportService
+{
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions)> ParseAllAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        string[] lines = await File.ReadAllLinesAsync(filePath, cancellationToken);
+        List<Transaction> transactions = new();
+        List<AssetTransaction> assetTransactions = new();
+
+        foreach (string line in lines.Skip(1))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            try
+            {
+                List<string> fields = BankCsvImportService.ParseCsvLine(line);
+                if (fields.Count < 12)
+                    continue;
+
+                DateTime date = ParseDate(fields[0]);
+                string description = fields[5];
+                string isin = fields[4];
+                string currency = NormalizeCurrency(fields[7], fields[9]);
+                decimal amount = ParseEuropeanDecimal(fields[8]);
+
+                if (string.IsNullOrWhiteSpace(description) || amount == 0)
+                    continue;
+
+                if (IsBuySell(description))
+                {
+                    var (assetTx, cashTx) = CreateAssetTransaction(date, description, isin, amount, currency);
+                    assetTransactions.Add(assetTx);
+                    if (cashTx is not null)
+                        transactions.Add(cashTx);
+                }
+                else
+                {
+                    Transaction? tx = CreateCashTransaction(date, description, amount, currency);
+                    if (tx is not null)
+                        transactions.Add(tx);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        return (transactions, assetTransactions);
+    }
+
+    public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Enumerable.Empty<AssetTransaction>());
+    }
+
+    private static DateTime ParseDate(string value)
+    {
+        if (DateTime.TryParseExact(value, "dd-MM-yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date))
+            return date;
+        if (DateTime.TryParse(value, CultureInfo.CreateSpecificCulture("ca-ES"), DateTimeStyles.None, out date))
+            return date;
+        return DateTime.Parse(value, CultureInfo.InvariantCulture);
+    }
+
+    private static decimal ParseEuropeanDecimal(string value)
+    {
+        string cleaned = value.Replace(".", "").Replace(",", ".");
+        return decimal.Parse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture);
+    }
+
+    private static string NormalizeCurrency(string variationCurrency, string balanceCurrency)
+    {
+        string c = variationCurrency;
+        if (string.IsNullOrWhiteSpace(c) || c.Length != 3 || c == "---")
+            c = balanceCurrency;
+        if (string.IsNullOrWhiteSpace(c) || c.Length != 3)
+            c = "EUR";
+        return c.ToUpperInvariant();
+    }
+
+    private static bool IsBuySell(string description)
+    {
+        return description.StartsWith("Compra ", StringComparison.OrdinalIgnoreCase)
+            || description.StartsWith("Venta ", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int ExtractQuantity(string description)
+    {
+        Match m = QuantityPattern().Match(description);
+        if (m.Success && int.TryParse(m.Groups[1].Value, out int qty))
+            return qty;
+        return 1;
+    }
+
+    [GeneratedRegex(@"^(?:Compra|Venta)\s+(\d+)\s", RegexOptions.IgnoreCase, 1000)]
+    private static partial Regex QuantityPattern();
+
+    private static (AssetTransaction, Transaction?) CreateAssetTransaction(
+        DateTime date, string description, string isin, decimal amount, string currency)
+    {
+        bool isBuy = description.StartsWith("Compra ", StringComparison.OrdinalIgnoreCase);
+        int quantity = ExtractQuantity(description);
+        AssetTransactionType type = isBuy ? AssetTransactionType.Buy : AssetTransactionType.Sell;
+        TransactionCategory category = isBuy ? TransactionCategory.EXPENSE : TransactionCategory.INCOME;
+
+        string symbol = string.IsNullOrWhiteSpace(isin) ? "UNKNOWN" : isin;
+        Money money = new Money(Math.Abs(amount), currency);
+        Transaction transaction = new Transaction(date, description, money, category);
+        AssetTransaction assetTx = new AssetTransaction(transaction, symbol, quantity, type);
+        return (assetTx, null);
+    }
+
+    private static Transaction? CreateCashTransaction(
+        DateTime date, string description, decimal amount, string currency)
+    {
+        TransactionCategory category = ClassifyDescription(description, amount);
+        if (category == TransactionCategory.DEPOSIT)
+            return null;
+
+        Money money = new Money(Math.Abs(amount), currency);
+        return new Transaction(date, description, money, category);
+    }
+
+    private static TransactionCategory ClassifyDescription(string description, decimal amount)
+    {
+        string upper = description.ToUpperInvariant();
+
+        if (upper.Contains("DIVIDENDO") || upper.Contains("DIVIDEND"))
+            return amount >= 0 ? TransactionCategory.INCOME : TransactionCategory.EXPENSE;
+
+        if (upper.Contains("RETENCI") || upper.Contains("WITHHOLDING"))
+            return TransactionCategory.EXPENSE;
+
+        if (upper.Contains("COSTES") || upper.Contains("COST") || upper.Contains("COMISI"))
+            return TransactionCategory.EXPENSE;
+
+        if (upper.Contains("TAX") || upper.Contains("IMPUESTO"))
+            return TransactionCategory.EXPENSE;
+
+        if (upper.Contains("INTEREST") || upper.Contains("INTERES"))
+            return amount >= 0 ? TransactionCategory.INCOME : TransactionCategory.EXPENSE;
+
+        if (upper.Contains("PRESTAMO") || upper.Contains("LENDING"))
+            return TransactionCategory.INCOME;
+
+        if (upper.Contains("PASS-THROUGH") || upper.Contains("PASS THROUGH") || upper.Contains("PASSTHROUGH"))
+            return TransactionCategory.EXPENSE;
+
+        if (upper.Contains("CASH SWEEP") || upper.Contains("TRANSFERIR") || upper.Contains("TRANSFER"))
+            return TransactionCategory.DEPOSIT;
+
+        if (upper.Contains("DEPOSIT") || upper.Contains("WITHDRAWAL"))
+            return TransactionCategory.DEPOSIT;
+
+        if (upper.Contains("FLATEX"))
+            return TransactionCategory.DEPOSIT;
+
+        if (upper.Contains("CAMBIO DE DIVISA") || upper.Contains("FX") || upper.Contains("EXCHANGE"))
+            return TransactionCategory.DEPOSIT;
+
+        if (upper.Contains("PROCESSED"))
+            return TransactionCategory.DEPOSIT;
+
+        return amount >= 0 ? TransactionCategory.INCOME : TransactionCategory.EXPENSE;
+    }
+}

--- a/src/MyAccountingApp.Core/Services/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroImportService.cs
@@ -28,13 +28,17 @@ public partial class DegiroImportService : IBrokerImportService
         foreach (string line in lines.Skip(1))
         {
             if (string.IsNullOrWhiteSpace(line))
+            {
                 continue;
+            }
 
             try
             {
                 List<string> fields = BankCsvImportService.ParseCsvLine(line);
                 if (fields.Count < 12)
+                {
                     continue;
+                }
 
                 DateTime date = ParseDate(fields[0]);
                 string description = fields[5];
@@ -43,20 +47,26 @@ public partial class DegiroImportService : IBrokerImportService
                 decimal amount = ParseEuropeanDecimal(fields[8]);
 
                 if (string.IsNullOrWhiteSpace(description) || amount == 0)
+                {
                     continue;
+                }
 
                 if (IsBuySell(description))
                 {
                     var (assetTx, cashTx) = CreateAssetTransaction(date, description, isin, amount, currency);
                     assetTransactions.Add(assetTx);
                     if (cashTx is not null)
+                    {
                         transactions.Add(cashTx);
+                    }
                 }
                 else
                 {
                     Transaction? tx = CreateCashTransaction(date, description, amount, currency);
                     if (tx is not null)
+                    {
                         transactions.Add(tx);
+                    }
                 }
             }
             catch
@@ -77,15 +87,21 @@ public partial class DegiroImportService : IBrokerImportService
     private static DateTime ParseDate(string value)
     {
         if (DateTime.TryParseExact(value, "dd-MM-yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date))
+        {
             return date;
+        }
+
         if (DateTime.TryParse(value, CultureInfo.CreateSpecificCulture("ca-ES"), DateTimeStyles.None, out date))
+        {
             return date;
+        }
+
         return DateTime.Parse(value, CultureInfo.InvariantCulture);
     }
 
     private static decimal ParseEuropeanDecimal(string value)
     {
-        string cleaned = value.Replace(".", "").Replace(",", ".");
+        string cleaned = value.Replace(".", string.Empty).Replace(",", ".");
         return decimal.Parse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture);
     }
 
@@ -93,9 +109,15 @@ public partial class DegiroImportService : IBrokerImportService
     {
         string c = variationCurrency;
         if (string.IsNullOrWhiteSpace(c) || c.Length != 3 || c == "---")
+        {
             c = balanceCurrency;
+        }
+
         if (string.IsNullOrWhiteSpace(c) || c.Length != 3)
+        {
             c = "EUR";
+        }
+
         return c.ToUpperInvariant();
     }
 
@@ -109,7 +131,10 @@ public partial class DegiroImportService : IBrokerImportService
     {
         Match m = QuantityPattern().Match(description);
         if (m.Success && int.TryParse(m.Groups[1].Value, out int qty))
+        {
             return qty;
+        }
+
         return 1;
     }
 
@@ -136,7 +161,9 @@ public partial class DegiroImportService : IBrokerImportService
     {
         TransactionCategory category = ClassifyDescription(description, amount);
         if (category == TransactionCategory.DEPOSIT)
+        {
             return null;
+        }
 
         Money money = new Money(Math.Abs(amount), currency);
         return new Transaction(date, description, money, category);
@@ -147,40 +174,64 @@ public partial class DegiroImportService : IBrokerImportService
         string upper = description.ToUpperInvariant();
 
         if (upper.Contains("DIVIDENDO") || upper.Contains("DIVIDEND"))
+        {
             return amount >= 0 ? TransactionCategory.INCOME : TransactionCategory.EXPENSE;
+        }
 
         if (upper.Contains("RETENCI") || upper.Contains("WITHHOLDING"))
+        {
             return TransactionCategory.EXPENSE;
+        }
 
         if (upper.Contains("COSTES") || upper.Contains("COST") || upper.Contains("COMISI"))
+        {
             return TransactionCategory.EXPENSE;
+        }
 
         if (upper.Contains("TAX") || upper.Contains("IMPUESTO"))
+        {
             return TransactionCategory.EXPENSE;
+        }
 
         if (upper.Contains("INTEREST") || upper.Contains("INTERES"))
+        {
             return amount >= 0 ? TransactionCategory.INCOME : TransactionCategory.EXPENSE;
+        }
 
         if (upper.Contains("PRESTAMO") || upper.Contains("LENDING"))
+        {
             return TransactionCategory.INCOME;
+        }
 
         if (upper.Contains("PASS-THROUGH") || upper.Contains("PASS THROUGH") || upper.Contains("PASSTHROUGH"))
+        {
             return TransactionCategory.EXPENSE;
+        }
 
         if (upper.Contains("CASH SWEEP") || upper.Contains("TRANSFERIR") || upper.Contains("TRANSFER"))
+        {
             return TransactionCategory.DEPOSIT;
+        }
 
         if (upper.Contains("DEPOSIT") || upper.Contains("WITHDRAWAL"))
+        {
             return TransactionCategory.DEPOSIT;
+        }
 
         if (upper.Contains("FLATEX"))
+        {
             return TransactionCategory.DEPOSIT;
+        }
 
         if (upper.Contains("CAMBIO DE DIVISA") || upper.Contains("FX") || upper.Contains("EXCHANGE"))
+        {
             return TransactionCategory.DEPOSIT;
+        }
 
         if (upper.Contains("PROCESSED"))
+        {
             return TransactionCategory.DEPOSIT;
+        }
 
         return amount >= 0 ? TransactionCategory.INCOME : TransactionCategory.EXPENSE;
     }

--- a/src/MyAccountingApp.Core/Services/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroImportService.cs
@@ -257,18 +257,13 @@ public partial class DegiroImportService : IBrokerImportService
             return TransactionCategory.EXPENSE;
         }
 
-        if (upper.Contains("FLATEX"))
+        if (upper.Contains("FLATEX") || upper.Contains("DEPOSIT"))
         {
-            return TransactionCategory.DEPOSIT;
-        }
+            if (upper.Contains("WITHDRAWAL") || upper.Contains("PROCESSED"))
+            {
+                return null;
+            }
 
-        if (upper.Contains("DEPOSIT"))
-        {
-            return TransactionCategory.DEPOSIT;
-        }
-
-        if (upper.Contains("PROCESSED"))
-        {
             return TransactionCategory.DEPOSIT;
         }
 

--- a/src/MyAccountingApp.Core/Services/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroImportService.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using MyAccountingApp.Domain.Entities;
@@ -13,7 +12,7 @@ using MyAccountingApp.Domain.Enums;
 using MyAccountingApp.Domain.Interfaces;
 using MyAccountingApp.Domain.ValueObjects;
 
-public partial class DegiroImportService : IBrokerImportService
+public class DegiroImportService : IBrokerImportService
 {
     public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions)> ParseAllAsync(
         string filePath,
@@ -41,9 +40,7 @@ public partial class DegiroImportService : IBrokerImportService
                 }
 
                 DateTime date = ParseDate(fields[0]);
-                string producto = fields[3];
                 string description = fields[5];
-                string isin = fields[4];
                 string currency = NormalizeCurrency(fields[7], fields[9]);
                 decimal amount = ParseEuropeanDecimal(fields[8]);
 
@@ -119,69 +116,6 @@ public partial class DegiroImportService : IBrokerImportService
     {
         return description.StartsWith("Compra ", StringComparison.OrdinalIgnoreCase)
             || description.StartsWith("Venta ", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static int ExtractQuantity(string description)
-    {
-        Match m = QuantityPattern().Match(description);
-        if (m.Success && int.TryParse(m.Groups[1].Value, out int qty))
-        {
-            return qty;
-        }
-
-        return 1;
-    }
-
-    [GeneratedRegex(@"^(?:Compra|Venta)\s+(\d+)\s", RegexOptions.IgnoreCase, 1000)]
-    private static partial Regex QuantityPattern();
-
-    private static string ExtractSymbol(string producto, string isin)
-    {
-        if (string.IsNullOrWhiteSpace(producto))
-        {
-            return string.IsNullOrWhiteSpace(isin) ? "UNKNOWN" : isin;
-        }
-
-        string trimmed = producto.TrimStart();
-
-        if (trimmed.StartsWith("ADR ", StringComparison.OrdinalIgnoreCase)
-            || trimmed.StartsWith("ADR/GDR ", StringComparison.OrdinalIgnoreCase))
-        {
-            int spaceIdx = trimmed.IndexOf(' ');
-            if (spaceIdx > 0)
-            {
-                                int afterPrefix = spaceIdx + 1;
-                string rest = trimmed[afterPrefix..].TrimStart();
-                if (rest.StartsWith("ON ", StringComparison.OrdinalIgnoreCase))
-                {
-                    rest = rest[3..].TrimStart();
-                }
-
-                if (rest.Length > 0)
-                {
-                    int nextSpace = rest.IndexOf(' ');
-                    return nextSpace > 0 ? rest[..nextSpace].ToUpperInvariant() : rest.ToUpperInvariant();
-                }
-            }
-        }
-
-        int firstSpace = trimmed.IndexOf(' ');
-        return firstSpace > 0 ? trimmed[..firstSpace].ToUpperInvariant() : trimmed.ToUpperInvariant();
-    }
-
-    private static (AssetTransaction, Transaction?) CreateAssetTransaction(
-        DateTime date, string description, string isin, string producto, decimal amount, string currency)
-    {
-        bool isBuy = description.StartsWith("Compra ", StringComparison.OrdinalIgnoreCase);
-        int quantity = ExtractQuantity(description);
-        AssetTransactionType type = isBuy ? AssetTransactionType.Buy : AssetTransactionType.Sell;
-        TransactionCategory category = isBuy ? TransactionCategory.EXPENSE : TransactionCategory.INCOME;
-
-        string symbol = ExtractSymbol(producto, isin);
-        Money money = new Money(Math.Abs(amount), currency);
-        Transaction transaction = new Transaction(date, description, money, category);
-        AssetTransaction assetTx = new AssetTransaction(transaction, symbol, quantity, type);
-        return (assetTx, null);
     }
 
     private static Transaction? CreateCashTransaction(

--- a/src/MyAccountingApp.Core/Services/DegiroTransactionImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroTransactionImportService.cs
@@ -1,0 +1,137 @@
+namespace MyAccountingApp.Core.Services;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+public partial class DegiroTransactionImportService : IBrokerImportService
+{
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions)> ParseAllAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        string[] lines = await File.ReadAllLinesAsync(filePath, cancellationToken);
+        List<AssetTransaction> assetTransactions = new();
+
+        foreach (string line in lines.Skip(1))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            try
+            {
+                List<string> fields = BankCsvImportService.ParseCsvLine(line);
+                if (fields.Count < 17)
+                {
+                    continue;
+                }
+
+                DateTime date = ParseDate(fields[0]);
+                string producto = fields[2];
+                string isin = fields[3];
+                int quantity = int.Parse(fields[6], NumberStyles.Any, CultureInfo.InvariantCulture);
+                decimal amount = ParseEuropeanDecimal(fields[9]);
+                string currency = NormalizeCurrency(fields[8]);
+
+                if (quantity <= 0 || amount == 0)
+                {
+                    continue;
+                }
+
+                bool isBuy = amount < 0;
+                string symbol = ExtractSymbol(producto, isin);
+                AssetTransactionType type = isBuy ? AssetTransactionType.Buy : AssetTransactionType.Sell;
+                TransactionCategory category = isBuy ? TransactionCategory.EXPENSE : TransactionCategory.INCOME;
+
+                Money money = new Money(Math.Abs(amount), currency);
+                Transaction transaction = new Transaction(date, producto, money, category);
+                AssetTransaction assetTx = new AssetTransaction(transaction, symbol, quantity, type);
+                assetTransactions.Add(assetTx);
+            }
+            catch
+            {
+            }
+        }
+
+        return (Array.Empty<Transaction>(), assetTransactions);
+    }
+
+    public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Enumerable.Empty<AssetTransaction>());
+    }
+
+    private static DateTime ParseDate(string value)
+    {
+        if (DateTime.TryParseExact(value, "dd-MM-yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date))
+        {
+            return date;
+        }
+
+        return DateTime.Parse(value, CultureInfo.InvariantCulture);
+    }
+
+    private static decimal ParseEuropeanDecimal(string value)
+    {
+        string cleaned = value.Replace(".", string.Empty).Replace(",", ".");
+        return decimal.Parse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture);
+    }
+
+    private static string NormalizeCurrency(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length != 3)
+        {
+            return "EUR";
+        }
+
+        return value.ToUpperInvariant();
+    }
+
+    private static string ExtractSymbol(string producto, string isin)
+    {
+        if (string.IsNullOrWhiteSpace(producto))
+        {
+            return string.IsNullOrWhiteSpace(isin) ? "UNKNOWN" : isin;
+        }
+
+        string trimmed = producto.TrimStart();
+
+        if (trimmed.StartsWith("ADR ", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("ADR/GDR ", StringComparison.OrdinalIgnoreCase))
+        {
+            int spaceIdx = trimmed.IndexOf(' ');
+            if (spaceIdx > 0)
+            {
+                                int afterPrefix = spaceIdx + 1;
+                string rest = trimmed[afterPrefix..].TrimStart();
+                if (rest.StartsWith("ON ", StringComparison.OrdinalIgnoreCase))
+                {
+                    rest = rest[3..].TrimStart();
+                }
+
+                if (rest.Length > 0)
+                {
+                    int nextSpace = rest.IndexOf(' ');
+                    return nextSpace > 0 ? rest[..nextSpace].ToUpperInvariant() : rest.ToUpperInvariant();
+                }
+            }
+        }
+
+        int firstSpace = trimmed.IndexOf(' ');
+        return firstSpace > 0 ? trimmed[..firstSpace].ToUpperInvariant() : trimmed.ToUpperInvariant();
+    }
+}

--- a/src/MyAccountingApp.Web/Pages/Import.razor
+++ b/src/MyAccountingApp.Web/Pages/Import.razor
@@ -116,11 +116,29 @@
                 {
                     <tr>
                         <td>
-                            <MudTextField @bind-Value="_editableSymbols[a.Transaction.Id]"
-                                          Variant="Variant.Outlined"
-                                          Dense="true"
-                                          Immediate="true"
-                                          Class="mud-width-full" />
+                            <div class="d-flex align-center">
+                                <MudTextField @bind-Value="_editableSymbols[a.Transaction.Id]"
+                                              Variant="Variant.Outlined"
+                                              Dense="true"
+                                              Immediate="true"
+                                              Class="flex-grow-1" />
+                                <MudIconButton Icon="@Icons.Material.Filled.Search"
+                                               Size="Size.Small"
+                                               OnClick="@(() => SearchSymbolAsync(a.Transaction.Id, a.Transaction.Description))"
+                                               Disabled="@_symbolSearching.Contains(a.Transaction.Id)" />
+                            </div>
+                            @if (_symbolResults.TryGetValue(a.Transaction.Id, out var symResults) && symResults.Count > 0)
+                            {
+                                <MudPaper Class="pa-2 mt-1" Outlined="true">
+                                    @foreach (var sr in symResults)
+                                    {
+                                        <MudText Typo="Typo.body2" Class="mud-primary-text cursor-pointer"
+                                                 @onclick="@(() => SelectSymbolResult(a.Transaction.Id, sr.Symbol))">
+                                            <strong>@sr.Symbol</strong> — @sr.Name (@sr.Exchange)
+                                        </MudText>
+                                    }
+                                </MudPaper>
+                            }
                         </td>
                         <td>@a.Transaction.Description</td>
                         <td>@a.Transaction.Money.Amount.ToString("N2")</td>
@@ -191,6 +209,8 @@
     private bool _loading;
     private bool _savingSymbols;
     private Dictionary<Guid, string> _editableSymbols = new();
+    private Dictionary<Guid, List<SymbolLookupResult>> _symbolResults = new();
+    private HashSet<Guid> _symbolSearching = new();
     private IBrowserFile? _selectedFile;
     private IBrowserFile? _rawFile;
     private IBrowserFile? _degiroFile;
@@ -374,5 +394,51 @@
         {
             Snackbar.Add($"Symbols corrected: {saved} updated, {errors} failed.", Severity.Warning);
         }
+    }
+
+    private async Task SearchSymbolAsync(Guid assetId, string description)
+    {
+        if (_symbolSearching.Contains(assetId)) return;
+
+        _symbolSearching.Add(assetId);
+        _symbolResults.Remove(assetId);
+
+        string name = description;
+        int atIdx = description.IndexOf('@');
+        if (atIdx > 0)
+        {
+            int spaceBefore = description.LastIndexOf(' ', atIdx - 1);
+            name = spaceBefore > 0 ? description[..spaceBefore].Trim() : description;
+        }
+
+        name = name.Replace("Compra ", string.Empty).Replace("Venta ", string.Empty).Trim();
+
+        try
+        {
+            var results = await Http.GetFromJsonAsync<List<SymbolLookupResult>>($"/api/symbol-lookup?name={Uri.EscapeDataString(name)}");
+            _symbolResults[assetId] = results ?? new();
+        }
+        catch
+        {
+            _symbolResults[assetId] = new();
+        }
+        finally
+        {
+            _symbolSearching.Remove(assetId);
+        }
+    }
+
+    private void SelectSymbolResult(Guid assetId, string symbol)
+    {
+        _editableSymbols[assetId] = symbol;
+        _symbolResults.Remove(assetId);
+    }
+
+    private sealed class SymbolLookupResult
+    {
+        public string Symbol { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Exchange { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
     }
 }

--- a/src/MyAccountingApp.Web/Pages/Import.razor
+++ b/src/MyAccountingApp.Web/Pages/Import.razor
@@ -407,11 +407,15 @@
         int atIdx = description.IndexOf('@');
         if (atIdx > 0)
         {
-            int spaceBefore = description.LastIndexOf(' ', atIdx - 1);
-            name = spaceBefore > 0 ? description[..spaceBefore].Trim() : description;
+            string beforeAt = description[..atIdx].Trim();
+            string stripped = beforeAt.Replace("Compra ", string.Empty).Replace("Venta ", string.Empty).Trim();
+            int firstSpace = stripped.IndexOf(' ');
+            if (firstSpace > 0 && int.TryParse(stripped[..firstSpace], out int _))
+            {
+                stripped = stripped[(firstSpace + 1)..].Trim();
+            }
+            name = stripped;
         }
-
-        name = name.Replace("Compra ", string.Empty).Replace("Venta ", string.Empty).Trim();
 
         try
         {

--- a/src/MyAccountingApp.Web/Pages/Import.razor
+++ b/src/MyAccountingApp.Web/Pages/Import.razor
@@ -100,6 +100,31 @@
         </MudText>
     </MudAlert>
 
+    @if (_result.AssetTransactions.Count > 0 && _showAssetTable)
+    {
+        <MudText Typo="Typo.subtitle1" GutterBottom="true">Asset Transactions</MudText>
+        <MudAlert Severity="Severity.Warning" Class="mb-4" Dense="true">
+            Verify the detected symbols. Incorrect symbols can be edited later in the Portfolio page.
+        </MudAlert>
+        <MudSimpleTable Class="mb-4" Outlined="true" Hover="true">
+            <thead>
+                <tr><th>Symbol</th><th>Description</th><th>Amount</th><th>Currency</th><th>Quantity</th></tr>
+            </thead>
+            <tbody>
+                @foreach (var a in _result.AssetTransactions)
+                {
+                    <tr>
+                        <td><MudText Typo="Typo.body2" Class="mud-primary-text">@a.Symbol</MudText></td>
+                        <td>@a.Transaction.Description</td>
+                        <td>@a.Transaction.Money.Amount.ToString("N2")</td>
+                        <td>@a.Transaction.Money.Currency</td>
+                        <td>@a.Quantity</td>
+                    </tr>
+                }
+            </tbody>
+        </MudSimpleTable>
+    }
+
     @if (_result.Errors.Count > 0)
     {
         <MudText Typo="Typo.subtitle1" GutterBottom="true">Errors</MudText>
@@ -147,6 +172,7 @@
 @code {
     private ImportResultDto? _result;
     private bool _loading;
+    private bool _showAssetTable;
     private IBrowserFile? _selectedFile;
     private IBrowserFile? _rawFile;
     private IBrowserFile? _degiroFile;
@@ -175,6 +201,7 @@
 
         _loading = true;
         _result = null;
+        _showAssetTable = false;
         try
         {
             using var content = new MultipartFormDataContent();
@@ -202,6 +229,7 @@
 
         _loading = true;
         _result = null;
+        _showAssetTable = false;
         try
         {
             using var content = new MultipartFormDataContent();
@@ -210,6 +238,7 @@
 
             var response = await Http.PostAsync("/api/import/upload", content);
             _result = await response.Content.ReadFromJsonAsync<ImportResultDto>();
+            _showAssetTable = true;
             Snackbar.Add("DeGiro import completed.", Severity.Success);
             _degiroFile = null;
         }
@@ -229,6 +258,7 @@
 
         _loading = true;
         _result = null;
+        _showAssetTable = false;
         try
         {
             using var content = new MultipartFormDataContent();

--- a/src/MyAccountingApp.Web/Pages/Import.razor
+++ b/src/MyAccountingApp.Web/Pages/Import.razor
@@ -31,6 +31,34 @@
 </MudPaper>
 
 <MudPaper Class="pa-6 mb-4" Outlined="true">
+    <MudText Typo="Typo.h6" GutterBottom="true">Import DeGiro / Flatex CSV</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Upload a CSV exported from DeGiro or Flatex (Spanish format). Asset transactions, dividends, and fees are detected automatically.
+    </MudText>
+    <MudAlert Severity="Severity.Info" Class="mb-4" Dense="true">
+        <strong>Format detected automatically.</strong> Expected columns: Fecha, Hora, Fecha valor, Producto, ISIN, Descripción, Tipo, Variación, (amount), Saldo, (balance), ID Orden.<br />
+        <strong>Compra</strong> / <strong>Venta</strong> rows become portfolio entries. <strong>Dividendo</strong>, <strong>Retención</strong> and <strong>Costes</strong> become cash transactions. Internal transfers are skipped.
+    </MudAlert>
+    <MudGrid>
+        <MudItem xs="12" sm="8">
+            <InputFile OnChange="@OnDegiroFileSelected" accept=".csv" class="mud-input-outlined" />
+        </MudItem>
+        <MudItem xs="12" sm="4" Class="d-flex align-center">
+            <MudButton Variant="Variant.Filled" Color="Color.Success" Size="Size.Large"
+                       OnClick="@UploadDegiroAsync" Disabled="@(_degiroFile is null || _loading)"
+                       StartIcon="@Icons.Material.Filled.FileUpload"
+                       FullWidth="true">
+                Import DeGiro
+            </MudButton>
+        </MudItem>
+    </MudGrid>
+    @if (_degiroFile is not null)
+    {
+        <MudText Typo="Typo.body2" Class="mt-2 mud-text-secondary">Selected: @_degiroFile.Name</MudText>
+    }
+</MudPaper>
+
+<MudPaper Class="pa-6 mb-4" Outlined="true">
     <MudText Typo="Typo.h6" GutterBottom="true">Import Raw CSV</MudText>
     <MudText Typo="Typo.body2" Class="mb-4">
         Upload a CSV with your own format. No transformations applied.
@@ -121,6 +149,7 @@
     private bool _loading;
     private IBrowserFile? _selectedFile;
     private IBrowserFile? _rawFile;
+    private IBrowserFile? _degiroFile;
 
     private void OnFileSelected(InputFileChangeEventArgs args)
     {
@@ -131,6 +160,12 @@
     private void OnRawFileSelected(InputFileChangeEventArgs args)
     {
         _rawFile = args.File;
+        _result = null;
+    }
+
+    private void OnDegiroFileSelected(InputFileChangeEventArgs args)
+    {
+        _degiroFile = args.File;
         _result = null;
     }
 
@@ -154,6 +189,33 @@
         catch (Exception ex)
         {
             Snackbar.Add($"Upload failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task UploadDegiroAsync()
+    {
+        if (_degiroFile is null) return;
+
+        _loading = true;
+        _result = null;
+        try
+        {
+            using var content = new MultipartFormDataContent();
+            using var stream = _degiroFile.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024);
+            content.Add(new StreamContent(stream), "file", _degiroFile.Name);
+
+            var response = await Http.PostAsync("/api/import/upload", content);
+            _result = await response.Content.ReadFromJsonAsync<ImportResultDto>();
+            Snackbar.Add("DeGiro import completed.", Severity.Success);
+            _degiroFile = null;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"DeGiro import failed: {ex.Message}", Severity.Error);
         }
         finally
         {

--- a/src/MyAccountingApp.Web/Pages/Import.razor
+++ b/src/MyAccountingApp.Web/Pages/Import.razor
@@ -100,11 +100,12 @@
         </MudText>
     </MudAlert>
 
-    @if (_result.AssetTransactions.Count > 0 && _showAssetTable)
+    @if (_result.AssetTransactions.Count > 0)
     {
-        <MudText Typo="Typo.subtitle1" GutterBottom="true">Asset Transactions</MudText>
+        <MudText Typo="Typo.subtitle1" GutterBottom="true">Asset Transactions — verify and correct symbols</MudText>
         <MudAlert Severity="Severity.Warning" Class="mb-4" Dense="true">
-            Verify the detected symbols. Incorrect symbols can be edited later in the Portfolio page.
+            Symbols are extracted from the product name and may not match the exact Yahoo Finance ticker.
+            Edit them below and click "Save Symbol Corrections".
         </MudAlert>
         <MudSimpleTable Class="mb-4" Outlined="true" Hover="true">
             <thead>
@@ -114,7 +115,13 @@
                 @foreach (var a in _result.AssetTransactions)
                 {
                     <tr>
-                        <td><MudText Typo="Typo.body2" Class="mud-primary-text">@a.Symbol</MudText></td>
+                        <td>
+                            <MudTextField @bind-Value="_editableSymbols[a.Transaction.Id]"
+                                          Variant="Variant.Outlined"
+                                          Dense="true"
+                                          Immediate="true"
+                                          Class="mud-width-full" />
+                        </td>
                         <td>@a.Transaction.Description</td>
                         <td>@a.Transaction.Money.Amount.ToString("N2")</td>
                         <td>@a.Transaction.Money.Currency</td>
@@ -123,6 +130,16 @@
                 }
             </tbody>
         </MudSimpleTable>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   OnClick="@SaveSymbolCorrectionsAsync"
+                   Disabled="@_savingSymbols"
+                   StartIcon="@Icons.Material.Filled.Save">
+            Save Symbol Corrections
+        </MudButton>
+        @if (_savingSymbols)
+        {
+            <MudProgressLinear Indeterminate="true" Class="mt-2" />
+        }
     }
 
     @if (_result.Errors.Count > 0)
@@ -172,7 +189,8 @@
 @code {
     private ImportResultDto? _result;
     private bool _loading;
-    private bool _showAssetTable;
+    private bool _savingSymbols;
+    private Dictionary<Guid, string> _editableSymbols = new();
     private IBrowserFile? _selectedFile;
     private IBrowserFile? _rawFile;
     private IBrowserFile? _degiroFile;
@@ -201,7 +219,7 @@
 
         _loading = true;
         _result = null;
-        _showAssetTable = false;
+        _editableSymbols = new();
         try
         {
             using var content = new MultipartFormDataContent();
@@ -210,6 +228,7 @@
 
             var response = await Http.PostAsync("/api/import/upload", content);
             _result = await response.Content.ReadFromJsonAsync<ImportResultDto>();
+            InitEditableSymbols();
             Snackbar.Add("Upload import completed.", Severity.Success);
             _selectedFile = null;
         }
@@ -229,7 +248,7 @@
 
         _loading = true;
         _result = null;
-        _showAssetTable = false;
+        _editableSymbols = new();
         try
         {
             using var content = new MultipartFormDataContent();
@@ -238,7 +257,7 @@
 
             var response = await Http.PostAsync("/api/import/upload", content);
             _result = await response.Content.ReadFromJsonAsync<ImportResultDto>();
-            _showAssetTable = true;
+            InitEditableSymbols();
             Snackbar.Add("DeGiro import completed.", Severity.Success);
             _degiroFile = null;
         }
@@ -258,7 +277,7 @@
 
         _loading = true;
         _result = null;
-        _showAssetTable = false;
+        _editableSymbols = new();
         try
         {
             using var content = new MultipartFormDataContent();
@@ -290,4 +309,70 @@
         }
     }
 
+    private void InitEditableSymbols()
+    {
+        if (_result is null) return;
+        _editableSymbols = new();
+        foreach (var a in _result.AssetTransactions)
+        {
+            _editableSymbols[a.Transaction.Id] = a.Symbol;
+        }
+    }
+
+    private async Task SaveSymbolCorrectionsAsync()
+    {
+        if (_result is null || _editableSymbols.Count == 0) return;
+
+        _savingSymbols = true;
+        int saved = 0;
+        int errors = 0;
+
+        foreach (var kv in _editableSymbols)
+        {
+            AssetTransactionDto? original = _result.AssetTransactions.FirstOrDefault(a => a.Transaction.Id == kv.Key);
+            if (original is null) continue;
+            if (original.Symbol == kv.Value) continue;
+
+            try
+            {
+                var request = new
+                {
+                    date = original.Transaction.Date,
+                    description = original.Transaction.Description,
+                    amount = original.Transaction.Money.Amount,
+                    currency = original.Transaction.Money.Currency,
+                    category = original.Transaction.Category,
+                    symbol = kv.Value,
+                    quantity = original.Quantity,
+                    type = original.Type,
+                };
+
+                var response = await Http.PutAsJsonAsync($"/api/asset-transactions/{kv.Key}", request);
+                if (response.IsSuccessStatusCode)
+                {
+                    original.Symbol = kv.Value;
+                    saved++;
+                }
+                else
+                {
+                    errors++;
+                }
+            }
+            catch
+            {
+                errors++;
+            }
+        }
+
+        _savingSymbols = false;
+
+        if (errors == 0)
+        {
+            Snackbar.Add($"Symbols corrected: {saved} updated.", Severity.Success);
+        }
+        else
+        {
+            Snackbar.Add($"Symbols corrected: {saved} updated, {errors} failed.", Severity.Warning);
+        }
+    }
 }

--- a/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
@@ -125,6 +125,50 @@ public class BrokerImportDispatcherTests
     }
 
     [Fact]
+    public async Task ParseAllAsync_DegiroHeader_UsesDegiroService()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n24-12-2025,08:31,24-12-2025,,,Degiro Cash Sweep Transfer,,USD,\"-5,35\",USD,\"110,85\",";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_DegiroBuy_CreatesAssetTransaction()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n30-12-2021,09:08,30-12-2021,GRIFOLS SA CLASS A,ES0171996087,\"Compra 40 Grifols SA Class A@16,53 EUR (ES0171996087)\",,EUR,\"-661,20\",EUR,\"1837,81\",577e222d-567c-4f9a-aa66-f462e3508a20";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.NotEmpty(assets);
+            Assert.Equal("ES0171996087", assets.First().Symbol);
+            Assert.Equal(40, assets.First().Quantity);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
     public async Task ParseCorporateActionsAsync_DelegatesToIbkr()
     {
         string file = Path.GetTempFileName();
@@ -145,7 +189,7 @@ public class BrokerImportDispatcherTests
     private static BrokerImportDispatcher CreateDispatcher()
     {
         InteractiveBrokersImportService ibkr = new(Parser, new FakeLogger<InteractiveBrokersImportService>());
-        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService());
+        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService());
     }
 }
 

--- a/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
@@ -169,6 +169,50 @@ public class BrokerImportDispatcherTests
     }
 
     [Fact]
+    public async Task ParseAllAsync_DegiroTransactionHeader_UsesDegiroTransactionService()
+    {
+        string csv = "Fecha,Hora,Producto,ISIN,Bolsa de referencia,Centro de ejecución,Número,Precio,,Valor local,,Valor EUR,Tipo de cambio,Comisión AutoFX,Costes de transacción y/o externos EUR,Total EUR,ID Orden\n30-12-2021,09:08,GRIFOLS SA CLASS A,ES0171996087,MAD,XMAD,40,\"16,5300\",EUR,\"-661,20\",EUR,\"-661,20\",,\"0,00\",\"-0,50\",\"-661,70\",,577e222d-567c-4f9a-aa66-f462e3508a20";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.NotEmpty(assets);
+            Assert.Equal("GRIFOLS", assets.First().Symbol);
+            Assert.Equal(40, assets.First().Quantity);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_DegiroAccountHeader_StillUsesDegiroService()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n24-12-2025,08:31,24-12-2025,,,Degiro Cash Sweep Transfer,,USD,\"-5,35\",USD,\"110,85\",";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
     public async Task ParseCorporateActionsAsync_DelegatesToIbkr()
     {
         string file = Path.GetTempFileName();
@@ -189,7 +233,7 @@ public class BrokerImportDispatcherTests
     private static BrokerImportDispatcher CreateDispatcher()
     {
         InteractiveBrokersImportService ibkr = new(Parser, new FakeLogger<InteractiveBrokersImportService>());
-        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService());
+        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService(), new DegiroTransactionImportService());
     }
 }
 

--- a/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
@@ -146,7 +146,7 @@ public class BrokerImportDispatcherTests
     }
 
     [Fact]
-    public async Task ParseAllAsync_DegiroBuy_CreatesAssetTransaction()
+    public async Task ParseAllAsync_DegiroAccountBuy_Skipped()
     {
         string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n30-12-2021,09:08,30-12-2021,GRIFOLS SA CLASS A,ES0171996087,\"Compra 40 Grifols SA Class A@16,53 EUR (ES0171996087)\",,EUR,\"-661,20\",EUR,\"1837,81\",577e222d-567c-4f9a-aa66-f462e3508a20";
         string file = Path.GetTempFileName();
@@ -158,9 +158,7 @@ public class BrokerImportDispatcherTests
             var (txs, assets) = await dispatcher.ParseAllAsync(file);
 
             Assert.Empty(txs);
-            Assert.NotEmpty(assets);
-            Assert.Equal("GRIFOLS", assets.First().Symbol);
-            Assert.Equal(40, assets.First().Quantity);
+            Assert.Empty(assets);
         }
         finally
         {

--- a/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
@@ -159,7 +159,7 @@ public class BrokerImportDispatcherTests
 
             Assert.Empty(txs);
             Assert.NotEmpty(assets);
-            Assert.Equal("ES0171996087", assets.First().Symbol);
+            Assert.Equal("GRIFOLS", assets.First().Symbol);
             Assert.Equal(40, assets.First().Quantity);
         }
         finally

--- a/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
@@ -186,7 +186,7 @@ public class DegiroImportServiceTests
     }
 
     [Fact]
-    public async Task ParseAllAsync_FlatexWithdrawal_Skipped()
+    public async Task ParseAllAsync_FlatexWithdrawal_CreatesTransfer()
     {
         string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
             "17-12-2021,10:30,17-12-2021,,,Flatex Withdrawal,,EUR,\"-800,00\",EUR,\"7200,00\",\n";
@@ -197,8 +197,10 @@ public class DegiroImportServiceTests
             await File.WriteAllTextAsync(file, csv);
             var (txs, assets) = await this.service.ParseAllAsync(file);
 
-            Assert.Empty(txs);
             Assert.Empty(assets);
+            var t = Assert.Single(txs);
+            Assert.Equal(800m, t.Money.Amount);
+            Assert.Equal(Domain.Enums.TransactionCategory.TRANSFER, t.Category);
         }
         finally
         {

--- a/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
@@ -24,7 +24,7 @@ public class DegiroImportServiceTests
 
             Assert.Empty(txs);
             var a = Assert.Single(assets);
-            Assert.Equal("ES0171996087", a.Symbol);
+            Assert.Equal("GRIFOLS", a.Symbol);
             Assert.Equal(40, a.Quantity);
             Assert.Equal(661.20m, a.Transaction.Money.Amount);
             Assert.Equal("EUR", a.Transaction.Money.Currency);
@@ -49,7 +49,7 @@ public class DegiroImportServiceTests
 
             Assert.Empty(txs);
             var a = Assert.Single(assets);
-            Assert.Equal("US9111631035", a.Symbol);
+            Assert.Equal("UNITED", a.Symbol);
             Assert.Equal(21, a.Quantity);
             Assert.Equal(903, a.Transaction.Money.Amount);
         }
@@ -161,7 +161,7 @@ public class DegiroImportServiceTests
 
             Assert.Empty(txs);
             var a = Assert.Single(assets);
-            Assert.Equal("DE000A27Z304", a.Symbol);
+            Assert.Equal("BTCETC", a.Symbol);
             Assert.Equal(5, a.Quantity);
             Assert.Equal(496.13m, a.Transaction.Money.Amount);
             Assert.Equal("USD", a.Transaction.Money.Currency);

--- a/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
@@ -237,4 +237,27 @@ public class DegiroImportServiceTests
             File.Delete(file);
         }
     }
+
+    [Fact]
+    public async Task ParseAllAsync_Ingreso_CreatesDepositTransaction()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
+            "01-11-2021,01:06,31-10-2021,,,Ingreso,,EUR,\"50,00\",EUR,\"50,00\",\n";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+            var t = Assert.Single(txs);
+            Assert.Equal(50m, t.Money.Amount);
+            Assert.Equal(Domain.Enums.TransactionCategory.DEPOSIT, t.Category);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
 }

--- a/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
@@ -11,7 +11,7 @@ public class DegiroImportServiceTests
     private readonly DegiroImportService service = new();
 
     [Fact]
-    public async Task ParseAllAsync_Buy_CreatesAssetTransaction()
+    public async Task ParseAllAsync_Buy_Skipped()
     {
         string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
             "30-12-2021,09:08,30-12-2021,GRIFOLS SA CLASS A,ES0171996087,\"Compra 40 Grifols SA Class A@16,53 EUR (ES0171996087)\",,EUR,\"-661,20\",EUR,\"1837,81\",577e222d-567c-4f9a-aa66-f462e3508a20";
@@ -23,11 +23,7 @@ public class DegiroImportServiceTests
             var (txs, assets) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
-            var a = Assert.Single(assets);
-            Assert.Equal("GRIFOLS", a.Symbol);
-            Assert.Equal(40, a.Quantity);
-            Assert.Equal(661.20m, a.Transaction.Money.Amount);
-            Assert.Equal("EUR", a.Transaction.Money.Currency);
+            Assert.Empty(assets);
         }
         finally
         {
@@ -36,7 +32,7 @@ public class DegiroImportServiceTests
     }
 
     [Fact]
-    public async Task ParseAllAsync_Sell_CreatesAssetTransaction()
+    public async Task ParseAllAsync_Sell_Skipped()
     {
         string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
             "15-10-2025,20:41,15-10-2025,UNITED NATURAL FOODS INC,US9111631035,\"Venta 21 United Natural Foods Inc@43 USD (US9111631035)\",,USD,\"903,00\",USD,\"11004,26\",9731a893-b30b-4d04-b5c9-734ed5617a74";
@@ -48,10 +44,7 @@ public class DegiroImportServiceTests
             var (txs, assets) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
-            var a = Assert.Single(assets);
-            Assert.Equal("UNITED", a.Symbol);
-            Assert.Equal(21, a.Quantity);
-            Assert.Equal(903, a.Transaction.Money.Amount);
+            Assert.Empty(assets);
         }
         finally
         {
@@ -148,7 +141,7 @@ public class DegiroImportServiceTests
     }
 
     [Fact]
-    public async Task ParseAllAsync_BtcetcBuy_ParsesQuantity()
+    public async Task ParseAllAsync_BtcetcBuy_Skipped()
     {
         string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
             "24-10-2025,17:15,24-10-2025,BTCETC BITCOIN EXCHANGE TRADED,DE000A27Z304,\"Compra 5 BTCetc Bitcoin Exchange Traded Crypto ETN@99,226 USD (DE000A27Z304)\",,USD,\"-496,13\",USD,\"89,61\",16e33fba-6d63-411c-bf21-bb8ef4fe3222";
@@ -160,11 +153,7 @@ public class DegiroImportServiceTests
             var (txs, assets) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
-            var a = Assert.Single(assets);
-            Assert.Equal("BTCETC", a.Symbol);
-            Assert.Equal(5, a.Quantity);
-            Assert.Equal(496.13m, a.Transaction.Money.Amount);
-            Assert.Equal("USD", a.Transaction.Money.Currency);
+            Assert.Empty(assets);
         }
         finally
         {

--- a/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
@@ -171,4 +171,70 @@ public class DegiroImportServiceTests
             File.Delete(file);
         }
     }
+
+    [Fact]
+    public async Task ParseAllAsync_FlatexDeposit_CreatesDepositTransaction()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
+            "07-11-2021,10:30,07-11-2021,,,Flatex Deposit,,EUR,\"8000,00\",EUR,\"8000,00\",\n";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+            var t = Assert.Single(txs);
+            Assert.Equal(8000m, t.Money.Amount);
+            Assert.Equal("EUR", t.Money.Currency);
+            Assert.Equal(Domain.Enums.TransactionCategory.DEPOSIT, t.Category);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_FlatexWithdrawal_Skipped()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
+            "17-12-2021,10:30,17-12-2021,,,Flatex Withdrawal,,EUR,\"-800,00\",EUR,\"7200,00\",\n";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ProcessedFlatexWithdrawal_Skipped()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
+            "17-12-2021,10:30,17-12-2021,,,Processed Flatex Withdrawal,,EUR,\"800,00\",EUR,\"8000,00\",\n";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
 }

--- a/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
@@ -1,0 +1,174 @@
+namespace MyAccountingApp.Core.Tests.Services;
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Services;
+using Xunit;
+
+public class DegiroImportServiceTests
+{
+    private readonly DegiroImportService service = new();
+
+    [Fact]
+    public async Task ParseAllAsync_Buy_CreatesAssetTransaction()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
+            "30-12-2021,09:08,30-12-2021,GRIFOLS SA CLASS A,ES0171996087,\"Compra 40 Grifols SA Class A@16,53 EUR (ES0171996087)\",,EUR,\"-661,20\",EUR,\"1837,81\",577e222d-567c-4f9a-aa66-f462e3508a20";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            var a = Assert.Single(assets);
+            Assert.Equal("ES0171996087", a.Symbol);
+            Assert.Equal(40, a.Quantity);
+            Assert.Equal(661.20m, a.Transaction.Money.Amount);
+            Assert.Equal("EUR", a.Transaction.Money.Currency);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_Sell_CreatesAssetTransaction()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
+            "15-10-2025,20:41,15-10-2025,UNITED NATURAL FOODS INC,US9111631035,\"Venta 21 United Natural Foods Inc@43 USD (US9111631035)\",,USD,\"903,00\",USD,\"11004,26\",9731a893-b30b-4d04-b5c9-734ed5617a74";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            var a = Assert.Single(assets);
+            Assert.Equal("US9111631035", a.Symbol);
+            Assert.Equal(21, a.Quantity);
+            Assert.Equal(903, a.Transaction.Money.Amount);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_Dividend_CreatesTransaction()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
+            "24-12-2025,07:44,23-12-2025,META PLATFORMS INC CLASS A,US30303M1027,Dividendo,,USD,\"6,30\",USD,\"110,85\",\n" +
+            "24-12-2025,07:44,23-12-2025,META PLATFORMS INC CLASS A,US30303M1027,\"Retención del dividendo\",,USD,\"-0,95\",USD,\"104,55\",\n";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+            Assert.Equal(2, txs.Count());
+            Assert.Equal("Dividendo", txs.First().Description);
+            Assert.Equal(6.30m, txs.First().Money.Amount);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_CashSweep_Skipped()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
+            "24-12-2025,08:31,24-12-2025,,,Degiro Cash Sweep Transfer,,USD,\"-5,35\",USD,\"110,85\",\n" +
+            "24-12-2025,08:31,24-12-2025,,,\"Transferir a su Cuenta de Efectivo en flatexDEGIRO Bank: 5,35 USD\",,,,USD,\"116,20\",\n";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_EmptyFile_ReturnsEmpty()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_Commission_CreatesExpense()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
+            "24-10-2025,17:15,24-10-2025,BTCETC BITCOIN EXCHANGE TRADED,DE000A27Z304,\"Costes de transacción y/o externos de DEGIRO\",,EUR,\"-3,00\",EUR,\"96,06\",16e33fba-6d63-411c-bf21-bb8ef4fe3222";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+            var t = Assert.Single(txs);
+            Assert.Equal(3.00m, t.Money.Amount);
+            Assert.Equal(Domain.Enums.TransactionCategory.EXPENSE, t.Category);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_BtcetcBuy_ParsesQuantity()
+    {
+        string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
+            "24-10-2025,17:15,24-10-2025,BTCETC BITCOIN EXCHANGE TRADED,DE000A27Z304,\"Compra 5 BTCetc Bitcoin Exchange Traded Crypto ETN@99,226 USD (DE000A27Z304)\",,USD,\"-496,13\",USD,\"89,61\",16e33fba-6d63-411c-bf21-bb8ef4fe3222";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            var a = Assert.Single(assets);
+            Assert.Equal("DE000A27Z304", a.Symbol);
+            Assert.Equal(5, a.Quantity);
+            Assert.Equal(496.13m, a.Transaction.Money.Amount);
+            Assert.Equal("USD", a.Transaction.Money.Currency);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Services/DegiroTransactionImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/DegiroTransactionImportServiceTests.cs
@@ -1,0 +1,131 @@
+namespace MyAccountingApp.Core.Tests.Services;
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Services;
+using Xunit;
+
+public class DegiroTransactionImportServiceTests
+{
+    private readonly DegiroTransactionImportService service = new();
+
+    [Fact]
+    public async Task ParseAllAsync_Buy_CreatesAssetTransaction()
+    {
+        string csv = "Fecha,Hora,Producto,ISIN,Bolsa de referencia,Centro de ejecución,Número,Precio,,Valor local,,Valor EUR,Tipo de cambio,Comisión AutoFX,Costes de transacción y/o externos EUR,Total EUR,ID Orden\n" +
+            "30-12-2021,09:08,GRIFOLS SA CLASS A,ES0171996087,MAD,XMAD,40,\"16,5300\",EUR,\"-661,20\",EUR,\"-661,20\",,\"0,00\",\"-0,50\",\"-661,70\",,577e222d-567c-4f9a-aa66-f462e3508a20";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            var a = Assert.Single(assets);
+            Assert.Equal("GRIFOLS", a.Symbol);
+            Assert.Equal(40, a.Quantity);
+            Assert.Equal(661.20m, a.Transaction.Money.Amount);
+            Assert.Equal("EUR", a.Transaction.Money.Currency);
+            Assert.Equal(Domain.Enums.AssetTransactionType.Buy, a.Type);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_Sell_CreatesAssetTransaction()
+    {
+        string csv = "Fecha,Hora,Producto,ISIN,Bolsa de referencia,Centro de ejecución,Número,Precio,,Valor local,,Valor EUR,Tipo de cambio,Comisión AutoFX,Costes de transacción y/o externos EUR,Total EUR,ID Orden\n" +
+            "15-10-2025,20:41,UNITED NATURAL FOODS INC,US9111631035,NSY,XNAS,21,\"43,0000\",USD,\"903,00\",USD,\"797,32\",\"1,1326\",\"-0,80\",,\"796,52\",,9731a893-b30b-4d04-b5c9-734ed5617a74";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            var a = Assert.Single(assets);
+            Assert.Equal("UNITED", a.Symbol);
+            Assert.Equal(21, a.Quantity);
+            Assert.Equal(903, a.Transaction.Money.Amount);
+            Assert.Equal("USD", a.Transaction.Money.Currency);
+            Assert.Equal(Domain.Enums.AssetTransactionType.Sell, a.Type);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_BtcetcBuy_ParsesSymbol()
+    {
+        string csv = "Fecha,Hora,Producto,ISIN,Bolsa de referencia,Centro de ejecución,Número,Precio,,Valor local,,Valor EUR,Tipo de cambio,Comisión AutoFX,Costes de transacción y/o externos EUR,Total EUR,ID Orden\n" +
+            "24-10-2025,17:15,BTCETC BITCOIN EXCHANGE TRADED,DE000A27Z304,XETR,XETR,5,\"99,2260\",USD,\"-496,13\",USD,\"-438,07\",\"1,1326\",\"-0,44\",,\"-438,51\",,16e33fba-6d63-411c-bf21-bb8ef4fe3222";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            var a = Assert.Single(assets);
+            Assert.Equal("BTCETC", a.Symbol);
+            Assert.Equal(5, a.Quantity);
+            Assert.Equal(496.13m, a.Transaction.Money.Amount);
+            Assert.Equal("USD", a.Transaction.Money.Currency);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_AdrSymbol_ExtractsCorrectly()
+    {
+        string csv = "Fecha,Hora,Producto,ISIN,Bolsa de referencia,Centro de ejecución,Número,Precio,,Valor local,,Valor EUR,Tipo de cambio,Comisión AutoFX,Costes de transacción y/o externos EUR,Total EUR,ID Orden\n" +
+            "08-11-2021,21:40,ADR ON HIMAX TECHNOLOGIES INC,US43289P1066,NDQ,XNAS,40,\"10,9500\",USD,\"-438,00\",USD,\"-377,94\",\"1,1589\",\"-0,38\",\"-0,64\",\"-378,96\",,295729ae-38ed-47b5-b5f6-199e3315e898";
+
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            var a = Assert.Single(assets);
+            Assert.Equal("HIMAX", a.Symbol);
+            Assert.Equal(40, a.Quantity);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_EmptyFile_ReturnsEmpty()
+    {
+        string csv = "Fecha,Hora,Producto,ISIN,Bolsa de referencia,Centro de ejecución,Número,Precio,,Valor local,,Valor EUR,Tipo de cambio,Comisión AutoFX,Costes de transacción y/o externos EUR,Total EUR,ID Orden";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            var (txs, assets) = await this.service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+}


### PR DESCRIPTION
## Changes

Adds native DeGiro CSV support to `BrokerImportDispatcher`.

### New file: `DegiroImportService.cs`
- Parses Spanish DeGiro/Flatex CSV exports (header: `Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,...`)
- Handles European decimal format (comma decimal, dot thousands)
- Detects `Compra`/`Venta` → creates `AssetTransaction` (Buy/Sell) with ISIN as symbol
- Detects dividends, withholding tax, commissions, fees → creates `Transaction`
- Skips internal entries (cash sweeps, transfers, FX conversions, deposits/withdrawals)

### Changes
- `BrokerImportDispatcher.cs`: routes files with header starting `Fecha,Hora,Fecha valor` to `DegiroImportService`
- `Program.cs`: registers `DegiroImportService` in DI
- Tests: 7 DegiroImportService tests + 3 dispatcher routing tests

Closes: asset transactions not saving when imported from DeGiro CSV