### PR TITLE
feat: add Revolut CSV import support

### DIFF
--- a/src/MyAccountingApp.Application/Services/ImportService.cs
+++ b/src/MyAccountingApp.Application/Services/ImportService.cs
@@ -164,17 +164,6 @@ public class ImportService : IImportService
             this._optionRepo.Initialize(mergedOptions);
         }
 
-        int matchedPairs = this.MatchTransferPairs();
-
-        this._logger.LogInformation(
-            "Import completed: {FilesProcessed} files, {Transactions} transactions, {AssetTransactions} asset transactions, {OptionTransactions} option transactions, {Matches} transfer pairs matched, {Errors} errors",
-            result.FilesProcessed,
-            result.Transactions.Count,
-            result.AssetTransactions.Count,
-            result.OptionTransactions.Count,
-            matchedPairs,
-            result.Errors.Count);
-
         return result;
     }
 

--- a/tests/MyAccountingApp.Application.Tests/Services/ImportServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ImportServiceTests.cs
@@ -146,7 +146,7 @@ public class ImportServiceTests
     }
 
     [Fact]
-    public async Task ImportFromFoldersAsync_MatchesTransferPairs()
+    public async Task ImportFromFoldersAsync_DoesNotMatchTransferPairs()
     {
         string dir = CreateTempDir();
         string file = Path.Combine(dir, "tx.csv");
@@ -179,7 +179,8 @@ public class ImportServiceTests
 
         var allTxs = txRepo.GetAll().ToList();
         Assert.Equal(2, allTxs.Count);
-        Assert.All(allTxs, tx => Assert.Equal(TransactionCategory.TRANSFER, tx.Category));
+        Assert.Equal(TransactionCategory.EXPENSE, allTxs[0].Category);
+        Assert.Equal(TransactionCategory.INCOME, allTxs[1].Category);
     }
 
     [Fact]


### PR DESCRIPTION
Nou servei d'import per fitxers CSV de Revolut amb secció dedicada a la UI.

**Format detectat automàticament:** capçalera `Type,Product,Started Date`.

**Classificació:**
- `Deposit` → DEPOSIT
- `Card Payment` / `ATM` → EXPENSE
- `Card Refund` → INCOME
- `Transfer` (outgoing) → EXPENSE
- `Transfer` (incoming) → INCOME
- `From Cuenta flexible` → INCOME
- `Balance migration` → skip
- Files no `COMPLETED` → skip
- Comissions (Fee column) → transacció EXPENSE separada

**Altres canvis:** s'elimina `MatchTransferPairs` que reclassificava EXPENSE/INCOME a TRANSFER si la descripció contenia 'FRANCESC'. Ja no cal amb els import services dedicats.