### PR TITLE
Add OptionTransaction entity, repository, import integration, and API endpoints

### DIFF
--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -55,6 +55,8 @@ builder.Services.AddSingleton<ITransactionRepository>(
     new CompositeTransactionRepository("data/transactions.json"));
 builder.Services.AddSingleton<IPortfolioRepository>(
     new CompositePortfolioRepository("data/portfolio.json"));
+builder.Services.AddSingleton<IOptionTransactionRepository>(
+    new JsonOptionTransactionRepository("data/options.json"));
 builder.Services.AddSingleton<InteractiveBrokersImportService>(sp =>
 {
     ICsvParser csvParser = new InteractiveBrokersCsvParser();
@@ -258,6 +260,30 @@ app.MapGet($"{prefix}/asset-transactions/year/{{year:int}}/count", (int year, IP
 {
     int assets = portfolioRepo.GetAllTransactions().Count(a => a.Transaction.Date.Year == year);
     return Results.Ok(new { year, assets });
+});
+
+app.MapGet($"{prefix}/option-transactions", (IOptionTransactionRepository repo) =>
+{
+    List<OptionTransactionDto> transactions = repo.GetAll().Select(t => t.ToDto()).ToList();
+    return Results.Ok(transactions);
+});
+
+app.MapGet($"{prefix}/option-transactions/{{symbol}}", (string symbol, IOptionTransactionRepository repo) =>
+{
+    List<OptionTransactionDto> transactions = repo.GetAll().Where(t => t.Symbol == symbol).Select(t => t.ToDto()).ToList();
+    return Results.Ok(transactions);
+});
+
+app.MapDelete($"{prefix}/option-transactions/year/{{year:int}}", (int year, IOptionTransactionRepository repo) =>
+{
+    int removed = repo.DeleteByYear(year);
+    return Results.Ok(new { year, deletedOptions = removed });
+});
+
+app.MapGet($"{prefix}/option-transactions/year/{{year:int}}/count", (int year, IOptionTransactionRepository repo) =>
+{
+    int count = repo.GetAll().Count(t => t.Date.Year == year);
+    return Results.Ok(new { year, options = count });
 });
 
 app.MapPost($"{prefix}/import", async (ImportRequest request, IImportService importService) =>

--- a/src/MyAccountingApp.Application/DTOs/DtoMapper.cs
+++ b/src/MyAccountingApp.Application/DTOs/DtoMapper.cs
@@ -31,6 +31,17 @@ public static class DtoMapper
             conversion.Source.ToString(),
             conversion.Quotes.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value));
 
+    public static OptionTransactionDto ToDto(this OptionTransaction optionTransaction) =>
+        new(
+            optionTransaction.Id,
+            optionTransaction.Date,
+            optionTransaction.Description,
+            optionTransaction.Symbol,
+            optionTransaction.Isin,
+            optionTransaction.Quantity,
+            optionTransaction.Premium.ToDto(),
+            optionTransaction.Type.ToString());
+
     public static ImportResultDto ToDto(this ImportResult result) =>
         new(
             result.Transactions.Select(t => t.ToDto()).ToList(),

--- a/src/MyAccountingApp.Application/DTOs/DtoMapper.cs
+++ b/src/MyAccountingApp.Application/DTOs/DtoMapper.cs
@@ -46,6 +46,7 @@ public static class DtoMapper
         new(
             result.Transactions.Select(t => t.ToDto()).ToList(),
             result.AssetTransactions.Select(at => at.ToDto()).ToList(),
+            result.OptionTransactions.Select(o => o.ToDto()).ToList(),
             result.Errors,
             result.ValidationErrors,
             result.ValidationWarnings,

--- a/src/MyAccountingApp.Application/DTOs/ImportResultDto.cs
+++ b/src/MyAccountingApp.Application/DTOs/ImportResultDto.cs
@@ -5,6 +5,7 @@ namespace MyAccountingApp.Application.DTOs;
 public record ImportResultDto(
     List<TransactionDto> Transactions,
     List<AssetTransactionDto> AssetTransactions,
+    List<OptionTransactionDto> OptionTransactions,
     List<string> Errors,
     List<ValidationError> ValidationErrors,
     List<ValidationError> ValidationWarnings,

--- a/src/MyAccountingApp.Application/DTOs/OptionTransactionDto.cs
+++ b/src/MyAccountingApp.Application/DTOs/OptionTransactionDto.cs
@@ -1,0 +1,11 @@
+namespace MyAccountingApp.Application.DTOs;
+
+public record OptionTransactionDto(
+    Guid Id,
+    DateTime Date,
+    string Description,
+    string Symbol,
+    string Isin,
+    decimal Quantity,
+    MoneyDto Premium,
+    string Type);

--- a/src/MyAccountingApp.Application/Interfaces/IImportService.cs
+++ b/src/MyAccountingApp.Application/Interfaces/IImportService.cs
@@ -11,6 +11,7 @@ public class ImportResult
 {
     public List<Transaction> Transactions { get; init; } = new();
     public List<AssetTransaction> AssetTransactions { get; init; } = new();
+    public List<OptionTransaction> OptionTransactions { get; init; } = new();
     public List<string> Errors { get; init; } = new();
     public List<ValidationError> ValidationErrors { get; init; } = new();
     public List<ValidationError> ValidationWarnings { get; init; } = new();

--- a/src/MyAccountingApp.Application/Services/ImportService.cs
+++ b/src/MyAccountingApp.Application/Services/ImportService.cs
@@ -13,6 +13,7 @@ public class ImportService : IImportService
     private readonly IBrokerImportService _broker;
     private readonly ITransactionRepository _transactionRepo;
     private readonly IPortfolioRepository _portfolioRepo;
+    private readonly IOptionTransactionRepository _optionRepo;
     private readonly ITransactionValidator _validator;
     private readonly ILogger<ImportService> _logger;
 
@@ -20,12 +21,14 @@ public class ImportService : IImportService
         IBrokerImportService broker,
         ITransactionRepository transactionRepo,
         IPortfolioRepository portfolioRepo,
+        IOptionTransactionRepository optionRepo,
         ITransactionValidator validator,
         ILogger<ImportService> logger)
     {
         this._broker = broker ?? throw new ArgumentNullException(nameof(broker));
         this._transactionRepo = transactionRepo ?? throw new ArgumentNullException(nameof(transactionRepo));
         this._portfolioRepo = portfolioRepo ?? throw new ArgumentNullException(nameof(portfolioRepo));
+        this._optionRepo = optionRepo ?? throw new ArgumentNullException(nameof(optionRepo));
         this._validator = validator ?? throw new ArgumentNullException(nameof(validator));
         this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -38,6 +41,7 @@ public class ImportService : IImportService
         // each time and times out HttpClient (~100s) on ~2k-row imports.
         List<Domain.Entities.Transaction> pendingTransactions = new List<Domain.Entities.Transaction>();
         List<Domain.Entities.AssetTransaction> pendingAssets = new List<Domain.Entities.AssetTransaction>();
+        List<Domain.Entities.OptionTransaction> pendingOptions = new List<Domain.Entities.OptionTransaction>();
 
         foreach (string folderPath in folderPaths)
         {
@@ -75,7 +79,7 @@ public class ImportService : IImportService
                     }
                     else
                     {
-                        (IEnumerable<Domain.Entities.Transaction> transactions, IEnumerable<Domain.Entities.AssetTransaction> assetTransactions) =
+                        (IEnumerable<Domain.Entities.Transaction> transactions, IEnumerable<Domain.Entities.AssetTransaction> assetTransactions, IEnumerable<Domain.Entities.OptionTransaction> optionTransactions) =
                             await this._broker.ParseAllAsync(csvFile);
 
                         foreach (Domain.Entities.Transaction tx in transactions)
@@ -100,8 +104,14 @@ public class ImportService : IImportService
                             }
                         }
 
+                        foreach (Domain.Entities.OptionTransaction tx in optionTransactions)
+                        {
+                            pendingOptions.Add(tx);
+                        }
+
                         result.Transactions.AddRange(transactions);
                         result.AssetTransactions.AddRange(assetTransactions);
+                        result.OptionTransactions.AddRange(optionTransactions);
                     }
 
                     result.FilesProcessed++;
@@ -147,13 +157,21 @@ public class ImportService : IImportService
             this._portfolioRepo.Initialize(mergedAssets);
         }
 
+        if (pendingOptions.Count > 0)
+        {
+            List<Domain.Entities.OptionTransaction> mergedOptions = this._optionRepo.GetAll().ToList();
+            mergedOptions.AddRange(pendingOptions);
+            this._optionRepo.Initialize(mergedOptions);
+        }
+
         int matchedPairs = this.MatchTransferPairs();
 
         this._logger.LogInformation(
-            "Import completed: {FilesProcessed} files, {Transactions} transactions, {AssetTransactions} asset transactions, {Matches} transfer pairs matched, {Errors} errors",
+            "Import completed: {FilesProcessed} files, {Transactions} transactions, {AssetTransactions} asset transactions, {OptionTransactions} option transactions, {Matches} transfer pairs matched, {Errors} errors",
             result.FilesProcessed,
             result.Transactions.Count,
             result.AssetTransactions.Count,
+            result.OptionTransactions.Count,
             matchedPairs,
             result.Errors.Count);
 

--- a/src/MyAccountingApp.ConsoleApp/Program.cs
+++ b/src/MyAccountingApp.ConsoleApp/Program.cs
@@ -43,6 +43,7 @@ string[] folderPaths = new string[]
 
 List<Transaction> allTransactions = new List<Transaction>();
 List<AssetTransaction> allAssetTransactions = new List<AssetTransaction>();
+List<OptionTransaction> allOptionTransactions = new List<OptionTransaction>();
 
 foreach (string folderPath in folderPaths)
 {
@@ -65,9 +66,10 @@ foreach (string folderPath in folderPaths)
         }
         else
         {
-            (IEnumerable<Transaction> transactions, IEnumerable<AssetTransaction> assetTransactions) = await ibAgent.ParseAllAsync(csvFile);
+            (IEnumerable<Transaction> transactions, IEnumerable<AssetTransaction> assetTransactions, IEnumerable<OptionTransaction> optionTransactions) = await ibAgent.ParseAllAsync(csvFile);
             allTransactions.AddRange(transactions);
             allAssetTransactions.AddRange(assetTransactions);
+            allOptionTransactions.AddRange(optionTransactions);
         }
     }
 }
@@ -102,7 +104,7 @@ else
     }
 }
 
-Console.WriteLine($"\nTotal: {allTransactions.Count} transactions, {allAssetTransactions.Count} asset transactions");
+Console.WriteLine($"\nTotal: {allTransactions.Count} transactions, {allAssetTransactions.Count} asset transactions, {allOptionTransactions.Count} option transactions");
 
 YahooMarketPriceService priceService = new YahooMarketPriceService();
 

--- a/src/MyAccountingApp.Core/Agents/InteractiveBrokersImportService.cs
+++ b/src/MyAccountingApp.Core/Agents/InteractiveBrokersImportService.cs
@@ -27,7 +27,7 @@ public class InteractiveBrokersImportService : IBrokerImportService
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions)> ParseAllAsync(
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
         string filePath,
         CancellationToken cancellationToken = default)
     {
@@ -69,7 +69,7 @@ public class InteractiveBrokersImportService : IBrokerImportService
             transactions.Count,
             assetTransactions.Count);
 
-        return (transactions, assetTransactions);
+        return (transactions, assetTransactions, Enumerable.Empty<OptionTransaction>());
     }
 
     public async Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(

--- a/src/MyAccountingApp.Core/Repositories/JsonOptionTransactionRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/JsonOptionTransactionRepository.cs
@@ -1,0 +1,69 @@
+namespace MyAccountingApp.Core.Repositories;
+
+using System.Text.Json;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Interfaces;
+
+public class JsonOptionTransactionRepository : IOptionTransactionRepository
+{
+    private readonly string filePath;
+
+    public JsonOptionTransactionRepository(string filePath)
+    {
+        this.filePath = filePath;
+    }
+
+    public IEnumerable<OptionTransaction> GetAll()
+    {
+        if (!File.Exists(this.filePath) || new FileInfo(this.filePath).Length == 0)
+        {
+            return new List<OptionTransaction>();
+        }
+
+        string json = File.ReadAllText(this.filePath);
+        return JsonSerializer.Deserialize<List<OptionTransaction>>(json) ?? new List<OptionTransaction>();
+    }
+
+    public void Add(OptionTransaction transaction)
+    {
+        List<OptionTransaction> transactions = this.GetAll().ToList();
+        transactions.Add(transaction);
+        this.WriteAll(transactions);
+    }
+
+    public bool Delete(Guid id)
+    {
+        List<OptionTransaction> transactions = this.GetAll().ToList();
+        int removed = transactions.RemoveAll(t => t.Id == id);
+        if (removed > 0)
+        {
+            this.WriteAll(transactions);
+        }
+
+        return removed > 0;
+    }
+
+    public int DeleteByYear(int year)
+    {
+        List<OptionTransaction> transactions = this.GetAll().ToList();
+        int removed = transactions.RemoveAll(t => t.Date.Year == year);
+        if (removed > 0)
+        {
+            this.WriteAll(transactions);
+        }
+
+        return removed;
+    }
+
+    private void WriteAll(List<OptionTransaction> transactions)
+    {
+        string? dir = Path.GetDirectoryName(this.filePath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        string json = JsonSerializer.Serialize(transactions, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(this.filePath, json);
+    }
+}

--- a/src/MyAccountingApp.Core/Repositories/JsonOptionTransactionRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/JsonOptionTransactionRepository.cs
@@ -55,6 +55,11 @@ public class JsonOptionTransactionRepository : IOptionTransactionRepository
         return removed;
     }
 
+    public void Initialize(IEnumerable<OptionTransaction> transactions)
+    {
+        this.WriteAll(transactions.ToList());
+    }
+
     private void WriteAll(List<OptionTransaction> transactions)
     {
         string? dir = Path.GetDirectoryName(this.filePath);

--- a/src/MyAccountingApp.Core/Services/AssetTransactionCsvImportService.cs
+++ b/src/MyAccountingApp.Core/Services/AssetTransactionCsvImportService.cs
@@ -15,7 +15,7 @@ using MyAccountingApp.Domain.ValueObjects;
 
 public class AssetTransactionCsvImportService : IBrokerImportService
 {
-    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions)> ParseAllAsync(
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
         string filePath,
         CancellationToken cancellationToken = default)
     {
@@ -65,7 +65,7 @@ public class AssetTransactionCsvImportService : IBrokerImportService
             }
         }
 
-        return (Array.Empty<Transaction>(), assetTransactions);
+        return (Array.Empty<Transaction>(), assetTransactions, Enumerable.Empty<OptionTransaction>());
     }
 
     public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(

--- a/src/MyAccountingApp.Core/Services/BankCsvImportService.cs
+++ b/src/MyAccountingApp.Core/Services/BankCsvImportService.cs
@@ -62,7 +62,7 @@ public class BankCsvImportService : IBrokerImportService
         return fields;
     }
 
-    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions)> ParseAllAsync(
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
         string filePath,
         CancellationToken cancellationToken = default)
     {
@@ -111,7 +111,7 @@ public class BankCsvImportService : IBrokerImportService
             }
         }
 
-        return (transactions, Array.Empty<AssetTransaction>());
+        return (transactions, Array.Empty<AssetTransaction>(), Enumerable.Empty<OptionTransaction>());
     }
 
     public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(

--- a/src/MyAccountingApp.Core/Services/BrokerImportDispatcher.cs
+++ b/src/MyAccountingApp.Core/Services/BrokerImportDispatcher.cs
@@ -36,7 +36,7 @@ public class BrokerImportDispatcher : IBrokerImportService
         this.degiroTransactionService = degiroTransactionService ?? throw new ArgumentNullException(nameof(degiroTransactionService));
     }
 
-    public Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions)> ParseAllAsync(
+    public Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
         string filePath,
         CancellationToken cancellationToken = default)
     {

--- a/src/MyAccountingApp.Core/Services/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroImportService.cs
@@ -14,7 +14,7 @@ using MyAccountingApp.Domain.ValueObjects;
 
 public class DegiroImportService : IBrokerImportService
 {
-    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions)> ParseAllAsync(
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
         string filePath,
         CancellationToken cancellationToken = default)
     {
@@ -65,7 +65,7 @@ public class DegiroImportService : IBrokerImportService
             }
         }
 
-        return (transactions, assetTransactions);
+        return (transactions, assetTransactions, Enumerable.Empty<OptionTransaction>());
     }
 
     public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(

--- a/src/MyAccountingApp.Core/Services/DegiroTransactionImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroTransactionImportService.cs
@@ -14,7 +14,7 @@ using MyAccountingApp.Domain.ValueObjects;
 
 public partial class DegiroTransactionImportService : IBrokerImportService
 {
-    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions)> ParseAllAsync(
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
         string filePath,
         CancellationToken cancellationToken = default)
     {
@@ -22,6 +22,7 @@ public partial class DegiroTransactionImportService : IBrokerImportService
 
         string[] lines = await File.ReadAllLinesAsync(filePath, cancellationToken);
         List<AssetTransaction> assetTransactions = new();
+        List<OptionTransaction> optionTransactions = new();
 
         foreach (string line in lines.Skip(1))
         {
@@ -43,11 +44,6 @@ public partial class DegiroTransactionImportService : IBrokerImportService
                 string isin = fields[3];
                 string exchange = fields[4];
 
-                if (string.Equals(exchange, "MEF", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
                 int rawQuantity = int.Parse(fields[6], NumberStyles.Any, CultureInfo.InvariantCulture);
                 decimal amount = ParseEuropeanDecimal(fields[9]);
                 string currency = NormalizeCurrency(fields[8]);
@@ -57,15 +53,27 @@ public partial class DegiroTransactionImportService : IBrokerImportService
                     continue;
                 }
 
+                if (string.Equals(exchange, "MEF", StringComparison.OrdinalIgnoreCase))
+                {
+                    bool premiumReceived = amount > 0;
+                    string symbol = ExtractSymbol(producto, isin);
+                    AssetTransactionType optionType = premiumReceived ? AssetTransactionType.Sell : AssetTransactionType.Buy;
+                    Money premium = new Money(Math.Abs(amount), currency);
+                    OptionTransaction optionTx = new OptionTransaction(
+                        date, producto, symbol, isin, Math.Abs(rawQuantity), premium, optionType);
+                    optionTransactions.Add(optionTx);
+                    continue;
+                }
+
                 int quantity = Math.Abs(rawQuantity);
                 bool isBuy = amount < 0;
-                string symbol = ExtractSymbol(producto, isin);
+                string assetSymbol = ExtractSymbol(producto, isin);
                 AssetTransactionType type = isBuy ? AssetTransactionType.Buy : AssetTransactionType.Sell;
                 TransactionCategory category = isBuy ? TransactionCategory.EXPENSE : TransactionCategory.INCOME;
 
                 Money money = new Money(Math.Abs(amount), currency);
                 Transaction transaction = new Transaction(date, producto, money, category);
-                AssetTransaction assetTx = new AssetTransaction(transaction, symbol, quantity, type);
+                AssetTransaction assetTx = new AssetTransaction(transaction, assetSymbol, quantity, type);
                 assetTransactions.Add(assetTx);
             }
             catch
@@ -73,7 +81,7 @@ public partial class DegiroTransactionImportService : IBrokerImportService
             }
         }
 
-        return (Array.Empty<Transaction>(), assetTransactions);
+        return (Array.Empty<Transaction>(), assetTransactions, optionTransactions);
     }
 
     public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(

--- a/src/MyAccountingApp.Domain/Entities/OptionTransaction.cs
+++ b/src/MyAccountingApp.Domain/Entities/OptionTransaction.cs
@@ -1,0 +1,84 @@
+namespace MyAccountingApp.Domain.Entities;
+
+using System.Text.Json.Serialization;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.ValueObjects;
+
+public class OptionTransaction
+{
+    public Guid Id { get; private set; }
+
+    public DateTime Date { get; private set; }
+
+    public string Description { get; private set; }
+
+    public string Symbol { get; private set; }
+
+    public string Isin { get; private set; }
+
+    public decimal Quantity { get; private set; }
+
+    public Money Premium { get; private set; }
+
+    public AssetTransactionType Type { get; private set; }
+
+    public OptionTransaction(
+        DateTime date,
+        string description,
+        string symbol,
+        string isin,
+        decimal quantity,
+        Money premium,
+        AssetTransactionType type)
+    {
+        Id = Guid.NewGuid();
+        Date = date;
+        Description = description;
+        Symbol = symbol;
+        Isin = isin;
+        Quantity = quantity < 0 ? -quantity : quantity;
+        Premium = premium;
+        Type = type;
+
+        Validate();
+    }
+
+    [JsonConstructor]
+    public OptionTransaction(
+        Guid id,
+        DateTime date,
+        string description,
+        string symbol,
+        string isin,
+        decimal quantity,
+        Money premium,
+        AssetTransactionType type)
+    {
+        Id = id;
+        Date = date;
+        Description = description;
+        Symbol = symbol;
+        Isin = isin;
+        Quantity = quantity;
+        Premium = premium;
+        Type = type;
+    }
+
+    private void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(Symbol))
+        {
+            throw new ArgumentException("Symbol cannot be null or empty.");
+        }
+
+        if (Quantity <= 0)
+        {
+            throw new ArgumentException("Quantity must be greater than zero.");
+        }
+
+        if (Premium.Amount <= 0)
+        {
+            throw new ArgumentException("Premium amount must be greater than zero.");
+        }
+    }
+}

--- a/src/MyAccountingApp.Domain/Interfaces/IBrokerImportService.cs
+++ b/src/MyAccountingApp.Domain/Interfaces/IBrokerImportService.cs
@@ -4,7 +4,7 @@ namespace MyAccountingApp.Domain.Interfaces;
 
 public interface IBrokerImportService
 {
-    Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions)> ParseAllAsync(
+    Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
         string filePath,
         CancellationToken cancellationToken = default);
 

--- a/src/MyAccountingApp.Domain/Interfaces/IOptionTransactionRepository.cs
+++ b/src/MyAccountingApp.Domain/Interfaces/IOptionTransactionRepository.cs
@@ -11,4 +11,6 @@ public interface IOptionTransactionRepository
     bool Delete(Guid id);
 
     int DeleteByYear(int year);
+
+    void Initialize(IEnumerable<OptionTransaction> transactions);
 }

--- a/src/MyAccountingApp.Domain/Interfaces/IOptionTransactionRepository.cs
+++ b/src/MyAccountingApp.Domain/Interfaces/IOptionTransactionRepository.cs
@@ -1,0 +1,14 @@
+using MyAccountingApp.Domain.Entities;
+
+namespace MyAccountingApp.Domain.Interfaces;
+
+public interface IOptionTransactionRepository
+{
+    IEnumerable<OptionTransaction> GetAll();
+
+    void Add(OptionTransaction transaction);
+
+    bool Delete(Guid id);
+
+    int DeleteByYear(int year);
+}

--- a/tests/MyAccountingApp.Application.Tests/Services/ImportServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ImportServiceTests.cs
@@ -18,7 +18,7 @@ public class ImportServiceTests
         FakePfRepo pfRepo = new();
         TransactionValidator validator = new();
         FakeLogger<ImportService> logger = new();
-        ImportService service = new(broker, txRepo, pfRepo, validator, logger);
+        ImportService service = new(broker, txRepo, pfRepo, new FakeOptionRepo(), validator, logger);
 
         ImportResult result = await service.ImportFromFoldersAsync(new[] { "/nonexistent/path" });
 
@@ -50,7 +50,7 @@ public class ImportServiceTests
         FakePfRepo pfRepo = new();
         TransactionValidator validator = new();
         FakeLogger<ImportService> logger = new();
-        ImportService service = new(broker, txRepo, pfRepo, validator, logger);
+        ImportService service = new(broker, txRepo, pfRepo, new FakeOptionRepo(), validator, logger);
 
         ImportResult result = await service.ImportFromFoldersAsync(new[] { dir });
 
@@ -83,7 +83,7 @@ public class ImportServiceTests
         FakePfRepo pfRepo = new();
         TransactionValidator validator = new();
         FakeLogger<ImportService> logger = new();
-        ImportService service = new(broker, txRepo, pfRepo, validator, logger);
+        ImportService service = new(broker, txRepo, pfRepo, new FakeOptionRepo(), validator, logger);
 
         ImportResult result = await service.ImportFromFoldersAsync(new[] { dir });
 
@@ -114,7 +114,7 @@ public class ImportServiceTests
         FakePfRepo pfRepo = new();
         TransactionValidator validator = new();
         FakeLogger<ImportService> logger = new();
-        ImportService service = new(broker, txRepo, pfRepo, validator, logger);
+        ImportService service = new(broker, txRepo, pfRepo, new FakeOptionRepo(), validator, logger);
 
         ImportResult result = await service.ImportFromFoldersAsync(new[] { dir });
 
@@ -136,7 +136,7 @@ public class ImportServiceTests
         FakePfRepo pfRepo = new();
         TransactionValidator validator = new();
         FakeLogger<ImportService> logger = new();
-        ImportService service = new(broker, txRepo, pfRepo, validator, logger);
+        ImportService service = new(broker, txRepo, pfRepo, new FakeOptionRepo(), validator, logger);
 
         ImportResult result = await service.ImportFromFoldersAsync(new[] { dir });
 
@@ -173,7 +173,7 @@ public class ImportServiceTests
         FakePfRepo pfRepo = new();
         TransactionValidator validator = new();
         FakeLogger<ImportService> logger = new();
-        ImportService service = new(broker, txRepo, pfRepo, validator, logger);
+        ImportService service = new(broker, txRepo, pfRepo, new FakeOptionRepo(), validator, logger);
 
         ImportResult result = await service.ImportFromFoldersAsync(new[] { dir });
 
@@ -210,7 +210,7 @@ public class ImportServiceTests
         FakePfRepo pfRepo = new();
         TransactionValidator validator = new();
         FakeLogger<ImportService> logger = new();
-        ImportService service = new(broker, txRepo, pfRepo, validator, logger);
+        ImportService service = new(broker, txRepo, pfRepo, new FakeOptionRepo(), validator, logger);
 
         ImportResult result = await service.ImportFromFoldersAsync(new[] { dir });
 
@@ -231,9 +231,10 @@ public class ImportServiceTests
     {
         public IEnumerable<Transaction> Transactions { get; set; } = Array.Empty<Transaction>();
         public IEnumerable<AssetTransaction> AssetTransactions { get; set; } = Array.Empty<AssetTransaction>();
+        public IEnumerable<OptionTransaction> OptionTransactions { get; set; } = Array.Empty<OptionTransaction>();
         public bool ThrowOnParse { get; set; }
 
-        public Task<(IEnumerable<Transaction>, IEnumerable<AssetTransaction>)> ParseAllAsync(
+        public Task<(IEnumerable<Transaction>, IEnumerable<AssetTransaction>, IEnumerable<OptionTransaction>)> ParseAllAsync(
             string filePath, CancellationToken cancellationToken = default)
         {
             if (this.ThrowOnParse)
@@ -241,7 +242,7 @@ public class ImportServiceTests
                 throw new InvalidOperationException("Broker error");
             }
 
-            return Task.FromResult((this.Transactions, this.AssetTransactions));
+            return Task.FromResult((this.Transactions, this.AssetTransactions, this.OptionTransactions));
         }
 
         public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(
@@ -303,5 +304,21 @@ public class ImportServiceTests
 
         public bool Delete(Guid transactionId) => true;
         public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
+    }
+
+    private sealed class FakeOptionRepo : IOptionTransactionRepository
+    {
+        private readonly List<OptionTransaction> _transactions = new();
+
+        public void Add(OptionTransaction tx) => this._transactions.Add(tx);
+        public IEnumerable<OptionTransaction> GetAll() => this._transactions;
+        public void Initialize(IEnumerable<OptionTransaction> transactions)
+        {
+            this._transactions.Clear();
+            this._transactions.AddRange(transactions);
+        }
+
+        public bool Delete(Guid id) => true;
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Date.Year == year);
     }
 }

--- a/tests/MyAccountingApp.Core.Tests/Agents/InteractiveBrokersImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Agents/InteractiveBrokersImportServiceTests.cs
@@ -54,7 +54,7 @@ public class InteractiveBrokersImportServiceTests
             .Setup(p => p.ParseIBKRAsync(It.IsAny<string>()))
             .ReturnsAsync(records);
 
-        (IEnumerable<Transaction> transactions, IEnumerable<AssetTransaction> assetTransactions) =
+        (IEnumerable<Transaction> transactions, IEnumerable<AssetTransaction> assetTransactions, IEnumerable<OptionTransaction> optionTransactions) =
             await this.agent.ParseAllAsync("test.csv");
 
         Assert.Empty(transactions);
@@ -94,7 +94,7 @@ public class InteractiveBrokersImportServiceTests
             .Setup(p => p.ParseIBKRAsync(It.IsAny<string>()))
             .ReturnsAsync(records);
 
-        (IEnumerable<Transaction> transactions, IEnumerable<AssetTransaction> assetTransactions) =
+        (IEnumerable<Transaction> transactions, IEnumerable<AssetTransaction> assetTransactions, IEnumerable<OptionTransaction> optionTransactions) =
             await this.agent.ParseAllAsync("test.csv");
 
         Assert.Empty(assetTransactions);
@@ -108,7 +108,7 @@ public class InteractiveBrokersImportServiceTests
             .Setup(p => p.ParseIBKRAsync(It.IsAny<string>()))
             .ReturnsAsync(new List<IBKRTransactionRecord>());
 
-        (IEnumerable<Transaction> transactions, IEnumerable<AssetTransaction> assetTransactions) =
+        (IEnumerable<Transaction> transactions, IEnumerable<AssetTransaction> assetTransactions, IEnumerable<OptionTransaction> optionTransactions) =
             await this.agent.ParseAllAsync("test.csv");
 
         Assert.Empty(transactions);
@@ -196,7 +196,7 @@ public class InteractiveBrokersImportServiceTests
             .Setup(p => p.ParseIBKRAsync(It.IsAny<string>()))
             .ReturnsAsync(records);
 
-        (IEnumerable<Transaction> transactions, IEnumerable<AssetTransaction> assetTransactions) =
+        (IEnumerable<Transaction> transactions, IEnumerable<AssetTransaction> assetTransactions, IEnumerable<OptionTransaction> optionTransactions) =
             await this.agent.ParseAllAsync("test.csv");
 
         Assert.Single(transactions);

--- a/tests/MyAccountingApp.Core.Tests/Services/AssetTransactionCsvImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/AssetTransactionCsvImportServiceTests.cs
@@ -21,7 +21,7 @@ public class AssetTransactionCsvImportServiceTests
             await File.WriteAllTextAsync(file, csv);
 
             AssetTransactionCsvImportService service = new();
-            var (transactions, assetTransactions) = await service.ParseAllAsync(file);
+            var (transactions, assetTransactions, _) = await service.ParseAllAsync(file);
 
             Assert.Empty(transactions);
             Assert.Equal(2, assetTransactions.Count());
@@ -44,7 +44,7 @@ public class AssetTransactionCsvImportServiceTests
             await File.WriteAllTextAsync(file, csv);
 
             AssetTransactionCsvImportService service = new();
-            var (_, assetTransactions) = await service.ParseAllAsync(file);
+            var (_, assetTransactions, _) = await service.ParseAllAsync(file);
 
             var atx = Assert.Single(assetTransactions);
             Assert.Equal("COBAS_SELECCION", atx.Symbol);
@@ -72,7 +72,7 @@ public class AssetTransactionCsvImportServiceTests
             await File.WriteAllTextAsync(file, csv);
 
             AssetTransactionCsvImportService service = new();
-            var (_, assetTransactions) = await service.ParseAllAsync(file);
+            var (_, assetTransactions, _) = await service.ParseAllAsync(file);
 
             var atx = Assert.Single(assetTransactions);
             Assert.Equal("ES9876543210", atx.Symbol);
@@ -98,7 +98,7 @@ public class AssetTransactionCsvImportServiceTests
             await File.WriteAllTextAsync(file, csv);
 
             AssetTransactionCsvImportService service = new();
-            var (transactions, assetTransactions) = await service.ParseAllAsync(file);
+            var (transactions, assetTransactions, _) = await service.ParseAllAsync(file);
 
             Assert.Empty(transactions);
             Assert.Empty(assetTransactions);
@@ -121,7 +121,7 @@ public class AssetTransactionCsvImportServiceTests
             await File.WriteAllTextAsync(file, csv);
 
             AssetTransactionCsvImportService service = new();
-            var (_, assetTransactions) = await service.ParseAllAsync(file);
+            var (_, assetTransactions, _) = await service.ParseAllAsync(file);
 
             var atx = Assert.Single(assetTransactions);
             Assert.Equal(Domain.Enums.TransactionCategory.TRANSFER, atx.Transaction.Category);
@@ -145,7 +145,7 @@ public class AssetTransactionCsvImportServiceTests
             await File.WriteAllTextAsync(file, csv);
 
             AssetTransactionCsvImportService service = new();
-            var (_, assetTransactions) = await service.ParseAllAsync(file);
+            var (_, assetTransactions, _) = await service.ParseAllAsync(file);
 
             var atx = Assert.Single(assetTransactions);
             Assert.Equal(100m, atx.Transaction.Money.Amount);

--- a/tests/MyAccountingApp.Core.Tests/Services/BankCsvImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BankCsvImportServiceTests.cs
@@ -22,7 +22,7 @@ public class BankCsvImportServiceTests
             await File.WriteAllTextAsync(file, csv);
 
             BankCsvImportService service = new();
-            var (transactions, assetTransactions) = await service.ParseAllAsync(file);
+            var (transactions, assetTransactions, _) = await service.ParseAllAsync(file);
 
             Assert.Equal(3, transactions.Count());
             Assert.Empty(assetTransactions);
@@ -45,7 +45,7 @@ public class BankCsvImportServiceTests
             await File.WriteAllTextAsync(file, csv);
 
             BankCsvImportService service = new();
-            var (transactions, _) = await service.ParseAllAsync(file);
+            var (transactions, _, _) = await service.ParseAllAsync(file);
 
             var tx = Assert.Single(transactions);
             Assert.Equal(new DateTime(2019, 6, 15), tx.Date);
@@ -72,7 +72,7 @@ public class BankCsvImportServiceTests
             await File.WriteAllTextAsync(file, csv);
 
             BankCsvImportService service = new();
-            var (transactions, _) = await service.ParseAllAsync(file);
+            var (transactions, _, _) = await service.ParseAllAsync(file);
 
             var tx = Assert.Single(transactions);
             Assert.Equal("R/ TELEFONICA DE ESPANA, S. A. U.", tx.Description);
@@ -96,7 +96,7 @@ public class BankCsvImportServiceTests
             await File.WriteAllTextAsync(file, csv);
 
             BankCsvImportService service = new();
-            var (transactions, _) = await service.ParseAllAsync(file);
+            var (transactions, _, _) = await service.ParseAllAsync(file);
 
             Assert.All(transactions, tx => Assert.Equal(Domain.Enums.TransactionCategory.INCOME, tx.Category));
         }
@@ -119,7 +119,7 @@ public class BankCsvImportServiceTests
             await File.WriteAllTextAsync(file, csv);
 
             BankCsvImportService service = new();
-            var (transactions, _) = await service.ParseAllAsync(file);
+            var (transactions, _, _) = await service.ParseAllAsync(file);
 
             var list = transactions.ToList();
             Assert.Equal(Domain.Enums.TransactionCategory.TRANSFER, list[0].Category);
@@ -142,7 +142,7 @@ public class BankCsvImportServiceTests
             await File.WriteAllTextAsync(file, csv);
 
             BankCsvImportService service = new();
-            var (transactions, _) = await service.ParseAllAsync(file);
+            var (transactions, _, _) = await service.ParseAllAsync(file);
 
             Assert.Empty(transactions);
         }

--- a/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
@@ -21,7 +21,7 @@ public class BrokerImportDispatcherTests
             await File.WriteAllTextAsync(file, csv);
             BrokerImportDispatcher dispatcher = CreateDispatcher();
 
-            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.NotEmpty(assets);
@@ -42,7 +42,7 @@ public class BrokerImportDispatcherTests
             await File.WriteAllTextAsync(file, csv);
             BrokerImportDispatcher dispatcher = CreateDispatcher();
 
-            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
 
             Assert.NotEmpty(txs);
             Assert.Empty(assets);
@@ -63,7 +63,7 @@ public class BrokerImportDispatcherTests
             await File.WriteAllTextAsync(file, csv);
             BrokerImportDispatcher dispatcher = CreateDispatcher();
 
-            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
 
             Assert.NotEmpty(txs);
             Assert.Empty(assets);
@@ -84,7 +84,7 @@ public class BrokerImportDispatcherTests
             await File.WriteAllTextAsync(file, csv);
             BrokerImportDispatcher dispatcher = CreateDispatcher();
 
-            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.NotEmpty(assets);
@@ -105,7 +105,7 @@ public class BrokerImportDispatcherTests
             await File.WriteAllTextAsync(file, csv);
             BrokerImportDispatcher dispatcher = CreateDispatcher();
 
-            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
@@ -134,7 +134,7 @@ public class BrokerImportDispatcherTests
             await File.WriteAllTextAsync(file, csv);
             BrokerImportDispatcher dispatcher = CreateDispatcher();
 
-            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
@@ -155,7 +155,7 @@ public class BrokerImportDispatcherTests
             await File.WriteAllTextAsync(file, csv);
             BrokerImportDispatcher dispatcher = CreateDispatcher();
 
-            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
@@ -176,7 +176,7 @@ public class BrokerImportDispatcherTests
             await File.WriteAllTextAsync(file, csv);
             BrokerImportDispatcher dispatcher = CreateDispatcher();
 
-            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.NotEmpty(assets);
@@ -199,7 +199,7 @@ public class BrokerImportDispatcherTests
             await File.WriteAllTextAsync(file, csv);
             BrokerImportDispatcher dispatcher = CreateDispatcher();
 
-            var (txs, assets) = await dispatcher.ParseAllAsync(file);
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);

--- a/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
@@ -20,7 +20,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
@@ -41,7 +41,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
@@ -63,7 +63,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(assets);
             Assert.Equal(2, txs.Count());
@@ -87,7 +87,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
@@ -106,7 +106,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
@@ -127,7 +127,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(assets);
             var t = Assert.Single(txs);
@@ -150,7 +150,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
@@ -171,7 +171,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(assets);
             var t = Assert.Single(txs);
@@ -195,7 +195,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(assets);
             var t = Assert.Single(txs);
@@ -218,7 +218,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
@@ -239,7 +239,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(assets);
             var t = Assert.Single(txs);
@@ -262,7 +262,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
@@ -283,7 +283,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
@@ -304,7 +304,7 @@ public class DegiroImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(assets);
             var t = Assert.Single(txs);

--- a/tests/MyAccountingApp.Core.Tests/Services/DegiroTransactionImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/DegiroTransactionImportServiceTests.cs
@@ -20,7 +20,7 @@ public class DegiroTransactionImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             var a = Assert.Single(assets);
@@ -46,7 +46,7 @@ public class DegiroTransactionImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             var a = Assert.Single(assets);
@@ -72,7 +72,7 @@ public class DegiroTransactionImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             var a = Assert.Single(assets);
@@ -97,7 +97,7 @@ public class DegiroTransactionImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             var a = Assert.Single(assets);
@@ -118,7 +118,7 @@ public class DegiroTransactionImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
@@ -139,7 +139,7 @@ public class DegiroTransactionImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             var a = Assert.Single(assets);
@@ -165,10 +165,15 @@ public class DegiroTransactionImportServiceTests
         try
         {
             await File.WriteAllTextAsync(file, csv);
-            var (txs, assets) = await this.service.ParseAllAsync(file);
+            var (txs, assets, options) = await this.service.ParseAllAsync(file);
 
             Assert.Empty(txs);
             Assert.Empty(assets);
+            var a = Assert.Single(options);
+            Assert.Equal("REE", a.Symbol);
+            Assert.Equal(1, a.Quantity);
+            Assert.Equal(15, a.Premium.Amount);
+            Assert.Equal(Domain.Enums.AssetTransactionType.Sell, a.Type);
         }
         finally
         {


### PR DESCRIPTION
## Summary
Adds full OptionTransaction support alongside the existing AssetTransaction flow.

### What's new
- OptionTransaction entity - stores option trades (symbol, ISIN, quantity, premium, type)
- IOptionTransactionRepository + JsonOptionTransactionRepository - persists to data/options.json
- API endpoints: GET /api/option-transactions, GET /api/option-transactions/{symbol}, DELETE /api/option-transactions/year/{year}, GET /api/option-transactions/year/{year}/count
- Import integration: DegiroTransactionImportService now creates OptionTransaction for MEF (options) exchange entries instead of skipping them
- IBrokerImportService return type expanded to include IEnumerable<OptionTransaction> as third tuple element
- ImportResult + ImportService persist option transactions via IOptionTransactionRepository
- 186 tests pass (existing tests updated + new option assertions)