### PR TITLE
feat: add ABN AMRO CSV import support

### DIFF
--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -81,6 +81,7 @@ builder.Services.AddSingleton<AssetTransactionCsvImportService>();
 builder.Services.AddSingleton<DegiroImportService>();
 builder.Services.AddSingleton<DegiroTransactionImportService>();
 builder.Services.AddSingleton<RevolutImportService>();
+builder.Services.AddSingleton<AbnAmroImportService>();
 builder.Services.AddSingleton<IBrokerImportService, BrokerImportDispatcher>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/src/MyAccountingApp.Core/Services/AbnAmroImportService.cs
+++ b/src/MyAccountingApp.Core/Services/AbnAmroImportService.cs
@@ -1,0 +1,166 @@
+namespace MyAccountingApp.Core.Services;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+public class AbnAmroImportService : IBrokerImportService
+{
+    private static readonly string[] TransferKeywords = { "J.P.MORGAN", "DEGIRO", "INTERACTIVE BROKERS", "REVOLUT" };
+    private static readonly string[] IncomeKeywords = { "SPECTRAL", "TESLA INTERNATIONAL" };
+    private static readonly string[] ExpenseKeywords = { "B GALENDE", "BERTA GALENDE" };
+
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        string[] lines = await File.ReadAllLinesAsync(filePath, cancellationToken);
+        List<Transaction> transactions = new();
+
+        foreach (string line in lines.Skip(1))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            try
+            {
+                List<string> fields = BankCsvImportService.ParseCsvLine(line);
+                if (fields.Count < 8)
+                {
+                    continue;
+                }
+
+                string mutationCode = fields[1].Trim();
+                string description = fields[7].Trim();
+                string dateStr = fields[2].Trim();
+                string amountStr = fields[6].Trim();
+
+                if (string.IsNullOrEmpty(amountStr))
+                {
+                    continue;
+                }
+
+                decimal amount = decimal.Parse(amountStr, NumberStyles.Any, CultureInfo.InvariantCulture);
+
+                if (amount == 0)
+                {
+                    continue;
+                }
+
+                DateTime date = DateTime.ParseExact(dateStr, "yyyyMMdd", CultureInfo.InvariantCulture);
+
+                TransactionCategory category = Classify(mutationCode, description, amount);
+
+                Money money = new(Math.Abs(amount), "EUR");
+                transactions.Add(new Transaction(date, description, money, category));
+            }
+            catch
+            {
+            }
+        }
+
+        return (transactions, Array.Empty<AssetTransaction>(), Enumerable.Empty<OptionTransaction>());
+    }
+
+    public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Enumerable.Empty<AssetTransaction>());
+    }
+
+    private static TransactionCategory Classify(string mutationCode, string description, decimal amount)
+    {
+        string descUpper = description.ToUpperInvariant();
+        string codeUpper = mutationCode.ToUpperInvariant();
+
+        if (descUpper.Contains("ABN AMRO BANK N.V.") || descUpper.Contains("ABN AMRO BANK"))
+        {
+            return TransactionCategory.EXPENSE;
+        }
+
+        if (codeUpper.Contains("BETAALPAS") || codeUpper == "BEA")
+        {
+            return TransactionCategory.EXPENSE;
+        }
+
+        if (codeUpper.Contains("IDEAL"))
+        {
+            return TransactionCategory.EXPENSE;
+        }
+
+        if (codeUpper.Contains("INCASSO"))
+        {
+            return TransactionCategory.EXPENSE;
+        }
+
+        if (codeUpper == "GEA")
+        {
+            return TransactionCategory.EXPENSE;
+        }
+
+        if (codeUpper.Contains("OVERBOEKING") || codeUpper.Contains("PERIODIEKE"))
+        {
+            return ClassifyByDescription(descUpper, amount);
+        }
+
+        if (codeUpper == "EUR" || codeUpper == "DIVERSEN" || string.IsNullOrEmpty(codeUpper))
+        {
+            return ClassifyByDescription(descUpper, amount);
+        }
+
+        if (amount < 0)
+        {
+            return TransactionCategory.EXPENSE;
+        }
+
+        return TransactionCategory.INCOME;
+    }
+
+    private static TransactionCategory ClassifyByDescription(string descUpper, decimal amount)
+    {
+        if (TransferKeywords.Any(k => descUpper.Contains(k)))
+        {
+            return TransactionCategory.TRANSFER;
+        }
+
+        if (IncomeKeywords.Any(k => descUpper.Contains(k)))
+        {
+            return TransactionCategory.INCOME;
+        }
+
+        if (ExpenseKeywords.Any(k => descUpper.Contains(k)))
+        {
+            return TransactionCategory.EXPENSE;
+        }
+
+        if (descUpper.Contains("TIKKIE"))
+        {
+            return TransactionCategory.INCOME;
+        }
+
+        if (descUpper.Contains("FRANCESC GIRBAU LLISTUELLA") || descUpper.Contains("F GIRBAU"))
+        {
+            return TransactionCategory.TRANSFER;
+        }
+
+        if (amount < 0)
+        {
+            return TransactionCategory.EXPENSE;
+        }
+
+        return TransactionCategory.INCOME;
+    }
+}

--- a/src/MyAccountingApp.Core/Services/BrokerImportDispatcher.cs
+++ b/src/MyAccountingApp.Core/Services/BrokerImportDispatcher.cs
@@ -17,6 +17,7 @@ public class BrokerImportDispatcher : IBrokerImportService
     private const string DegiroCsvHeaderPrefix = "Fecha,Hora,Fecha valor";
     private const string DegiroTransactionCsvHeaderPrefix = "Fecha,Hora,Producto,ISIN,Bolsa";
     private const string RevolutCsvHeaderPrefix = "Type,Product,Started Date";
+    private const string AbnAmroCsvHeaderPrefix = "accountNumber,mutationcode";
 
     private readonly InteractiveBrokersImportService ibkrService;
     private readonly BankCsvImportService bankService;
@@ -25,6 +26,7 @@ public class BrokerImportDispatcher : IBrokerImportService
     private readonly DegiroTransactionImportService degiroTransactionService;
     private readonly IBKRFlexQueryImportService flexQueryService;
     private readonly RevolutImportService revolutService;
+    private readonly AbnAmroImportService abnAmroService;
 
     public BrokerImportDispatcher(
         InteractiveBrokersImportService ibkrService,
@@ -33,7 +35,8 @@ public class BrokerImportDispatcher : IBrokerImportService
         DegiroImportService degiroService,
         DegiroTransactionImportService degiroTransactionService,
         IBKRFlexQueryImportService flexQueryService,
-        RevolutImportService revolutService)
+        RevolutImportService revolutService,
+        AbnAmroImportService abnAmroService)
     {
         this.ibkrService = ibkrService ?? throw new ArgumentNullException(nameof(ibkrService));
         this.bankService = bankService ?? throw new ArgumentNullException(nameof(bankService));
@@ -42,6 +45,7 @@ public class BrokerImportDispatcher : IBrokerImportService
         this.degiroTransactionService = degiroTransactionService ?? throw new ArgumentNullException(nameof(degiroTransactionService));
         this.flexQueryService = flexQueryService ?? throw new ArgumentNullException(nameof(flexQueryService));
         this.revolutService = revolutService ?? throw new ArgumentNullException(nameof(revolutService));
+        this.abnAmroService = abnAmroService ?? throw new ArgumentNullException(nameof(abnAmroService));
     }
 
     public Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
@@ -88,6 +92,11 @@ public class BrokerImportDispatcher : IBrokerImportService
             return this.assetService;
         }
 
+        if (fileName.StartsWith("ABN_", StringComparison.OrdinalIgnoreCase))
+        {
+            return this.abnAmroService;
+        }
+
         if (fileName.EndsWith("_transactions.csv", StringComparison.OrdinalIgnoreCase))
         {
             return this.bankService;
@@ -109,6 +118,11 @@ public class BrokerImportDispatcher : IBrokerImportService
             if (header.StartsWith(RevolutCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 return this.revolutService;
+            }
+
+            if (header.StartsWith(AbnAmroCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return this.abnAmroService;
             }
 
             if (header.StartsWith(DegiroTransactionCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))

--- a/src/MyAccountingApp.Web/Pages/Import.razor
+++ b/src/MyAccountingApp.Web/Pages/Import.razor
@@ -115,6 +115,34 @@
 </MudPaper>
 
 <MudPaper Class="pa-6 mb-4" Outlined="true">
+    <MudText Typo="Typo.h6" GutterBottom="true">Import ABN AMRO CSV</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Upload a CSV exported from ABN AMRO. Card payments, transfers, direct debits, and salary are detected automatically.
+    </MudText>
+    <MudAlert Severity="Severity.Info" Class="mb-4" Dense="true">
+        <strong>Format detected automatically.</strong> Expected columns: accountNumber, mutationcode, transactiondate, valuedate, startsaldo, endsaldo, amount, description.<br />
+        <strong>Betaalpas</strong> and <strong>iDEAL</strong> become expenses. <strong>Overboeking</strong> to brokers become transfers. Salary from <strong>Spectral/Tesla</strong> becomes income.
+    </MudAlert>
+    <MudGrid>
+        <MudItem xs="12" sm="8">
+            <InputFile OnChange="@OnAbnAmroFileSelected" accept=".csv" class="mud-input-outlined" />
+        </MudItem>
+        <MudItem xs="12" sm="4" Class="d-flex align-center">
+            <MudButton Variant="Variant.Filled" Color="Color.Tertiary" Size="Size.Large"
+                       OnClick="@UploadAbnAmroAsync" Disabled="@(_abnAmroFile is null || _loading)"
+                       StartIcon="@Icons.Material.Filled.FileUpload"
+                       FullWidth="true">
+                Import ABN AMRO
+            </MudButton>
+        </MudItem>
+    </MudGrid>
+    @if (_abnAmroFile is not null)
+    {
+        <MudText Typo="Typo.body2" Class="mt-2 mud-text-secondary">Selected: @_abnAmroFile.Name</MudText>
+    }
+</MudPaper>
+
+<MudPaper Class="pa-6 mb-4" Outlined="true">
     <MudText Typo="Typo.h6" GutterBottom="true">Import Raw CSV</MudText>
     <MudText Typo="Typo.body2" Class="mb-4">
         Upload a CSV with your own format. No transformations applied.
@@ -272,6 +300,7 @@
     private IBrowserFile? _degiroFile;
     private IBrowserFile? _ibkrFile;
     private IBrowserFile? _revolutFile;
+    private IBrowserFile? _abnAmroFile;
 
     private void OnFileSelected(InputFileChangeEventArgs args)
     {
@@ -294,6 +323,12 @@
     private void OnRevolutFileSelected(InputFileChangeEventArgs args)
     {
         _revolutFile = args.File;
+        _result = null;
+    }
+
+    private void OnAbnAmroFileSelected(InputFileChangeEventArgs args)
+    {
+        _abnAmroFile = args.File;
         _result = null;
     }
 
@@ -383,6 +418,35 @@
         catch (Exception ex)
         {
             Snackbar.Add($"Revolut import failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task UploadAbnAmroAsync()
+    {
+        if (_abnAmroFile is null) return;
+
+        _loading = true;
+        _result = null;
+        _editableSymbols = new();
+        try
+        {
+            using var content = new MultipartFormDataContent();
+            using var stream = _abnAmroFile.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024);
+            content.Add(new StreamContent(stream), "file", _abnAmroFile.Name);
+
+            var response = await Http.PostAsync("/api/import/upload", content);
+            _result = await response.Content.ReadFromJsonAsync<ImportResultDto>();
+            InitEditableSymbols();
+            Snackbar.Add("ABN AMRO import completed.", Severity.Success);
+            _abnAmroFile = null;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"ABN AMRO import failed: {ex.Message}", Severity.Error);
         }
         finally
         {

--- a/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
@@ -233,7 +233,7 @@ public class BrokerImportDispatcherTests
     {
         InteractiveBrokersImportService ibkr = new(Parser, new FakeLogger<InteractiveBrokersImportService>());
         IBKRFlexQueryImportService flexQuery = new(Array.Empty<IIBKRStatementAgent>());
-        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService(), new DegiroTransactionImportService(), flexQuery, new RevolutImportService());
+        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService(), new DegiroTransactionImportService(), flexQuery, new RevolutImportService(), new AbnAmroImportService());
     }
 }
 


### PR DESCRIPTION
Adds an ABN AMRO import service to parse ABN AMRO bank CSV exports.

- New `AbnAmroImportService` parsing ABN AMRO CSV (header `accountNumber,mutationcode,...`)
- Classification by mutation code (BEA/Betaalpas→EXPENSE, iDEAL/Incasso→EXPENSE, Overboeking→by description) and description patterns (J.P.MORGAN/DEGIRO→TRANSFER, Spectral/Tesla→INCOME, B Galende→EXPENSE, Tikkie→INCOME, own IBAN→TRANSFER)
- Routing in `BrokerImportDispatcher` by filename (`ABN_*`) and header
- Registered in DI and added dedicated Import.razor section
- Updated dispatcher tests