### PR TITLE
feat: add Revolut CSV import support

### DIFF
--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -80,6 +80,7 @@ builder.Services.AddSingleton<BankCsvImportService>();
 builder.Services.AddSingleton<AssetTransactionCsvImportService>();
 builder.Services.AddSingleton<DegiroImportService>();
 builder.Services.AddSingleton<DegiroTransactionImportService>();
+builder.Services.AddSingleton<RevolutImportService>();
 builder.Services.AddSingleton<IBrokerImportService, BrokerImportDispatcher>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/src/MyAccountingApp.Core/Services/BrokerImportDispatcher.cs
+++ b/src/MyAccountingApp.Core/Services/BrokerImportDispatcher.cs
@@ -16,6 +16,7 @@ public class BrokerImportDispatcher : IBrokerImportService
     private const string BankCsvHeader = "Data,Descripcio,Import,Moneda,Source";
     private const string DegiroCsvHeaderPrefix = "Fecha,Hora,Fecha valor";
     private const string DegiroTransactionCsvHeaderPrefix = "Fecha,Hora,Producto,ISIN,Bolsa";
+    private const string RevolutCsvHeaderPrefix = "Type,Product,Started Date";
 
     private readonly InteractiveBrokersImportService ibkrService;
     private readonly BankCsvImportService bankService;
@@ -23,6 +24,7 @@ public class BrokerImportDispatcher : IBrokerImportService
     private readonly DegiroImportService degiroService;
     private readonly DegiroTransactionImportService degiroTransactionService;
     private readonly IBKRFlexQueryImportService flexQueryService;
+    private readonly RevolutImportService revolutService;
 
     public BrokerImportDispatcher(
         InteractiveBrokersImportService ibkrService,
@@ -30,7 +32,8 @@ public class BrokerImportDispatcher : IBrokerImportService
         AssetTransactionCsvImportService assetService,
         DegiroImportService degiroService,
         DegiroTransactionImportService degiroTransactionService,
-        IBKRFlexQueryImportService flexQueryService)
+        IBKRFlexQueryImportService flexQueryService,
+        RevolutImportService revolutService)
     {
         this.ibkrService = ibkrService ?? throw new ArgumentNullException(nameof(ibkrService));
         this.bankService = bankService ?? throw new ArgumentNullException(nameof(bankService));
@@ -38,6 +41,7 @@ public class BrokerImportDispatcher : IBrokerImportService
         this.degiroService = degiroService ?? throw new ArgumentNullException(nameof(degiroService));
         this.degiroTransactionService = degiroTransactionService ?? throw new ArgumentNullException(nameof(degiroTransactionService));
         this.flexQueryService = flexQueryService ?? throw new ArgumentNullException(nameof(flexQueryService));
+        this.revolutService = revolutService ?? throw new ArgumentNullException(nameof(revolutService));
     }
 
     public Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
@@ -100,6 +104,11 @@ public class BrokerImportDispatcher : IBrokerImportService
             if (header.Contains("Ticker", StringComparison.OrdinalIgnoreCase))
             {
                 return this.assetService;
+            }
+
+            if (header.StartsWith(RevolutCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return this.revolutService;
             }
 
             if (header.StartsWith(DegiroTransactionCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))

--- a/src/MyAccountingApp.Core/Services/RevolutImportService.cs
+++ b/src/MyAccountingApp.Core/Services/RevolutImportService.cs
@@ -138,7 +138,7 @@ public class RevolutImportService : IBrokerImportService
 
             if (descUpper.Contains("FROM CUENTA FLEXIBLE"))
             {
-                return TransactionCategory.DEPOSIT;
+                return TransactionCategory.INCOME;
             }
 
             if (amount > 0)

--- a/src/MyAccountingApp.Core/Services/RevolutImportService.cs
+++ b/src/MyAccountingApp.Core/Services/RevolutImportService.cs
@@ -136,22 +136,17 @@ public class RevolutImportService : IBrokerImportService
                 return null;
             }
 
-            if (descUpper.Contains("SAVINGS VAULT TOPUP"))
-            {
-                return TransactionCategory.TRANSFER;
-            }
-
             if (descUpper.Contains("FROM CUENTA FLEXIBLE"))
             {
                 return TransactionCategory.DEPOSIT;
             }
 
-            if (descUpper.Contains("FRANCESC") || descUpper.Contains("GIRBAU"))
+            if (amount > 0)
             {
-                return TransactionCategory.TRANSFER;
+                return TransactionCategory.INCOME;
             }
 
-            return amount > 0 ? TransactionCategory.DEPOSIT : TransactionCategory.TRANSFER;
+            return TransactionCategory.EXPENSE;
         }
 
         return null;

--- a/src/MyAccountingApp.Core/Services/RevolutImportService.cs
+++ b/src/MyAccountingApp.Core/Services/RevolutImportService.cs
@@ -1,0 +1,159 @@
+namespace MyAccountingApp.Core.Services;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+public class RevolutImportService : IBrokerImportService
+{
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        string[] lines = await File.ReadAllLinesAsync(filePath, cancellationToken);
+        List<Transaction> transactions = new();
+
+        foreach (string line in lines.Skip(1))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            try
+            {
+                List<string> fields = BankCsvImportService.ParseCsvLine(line);
+                if (fields.Count < 10)
+                {
+                    continue;
+                }
+
+                string type = fields[0].Trim();
+                string description = fields[4].Trim();
+                string amountStr = fields[5].Trim();
+                string feeStr = fields[6].Trim();
+                string currency = fields[7].Trim();
+                string state = fields[8].Trim();
+
+                if (state != "COMPLETED")
+                {
+                    continue;
+                }
+
+                decimal amount = decimal.Parse(amountStr, NumberStyles.Any, CultureInfo.InvariantCulture);
+                decimal fee = decimal.Parse(feeStr, NumberStyles.Any, CultureInfo.InvariantCulture);
+
+                if (amount == 0 && fee == 0)
+                {
+                    continue;
+                }
+
+                DateTime date = ParseDate(fields[2]);
+
+                TransactionCategory? category = Classify(type, description, amount);
+                if (category is null)
+                {
+                    continue;
+                }
+
+                if (amount != 0)
+                {
+                    Money money = new(Math.Abs(amount), currency);
+                    transactions.Add(new Transaction(date, description, money, category.Value));
+                }
+
+                if (fee > 0)
+                {
+                    Money feeMoney = new(fee, currency);
+                    transactions.Add(new Transaction(date, $"{description} (fee)", feeMoney, TransactionCategory.EXPENSE));
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        return (transactions, Array.Empty<AssetTransaction>(), Enumerable.Empty<OptionTransaction>());
+    }
+
+    public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Enumerable.Empty<AssetTransaction>());
+    }
+
+    private static DateTime ParseDate(string value)
+    {
+        if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date))
+        {
+            return date;
+        }
+
+        return DateTime.Parse(value, CultureInfo.InvariantCulture);
+    }
+
+    private static TransactionCategory? Classify(string type, string description, decimal amount)
+    {
+        string upper = type.ToUpperInvariant();
+
+        if (upper == "DEPOSIT")
+        {
+            return TransactionCategory.DEPOSIT;
+        }
+
+        if (upper == "CARD PAYMENT")
+        {
+            return TransactionCategory.EXPENSE;
+        }
+
+        if (upper == "CARD REFUND")
+        {
+            return TransactionCategory.INCOME;
+        }
+
+        if (upper == "ATM")
+        {
+            return TransactionCategory.EXPENSE;
+        }
+
+        if (upper == "TRANSFER")
+        {
+            string descUpper = description.ToUpperInvariant();
+
+            if (descUpper.Contains("BALANCE MIGRATION"))
+            {
+                return null;
+            }
+
+            if (descUpper.Contains("SAVINGS VAULT TOPUP"))
+            {
+                return TransactionCategory.TRANSFER;
+            }
+
+            if (descUpper.Contains("FROM CUENTA FLEXIBLE"))
+            {
+                return TransactionCategory.DEPOSIT;
+            }
+
+            if (descUpper.Contains("FRANCESC") || descUpper.Contains("GIRBAU"))
+            {
+                return TransactionCategory.TRANSFER;
+            }
+
+            return amount > 0 ? TransactionCategory.DEPOSIT : TransactionCategory.TRANSFER;
+        }
+
+        return null;
+    }
+}

--- a/src/MyAccountingApp.Web/Pages/Import.razor
+++ b/src/MyAccountingApp.Web/Pages/Import.razor
@@ -87,6 +87,34 @@
 </MudPaper>
 
 <MudPaper Class="pa-6 mb-4" Outlined="true">
+    <MudText Typo="Typo.h6" GutterBottom="true">Import Revolut CSV</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Upload a CSV exported from Revolut. Deposits, card payments, ATM withdrawals, and transfers are detected automatically.
+    </MudText>
+    <MudAlert Severity="Severity.Info" Class="mb-4" Dense="true">
+        <strong>Format detected automatically.</strong> Expected columns: Type, Product, Started Date, Completed Date, Description, Amount, Fee, Currency, State, Balance.<br />
+        <strong>Deposits</strong> and <strong>transfers</strong> become cash entries. Fees are handled as separate expense transactions.
+    </MudAlert>
+    <MudGrid>
+        <MudItem xs="12" sm="8">
+            <InputFile OnChange="@OnRevolutFileSelected" accept=".csv" class="mud-input-outlined" />
+        </MudItem>
+        <MudItem xs="12" sm="4" Class="d-flex align-center">
+            <MudButton Variant="Variant.Filled" Color="Color.Tertiary" Size="Size.Large"
+                       OnClick="@UploadRevolutAsync" Disabled="@(_revolutFile is null || _loading)"
+                       StartIcon="@Icons.Material.Filled.FileUpload"
+                       FullWidth="true">
+                Import Revolut
+            </MudButton>
+        </MudItem>
+    </MudGrid>
+    @if (_revolutFile is not null)
+    {
+        <MudText Typo="Typo.body2" Class="mt-2 mud-text-secondary">Selected: @_revolutFile.Name</MudText>
+    }
+</MudPaper>
+
+<MudPaper Class="pa-6 mb-4" Outlined="true">
     <MudText Typo="Typo.h6" GutterBottom="true">Import Raw CSV</MudText>
     <MudText Typo="Typo.body2" Class="mb-4">
         Upload a CSV with your own format. No transformations applied.
@@ -243,6 +271,7 @@
     private IBrowserFile? _rawFile;
     private IBrowserFile? _degiroFile;
     private IBrowserFile? _ibkrFile;
+    private IBrowserFile? _revolutFile;
 
     private void OnFileSelected(InputFileChangeEventArgs args)
     {
@@ -259,6 +288,12 @@
     private void OnDegiroFileSelected(InputFileChangeEventArgs args)
     {
         _degiroFile = args.File;
+        _result = null;
+    }
+
+    private void OnRevolutFileSelected(InputFileChangeEventArgs args)
+    {
+        _revolutFile = args.File;
         _result = null;
     }
 
@@ -319,6 +354,35 @@
         catch (Exception ex)
         {
             Snackbar.Add($"DeGiro import failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task UploadRevolutAsync()
+    {
+        if (_revolutFile is null) return;
+
+        _loading = true;
+        _result = null;
+        _editableSymbols = new();
+        try
+        {
+            using var content = new MultipartFormDataContent();
+            using var stream = _revolutFile.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024);
+            content.Add(new StreamContent(stream), "file", _revolutFile.Name);
+
+            var response = await Http.PostAsync("/api/import/upload", content);
+            _result = await response.Content.ReadFromJsonAsync<ImportResultDto>();
+            InitEditableSymbols();
+            Snackbar.Add("Revolut import completed.", Severity.Success);
+            _revolutFile = null;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Revolut import failed: {ex.Message}", Severity.Error);
         }
         finally
         {

--- a/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
@@ -233,7 +233,7 @@ public class BrokerImportDispatcherTests
     {
         InteractiveBrokersImportService ibkr = new(Parser, new FakeLogger<InteractiveBrokersImportService>());
         IBKRFlexQueryImportService flexQuery = new(Array.Empty<IIBKRStatementAgent>());
-        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService(), new DegiroTransactionImportService(), flexQuery);
+        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService(), new DegiroTransactionImportService(), flexQuery, new RevolutImportService());
     }
 }
 


### PR DESCRIPTION
Nou servei d'import per fitxers CSV de Revolut amb secció dedicada a la UI.\n\n**Format detectat automàticament:** capçalera `Type,Product,Started Date`.\n\n**Classificació:**\n- `Deposit` → DEPOSIT\n- `Card Payment` / `ATM` → EXPENSE\n- `Card Refund` → INCOME\n- `Transfer` → TRANSFER/DEPOSIT segons descripció (Savings Vault, Cuenta flexible, transf. personals)\n- `Balance migration` → skip\n- Files no `COMPLETED` → skip\n- Comissions (Fee column) → transacció EXPENSE separada