### PR TITLE
fix: Processed Flatex Withdrawal classified as TRANSFER instead of skipped

### DIFF
--- a/src/MyAccountingApp.Core/Services/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/DegiroImportService.cs
@@ -202,14 +202,14 @@ public class DegiroImportService : IBrokerImportService
 
         if (upper.Contains("FLATEX") || upper.Contains("DEPOSIT"))
         {
-            if (upper.Contains("PROCESSED"))
-            {
-                return null;
-            }
-
             if (upper.Contains("WITHDRAWAL"))
             {
                 return TransactionCategory.TRANSFER;
+            }
+
+            if (upper.Contains("PROCESSED"))
+            {
+                return null;
             }
 
             return TransactionCategory.DEPOSIT;

--- a/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
@@ -209,7 +209,7 @@ public class DegiroImportServiceTests
     }
 
     [Fact]
-    public async Task ParseAllAsync_ProcessedFlatexWithdrawal_Skipped()
+    public async Task ParseAllAsync_ProcessedFlatexWithdrawal_CreatesTransfer()
     {
         string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
             "17-12-2021,10:30,17-12-2021,,,Processed Flatex Withdrawal,,EUR,\"800,00\",EUR,\"8000,00\",\n";
@@ -220,8 +220,10 @@ public class DegiroImportServiceTests
             await File.WriteAllTextAsync(file, csv);
             var (txs, assets, _) = await this.service.ParseAllAsync(file);
 
-            Assert.Empty(txs);
             Assert.Empty(assets);
+            var t = Assert.Single(txs);
+            Assert.Equal(800m, t.Money.Amount);
+            Assert.Equal(Domain.Enums.TransactionCategory.TRANSFER, t.Category);
         }
         finally
         {


### PR DESCRIPTION
Fix: `Processed Flatex Withdrawal` ara es classifica com a TRANSFER en lloc de ser ignorat (null). S'ha reordenat el bloc FLATEX a `ClassifyDescription` per comprovar WITHDRAWAL abans que PROCESSED, ja que `Processed Flatex Withdrawal` és una sortida de diners del compte, no un moviment intern.\n\nTest actualitzat: `ParseAllAsync_ProcessedFlatexWithdrawal_Skipped` → `ParseAllAsync_ProcessedFlatexWithdrawal_CreatesTransfer`