### PR TITLE
feat: add quota-aware currency rate caching with timeseries sync

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -24,7 +24,7 @@ MyAccountingApp.Web       → Blazor WASM UI (MudBlazor pages)
 - **Asset Transactions**: CRUD with Symbol, Quantity, Type fields
 - **Portfolio**: Positions table with expandable open lots, realized/unrealized P&L, coloring
 - **Annual Summary**: `GET /api/summary` and `GET /api/summary/{year}`
-- **Conversions**: Currency rate management
+- **Conversions**: Currency rate caching with quota management (exchangerate.host). Timeseries fetch, lazy per-day lookups with stale fallback, pending queue for dates that could not be fetched
 - **Market Prices**: Yahoo Finance integration via `IMarketPriceService`
 - **Position Engine**: FIFO cost basis, P&L calculation
 
@@ -40,13 +40,22 @@ MyAccountingApp.Web       → Blazor WASM UI (MudBlazor pages)
 | PUT | `/api/asset-transactions/{id}` | Update asset transaction |
 | DELETE | `/api/asset-transactions/{id}` | Delete asset transaction |
 | GET | `/api/portfolio` | Portfolio positions |
-| GET | `/api/conversions` | Currency conversions |
+| GET | `/api/conversions` | Currency conversions (timeseries lookups) |
+| GET | `/api/conversions?date=YYYY-MM-DD` | Single conversion, fetched on demand and cached (stale fallback when quota is exhausted) |
+| GET | `/api/conversions/quota` | Quota usage, safety margin, availability period, pending queue size |
+| POST | `/api/conversions/sync` | Backfill a date range in one request `{from, to}` |
+| POST | `/api/conversions/process-pending` | Retry dates in the pending queue |
 | GET | `/api/summary` | Annual summaries |
 | POST | `/api/import` | Folder import |
 | POST | `/api/import/upload` | CSV file upload |
 
 ## Persistence
 - **JSON files** mounted as Docker volumes (`./data:/app/data`)
+  - `data/transactions.json` — transactions
+  - `data/portfolio.json` — asset transactions (portfolio)
+  - `data/conversions.json` — cached conversion rates
+  - `data/api_quota.json` — API quota usage per period
+  - `data/pending_conversions.json` — dates waiting for quota to be available
 - Atomic writes: write to `.tmp`, then `File.Move` (prevents corruption)
 - Auto-recovery: `GetAll()` truncates to last valid `}` if JSON is corrupted
 - Deduplication: `GetAll()` removes duplicate IDs on read
@@ -63,10 +72,21 @@ docker compose up --build -d
 ## Key Environment Variables
 - `CURRENCY_API_KEY` — API key for exchangerate.host
 
-## Current State (July 2026)
-- 134 tests, 81.94% combined coverage
-- Branch: `58-transaction-crud` (PR #5 open)
-- CI: GitHub Actions, Release build with `-warnaserror`
+## Currency Options (`appsettings.json` → `CurrencyApi`)
+| Key | Default | Description |
+|---|---|---|
+| `CurrencyApi:BaseUrl` | `https://api.exchangerate.host` | External rate provider |
+| `CurrencyApi:ApiKey` | *(from `CURRENCY_API_KEY`)* | Provider API key |
+| `CurrencyApi:RequestsLimit` | `100` | Monthly request limit |
+| `CurrencyApi:SafetyMargin` | `10` | Requests reserved as safety margin |
+| `CurrencyApi:BackfillDaysOnFirstRun` | `90` | Days backfilled on first run when the repository is empty |
+| `CurrencyApi:MaxTimeseriesDays` | `365` | Max days a single timeseries request may cover |
+
+On startup the API backfills the last 90 days if no conversions are stored. When the quota is exhausted for a requested date, the date is queued in `pending_conversions.json` and the closest cached conversion is returned marked as **stale**; once quota is available again, `POST /api/conversions/process-pending` retries the queue.
+
+## Current State (August 2026)
+- 281 tests, 83.3% combined coverage
+- CI: GitHub Actions, Release build with `-warnaserror`, coverage gate ≥ 80%
 
 ## Known Issues
 - WASM browser cache: use Ctrl+F5 or incognito after rebuild

--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -1,5 +1,6 @@
 using MyAccountingApp.Application.DTOs;
 using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Application.Options;
 using MyAccountingApp.Application.Services;
 using MyAccountingApp.Core.Agents;
 using MyAccountingApp.Core.Agents.IBKR;
@@ -10,6 +11,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Diagnostics;
 using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Exceptions;
 using MyAccountingApp.Domain.Interfaces;
 using MyAccountingApp.Domain.ValueObjects;
 using System.Globalization;
@@ -40,17 +42,29 @@ builder.Services.AddCors(options =>
     });
 });
 
-string currencyApiKey = builder.Configuration["CurrencyApi:ApiKey"]
-    ?? Environment.GetEnvironmentVariable("CURRENCY_API_KEY")
-    ?? throw new InvalidOperationException(
-        "CurrencyApi:ApiKey not found. Set it in appsettings.json or the CURRENCY_API_KEY environment variable.");
+CurrencyApiOptions currencyOptions = builder.Configuration.GetSection("CurrencyApi").Get<CurrencyApiOptions>() ?? new CurrencyApiOptions();
+
+string currencyApiKey = !string.IsNullOrEmpty(currencyOptions.ApiKey)
+    ? currencyOptions.ApiKey
+    : builder.Configuration["CurrencyApi:ApiKey"]
+        ?? Environment.GetEnvironmentVariable("CURRENCY_API_KEY")
+        ?? throw new InvalidOperationException(
+            "CurrencyApi:ApiKey not found. Set it in appsettings.json or the CURRENCY_API_KEY environment variable.");
 
 CompositeConversionRepository repo = new CompositeConversionRepository("data/conversions.json");
-CurrencyConverter api = new CurrencyConverter(currencyApiKey);
+CurrencyConverter api = new CurrencyConverter(currencyApiKey, excludedCurrencies: currencyOptions.ExcludeCurrencies);
 Currencies source = Currencies.EUR;
-CurencyRateService currencyRateService = new CurencyRateService(repo, api, source);
+JsonApiQuotaRepository quotaRepo = new JsonApiQuotaRepository("data/api_quota.json", currencyOptions.RequestsLimit, currencyOptions.SafetyMargin, currencyOptions.ProviderName);
+JsonPendingConversionRepository pendingRepo = new JsonPendingConversionRepository("data/pending_conversions.json");
+ApiQuotaManager quotaManager = new ApiQuotaManager(quotaRepo);
+PendingConversionQueue pendingQueue = new PendingConversionQueue(pendingRepo);
+CurencyRateService currencyRateService = new CurencyRateService(repo, api, source, quotaManager, pendingQueue, currencyOptions.MaxTimeseriesDays);
 
 builder.Services.AddSingleton<IConversionRepository>(repo);
+builder.Services.AddSingleton<IApiQuotaRepository>(quotaRepo);
+builder.Services.AddSingleton<IPendingConversionRepository>(pendingRepo);
+builder.Services.AddSingleton<IApiQuotaManager>(quotaManager);
+builder.Services.AddSingleton<IPendingConversionQueue>(pendingQueue);
 builder.Services.AddSingleton<ICurrencyRateService>(currencyRateService);
 builder.Services.AddSingleton<ITransactionRepository>(
     new CompositeTransactionRepository("data/transactions.json"));
@@ -501,16 +515,62 @@ app.MapGet($"{prefix}/validate", (IValidationQuery validationQuery) =>
     });
 });
 
-app.MapGet($"{prefix}/conversions", (IConversionRepository repo, DateTime? date) =>
+app.MapGet($"{prefix}/conversions", async (IConversionRepository repo, ICurrencyRateService currencyRateService, DateTime? date) =>
 {
     if (date.HasValue)
     {
-        var conversion = repo.GetByDate(date.Value);
-        return conversion is not null ? Results.Ok(conversion.ToDto()) : Results.NotFound();
+        try
+        {
+            Conversion conversion = await currencyRateService.GetConversionAsync(date.Value);
+            return Results.Ok(conversion.ToDto());
+        }
+        catch (ConversionNotAvailableException)
+        {
+            return Results.NotFound(new { date = date.Value, message = "No conversion available for this date" });
+        }
     }
 
     List<ConversionDto> conversions = repo.GetAll().Select(c => c.ToDto()).ToList();
     return Results.Ok(conversions);
+});
+
+app.MapGet($"{prefix}/conversions/quota", async (ICurrencyRateService currencyRateService, IPendingConversionQueue pendingQueue) =>
+{
+    ApiUsageQuota quota = await currencyRateService.GetQuotaAsync();
+    IReadOnlyList<PendingConversionRequest> pending = await pendingQueue.GetPendingAsync();
+    return Results.Ok(new
+    {
+        provider = quota.Provider,
+        requestsUsed = quota.RequestsUsed,
+        requestsLimit = quota.RequestsLimit,
+        safetyMargin = quota.SafetyMargin,
+        available = quota.Available,
+        periodStart = quota.PeriodStart,
+        periodEnd = quota.PeriodEnd,
+        pendingCount = pending.Count,
+    });
+});
+
+app.MapPost($"{prefix}/conversions/sync", async (SyncConversionsRequest? request, ICurrencyRateService currencyRateService) =>
+{
+    DateOnly start = DateOnly.FromDateTime(request?.From ?? DateTime.UtcNow.AddDays(-7));
+    DateOnly end = DateOnly.FromDateTime(request?.To ?? DateTime.UtcNow.Date);
+
+    if (end < start)
+    {
+        return Results.BadRequest(new { message = "'to' must be greater than or equal to 'from'" });
+    }
+
+    bool synced = await currencyRateService.SyncRangeAsync(start, end);
+    return synced
+        ? Results.Ok(new { message = "Range synced", start, end })
+        : Results.Conflict(new { message = "No API quota available to sync the range" });
+});
+
+app.MapPost($"{prefix}/conversions/process-pending", async (ICurrencyRateService currencyRateService) =>
+{
+    PendingProcessingResult result = await currencyRateService.ProcessPendingAsync();
+    return Results.Ok(new { processedDays = result.ProcessedDays, requestsSpent = result.RequestsSpent, failures = result.Failures });
 });
 
 app.MapGet($"{prefix}/summary", (IAnnualSummaryService summaryService) =>
@@ -598,6 +658,20 @@ app.MapGet($"{prefix}/symbol-lookup", async (string name) =>
 
 app.MapFallbackToFile("index.html");
 
+// Currency API startup sync: backfill when empty, then process any pending conversions.
+_ = Task.Run(async () =>
+{
+    try
+    {
+        await currencyRateService.BackfillIfEmptyAsync(currencyOptions.BackfillDaysOnFirstRun);
+        await currencyRateService.ProcessPendingAsync();
+    }
+    catch (Exception ex)
+    {
+        Log.Error(ex, "Currency API startup sync failed");
+    }
+});
+
 app.Run();
 
 }
@@ -615,3 +689,4 @@ record CreateTransactionRequest(DateTime Date, string Description, decimal Amoun
 record CreateAssetTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category, string Symbol, decimal Quantity, string Type);
 record UpdateOptionTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category, string Symbol, string Isin, decimal Quantity, string Type);
 record BackupData(List<Transaction> Transactions, List<AssetTransaction>? AssetTransactions, List<OptionTransaction>? OptionTransactions);
+record SyncConversionsRequest(DateTime? From, DateTime? To);

--- a/src/MyAccountingApp.Application/DTOs/ConversionDto.cs
+++ b/src/MyAccountingApp.Application/DTOs/ConversionDto.cs
@@ -3,4 +3,7 @@ namespace MyAccountingApp.Application.DTOs;
 public record ConversionDto(
     DateTime Date,
     string Source,
-    Dictionary<string, decimal> Quotes);
+    Dictionary<string, decimal> Quotes,
+    bool IsStale,
+    DateTime RetrievedAtUtc,
+    string SourceProvider);

--- a/src/MyAccountingApp.Application/DTOs/DtoMapper.cs
+++ b/src/MyAccountingApp.Application/DTOs/DtoMapper.cs
@@ -29,7 +29,10 @@ public static class DtoMapper
         new(
             conversion.Date,
             conversion.Source.ToString(),
-            conversion.Quotes.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value));
+            conversion.Quotes.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value),
+            conversion.IsStale,
+            conversion.RetrievedAtUtc,
+            conversion.SourceProvider);
 
     public static OptionTransactionDto ToDto(this OptionTransaction optionTransaction) =>
         new(

--- a/src/MyAccountingApp.Application/Interfaces/IApiQuotaManager.cs
+++ b/src/MyAccountingApp.Application/Interfaces/IApiQuotaManager.cs
@@ -1,0 +1,37 @@
+using MyAccountingApp.Domain.Entities;
+
+namespace MyAccountingApp.Application.Interfaces;
+
+/// <summary>
+/// Manages the monthly request quota against the external currency API.
+/// </summary>
+public interface IApiQuotaManager
+{
+    /// <summary>
+    /// Gets the current quota, resetting the period if a new month has started.
+    /// </summary>
+    /// <returns>The current quota.</returns>
+    Task<ApiUsageQuota> GetQuotaAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Attempts to consume the given number of requests from the quota.
+    /// </summary>
+    /// <param name="cost">The number of requests the operation would consume.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>True if the quota was consumed; otherwise, false.</returns>
+    Task<bool> TryConsumeAsync(int cost = 1, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks the quota as exhausted, stopping any further consumption.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task MarkExhaustedAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Ensures the quota reflects the current period, resetting usage when a new month begins.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task EnsurePeriodAsync(CancellationToken cancellationToken = default);
+}

--- a/src/MyAccountingApp.Application/Interfaces/ICurrencyRateService.cs
+++ b/src/MyAccountingApp.Application/Interfaces/ICurrencyRateService.cs
@@ -1,4 +1,6 @@
-﻿using MyAccountingApp.Domain.Enums;
+﻿using MyAccountingApp.Application.Services;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
 
 namespace MyAccountingApp.Application.Interfaces;
 
@@ -16,4 +18,43 @@ public interface ICurrencyRateService
     /// mapping currencies to their conversion rates.
     /// </returns>
     Task<Dictionary<Currencies, decimal>> GetQuotes(DateTime date);
+
+    /// <summary>
+    /// Asynchronously retrieves the conversion for the specified date, fetching from the API when
+    /// the date is missing and quota allows, and falling back to a stale conversion otherwise.
+    /// </summary>
+    /// <param name="date">The date for which to retrieve the conversion.</param>
+    /// <returns>The conversion for the requested date, which may be marked as stale.</returns>
+    Task<Conversion> GetConversionAsync(DateTime date);
+
+    /// <summary>
+    /// Fetches and persists conversions for a range of dates using a single timeseries request.
+    /// </summary>
+    /// <param name="start">The first date of the range (inclusive).</param>
+    /// <param name="end">The last date of the range (inclusive).</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>True if the range was fetched; false if there was no quota available.</returns>
+    Task<bool> SyncRangeAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Processes the pending conversion queue, grouping dates into timeseries ranges.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A summary of the processing run.</returns>
+    Task<PendingProcessingResult> ProcessPendingAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Backfills conversions from the start of the current period if the repository is empty.
+    /// </summary>
+    /// <param name="days">The number of days to backfill.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>True if the backfill was performed; otherwise, false.</returns>
+    Task<bool> BackfillIfEmptyAsync(int days, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the current currency API quota.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The current quota.</returns>
+    Task<ApiUsageQuota> GetQuotaAsync(CancellationToken cancellationToken = default);
 }

--- a/src/MyAccountingApp.Application/Interfaces/IPendingConversionQueue.cs
+++ b/src/MyAccountingApp.Application/Interfaces/IPendingConversionQueue.cs
@@ -1,0 +1,41 @@
+using MyAccountingApp.Domain.Entities;
+
+namespace MyAccountingApp.Application.Interfaces;
+
+/// <summary>
+/// Manages a queue of conversion dates waiting to be fetched when API quota becomes available.
+/// </summary>
+public interface IPendingConversionQueue
+{
+    /// <summary>
+    /// Enqueues a date for later processing if it is not already queued.
+    /// </summary>
+    /// <param name="date">The date to enqueue.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task EnqueueAsync(DateOnly date, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the requests currently waiting to be processed.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The list of pending requests.</returns>
+    Task<IReadOnlyList<PendingConversionRequest>> GetPendingAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks the request for the given date as processed.
+    /// </summary>
+    /// <param name="date">The processed date.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task MarkProcessedAsync(DateOnly date, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks the request for the given date as failed.
+    /// </summary>
+    /// <param name="date">The failed date.</param>
+    /// <param name="error">A description of the failure.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task MarkFailedAsync(DateOnly date, string error, CancellationToken cancellationToken = default);
+}

--- a/src/MyAccountingApp.Application/Options/CurrencyApiOptions.cs
+++ b/src/MyAccountingApp.Application/Options/CurrencyApiOptions.cs
@@ -1,0 +1,47 @@
+namespace MyAccountingApp.Application.Options;
+
+/// <summary>
+/// Configuration options for the currency API integration.
+/// </summary>
+public sealed class CurrencyApiOptions
+{
+    /// <summary>
+    /// Gets or sets the base URL of the currency API.
+    /// </summary>
+    public string BaseUrl { get; set; } = "https://api.exchangerate.host";
+
+    /// <summary>
+    /// Gets or sets the API key.
+    /// </summary>
+    public string ApiKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the monthly request limit.
+    /// </summary>
+    public int RequestsLimit { get; set; } = 100;
+
+    /// <summary>
+    /// Gets or sets the number of requests reserved as a safety margin.
+    /// </summary>
+    public int SafetyMargin { get; set; } = 10;
+
+    /// <summary>
+    /// Gets or sets the number of days to backfill on first run when the repository is empty.
+    /// </summary>
+    public int BackfillDaysOnFirstRun { get; set; } = 90;
+
+    /// <summary>
+    /// Gets or sets the maximum number of days a single timeseries request may cover.
+    /// </summary>
+    public int MaxTimeseriesDays { get; set; } = 365;
+
+    /// <summary>
+    /// Gets or sets the name of the external provider.
+    /// </summary>
+    public string ProviderName { get; set; } = "exchangerate.host";
+
+    /// <summary>
+    /// Gets or sets the list of currencies to exclude from API requests (e.g. "BTC").
+    /// </summary>
+    public List<string> ExcludeCurrencies { get; set; } = new();
+}

--- a/src/MyAccountingApp.Application/Services/ApiQuotaManager.cs
+++ b/src/MyAccountingApp.Application/Services/ApiQuotaManager.cs
@@ -1,0 +1,68 @@
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Interfaces;
+
+namespace MyAccountingApp.Application.Services;
+
+/// <summary>
+/// Manages the monthly request quota against the external currency API.
+/// </summary>
+public class ApiQuotaManager : IApiQuotaManager
+{
+    private readonly IApiQuotaRepository _repository;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApiQuotaManager"/> class.
+    /// </summary>
+    /// <param name="repository">The repository backing the quota.</param>
+    public ApiQuotaManager(IApiQuotaRepository repository)
+    {
+        this._repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    /// <inheritdoc/>
+    public Task<ApiUsageQuota> GetQuotaAsync(CancellationToken cancellationToken = default)
+    {
+        ApiUsageQuota quota = this.GetCurrentQuota();
+        return Task.FromResult(quota);
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> TryConsumeAsync(int cost = 1, CancellationToken cancellationToken = default)
+    {
+        ApiUsageQuota quota = this.GetCurrentQuota();
+
+        if (!quota.CanConsume(cost))
+        {
+            return Task.FromResult(false);
+        }
+
+        quota.RegisterUsage(cost);
+        this._repository.Save(quota);
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc/>
+    public Task MarkExhaustedAsync(CancellationToken cancellationToken = default)
+    {
+        ApiUsageQuota quota = this.GetCurrentQuota();
+        quota.MarkExhausted();
+        this._repository.Save(quota);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task EnsurePeriodAsync(CancellationToken cancellationToken = default)
+    {
+        ApiUsageQuota quota = this.GetCurrentQuota();
+        this._repository.Save(quota);
+        return Task.CompletedTask;
+    }
+
+    private ApiUsageQuota GetCurrentQuota()
+    {
+        ApiUsageQuota quota = this._repository.Get();
+        quota.EnsureCurrentPeriod(DateOnly.FromDateTime(DateTime.UtcNow.Date));
+        return quota;
+    }
+}

--- a/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
+++ b/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
@@ -1,19 +1,24 @@
 ﻿using MyAccountingApp.Application.Interfaces;
 using MyAccountingApp.Domain.Entities;
 using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Exceptions;
 using MyAccountingApp.Domain.Interfaces;
 
 namespace MyAccountingApp.Application.Services;
 
 /// <summary>
-/// Provides currency rate retrieval and caching functionality.
-/// Uses a repository for local storage and an external API for fetching rates.
+/// Provides currency rate retrieval with a cache-first, quota-aware orchestration.
+/// Uses a repository for local storage, a quota manager to respect API limits, and
+/// a queue for dates that could not be fetched immediately.
 /// </summary>
 public class CurencyRateService : ICurrencyRateService
 {
     private readonly IConversionRepository _repository;
     private readonly ICurrencyConverter _api;
     private readonly Currencies _source;
+    private readonly IApiQuotaManager _quotaManager;
+    private readonly IPendingConversionQueue _pendingQueue;
+    private readonly int _maxTimeseriesDays;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CurencyRateService"/> class.
@@ -21,12 +26,24 @@ public class CurencyRateService : ICurrencyRateService
     /// <param name="repository">Repository for storing currency conversions.</param>
     /// <param name="api">External API for fetching currency rates.</param>
     /// <param name="source">Base currency for conversion.</param>
+    /// <param name="quotaManager">Manager for the API request quota.</param>
+    /// <param name="pendingQueue">Queue for dates that could not be fetched immediately.</param>
+    /// <param name="maxTimeseriesDays">Maximum number of days a single timeseries request may cover.</param>
     /// <exception cref="ArgumentException">Thrown if the source currency is not EUR.</exception>
-    public CurencyRateService(IConversionRepository repository, ICurrencyConverter api, Currencies source)
+    public CurencyRateService(
+        IConversionRepository repository,
+        ICurrencyConverter api,
+        Currencies source,
+        IApiQuotaManager quotaManager,
+        IPendingConversionQueue pendingQueue,
+        int maxTimeseriesDays = 365)
     {
         this._repository = repository;
         this._api = api;
         this._source = source;
+        this._quotaManager = quotaManager;
+        this._pendingQueue = pendingQueue;
+        this._maxTimeseriesDays = maxTimeseriesDays;
         this.Validate();
     }
 
@@ -46,39 +63,223 @@ public class CurencyRateService : ICurrencyRateService
         }
     }
 
-    /// <summary>
-    /// Gets currency conversion quotes for a specific date.
-    /// If not cached, fetches from the external API and stores the result.
-    /// </summary>
-    /// <param name="date">The date for which to retrieve currency quotes.</param>
-    /// <returns>
-    /// A dictionary mapping target currencies to their conversion rates.
-    /// </returns>
+    /// <inheritdoc/>
     public async Task<Dictionary<Currencies, decimal>> GetQuotes(DateTime date)
     {
-        Conversion? conversion = this._repository.GetByDate(date);
+        Conversion conversion = await this.GetConversionAsync(date);
+        return conversion.Quotes;
+    }
 
-        if (conversion != null)
+    /// <inheritdoc/>
+    public async Task<Conversion> GetConversionAsync(DateTime date)
+    {
+        Conversion? existing = this._repository.GetByDate(date);
+
+        if (existing != null)
         {
-            return conversion.Quotes;
+            return existing;
         }
 
-        Dictionary<string, decimal> rates = await this._api.FetchAllRatesAsync(this._source, date);
+        DateOnly day = DateOnly.FromDateTime(date.Date);
 
-        conversion = new Conversion(date, this._source);
+        await this._quotaManager.EnsurePeriodAsync();
+
+        if (await this._quotaManager.TryConsumeAsync(1))
+        {
+            try
+            {
+                Dictionary<string, decimal> rates = await this._api.FetchAllRatesAsync(this._source, date);
+                Conversion conversion = this.BuildConversion(day, rates);
+                this._repository.AddOrUpdate(conversion);
+                return conversion;
+            }
+            catch (CurrencyApiQuotaExceededException)
+            {
+                await this._quotaManager.MarkExhaustedAsync();
+            }
+        }
+
+        await this._pendingQueue.EnqueueAsync(day);
+
+        Conversion? fallback = this.FindFallback(day);
+
+        if (fallback != null)
+        {
+            return CloneForStale(fallback);
+        }
+
+        throw new ConversionNotAvailableException($"No conversion available for {day:yyyy-MM-dd} and no API quota to fetch it.");
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> SyncRangeAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default)
+    {
+        await this._quotaManager.EnsurePeriodAsync(cancellationToken);
+
+        if (!await this._quotaManager.TryConsumeAsync(1, cancellationToken))
+        {
+            return false;
+        }
+
+        try
+        {
+            IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>> rates = await this._api.FetchRangeAsync(this._source, start, end, null, cancellationToken);
+
+            foreach (KeyValuePair<DateOnly, Dictionary<string, decimal>> kv in rates)
+            {
+                this._repository.AddOrUpdate(this.BuildConversion(kv.Key, kv.Value));
+            }
+
+            return true;
+        }
+        catch (CurrencyApiQuotaExceededException)
+        {
+            await this._quotaManager.MarkExhaustedAsync(cancellationToken);
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<PendingProcessingResult> ProcessPendingAsync(CancellationToken cancellationToken = default)
+    {
+        await this._quotaManager.EnsurePeriodAsync(cancellationToken);
+
+        IReadOnlyList<PendingConversionRequest> pending = await this._pendingQueue.GetPendingAsync(cancellationToken);
+        List<DateOnly> pendingDays = pending.Select(p => p.Date).Distinct().OrderBy(d => d).ToList();
+
+        int processedDays = 0;
+        int requestsSpent = 0;
+        int failures = 0;
+
+        foreach ((DateOnly start, DateOnly end) in GroupIntoRanges(pendingDays, this._maxTimeseriesDays))
+        {
+            if (!await this._quotaManager.TryConsumeAsync(1, cancellationToken))
+            {
+                break;
+            }
+
+            requestsSpent++;
+
+            try
+            {
+                IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>> rates = await this._api.FetchRangeAsync(this._source, start, end, null, cancellationToken);
+
+                foreach (KeyValuePair<DateOnly, Dictionary<string, decimal>> kv in rates)
+                {
+                    this._repository.AddOrUpdate(this.BuildConversion(kv.Key, kv.Value));
+                    await this._pendingQueue.MarkProcessedAsync(kv.Key, cancellationToken);
+                    processedDays++;
+                }
+            }
+            catch (CurrencyApiQuotaExceededException)
+            {
+                await this._quotaManager.MarkExhaustedAsync(cancellationToken);
+                break;
+            }
+            catch
+            {
+                foreach (DateOnly day in pendingDays.Where(d => d >= start && d <= end))
+                {
+                    await this._pendingQueue.MarkFailedAsync(day, "Range fetch failed.", cancellationToken);
+                }
+
+                failures++;
+            }
+        }
+
+        return new PendingProcessingResult(processedDays, requestsSpent, failures);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> BackfillIfEmptyAsync(int days, CancellationToken cancellationToken = default)
+    {
+        if (this._repository.GetAll().Any())
+        {
+            return false;
+        }
+
+        DateOnly end = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        DateOnly start = end.AddDays(-(days - 1));
+        return await this.SyncRangeAsync(start, end, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public Task<ApiUsageQuota> GetQuotaAsync(CancellationToken cancellationToken = default)
+    {
+        return this._quotaManager.GetQuotaAsync(cancellationToken);
+    }
+
+    private Conversion BuildConversion(DateOnly day, Dictionary<string, decimal> rates)
+    {
+        Conversion conversion = new(day.ToDateTime(TimeOnly.MinValue), this._source);
+        int prefixLength = this._source.ToString().Length;
 
         foreach (KeyValuePair<string, decimal> kv in rates)
         {
-            string targetCurrencyCode = kv.Key.Substring(3);
+            string targetCode = kv.Key.Substring(prefixLength);
 
-            if (Enum.TryParse<Currencies>(targetCurrencyCode, out Currencies currency))
+            if (Enum.TryParse<Currencies>(targetCode, out Currencies currency))
             {
                 conversion.AddOrUpdateQuote(currency, kv.Value);
             }
         }
 
-        this._repository.AddOrUpdate(conversion);
+        conversion.MarkFresh(DateTime.UtcNow);
+        return conversion;
+    }
 
-        return conversion.Quotes;
+    private Conversion? FindFallback(DateOnly day)
+    {
+        DateTime date = day.ToDateTime(TimeOnly.MinValue);
+        return this._repository.GetAll()
+            .OrderByDescending(c => c.Date)
+            .FirstOrDefault(c => c.Date.Date <= date);
+    }
+
+    private static Conversion CloneForStale(Conversion fallback)
+    {
+        Conversion clone = new(
+            fallback.Date,
+            fallback.Source,
+            new Dictionary<Currencies, decimal>(fallback.Quotes),
+            fallback.RetrievedAtUtc,
+            fallback.IsStale,
+            fallback.SourceProvider);
+        clone.MarkStale();
+        return clone;
+    }
+
+    private static List<(DateOnly Start, DateOnly End)> GroupIntoRanges(List<DateOnly> dates, int maxDays)
+    {
+        List<(DateOnly, DateOnly)> ranges = new();
+
+        if (dates.Count == 0)
+        {
+            return ranges;
+        }
+
+        DateOnly rangeStart = dates[0];
+        DateOnly rangeEnd = dates[0];
+
+        for (int i = 1; i < dates.Count; i++)
+        {
+            DateOnly day = dates[i];
+            bool consecutive = day.AddDays(-1) <= rangeEnd;
+            bool fits = day.DayNumber - rangeStart.DayNumber < maxDays;
+
+            if (consecutive && fits)
+            {
+                rangeEnd = day;
+            }
+            else
+            {
+                ranges.Add((rangeStart, rangeEnd));
+                rangeStart = day;
+                rangeEnd = day;
+            }
+        }
+
+        ranges.Add((rangeStart, rangeEnd));
+        return ranges;
     }
 }

--- a/src/MyAccountingApp.Application/Services/PendingConversionQueue.cs
+++ b/src/MyAccountingApp.Application/Services/PendingConversionQueue.cs
@@ -1,0 +1,73 @@
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+
+namespace MyAccountingApp.Application.Services;
+
+/// <summary>
+/// Manages a queue of conversion dates waiting to be fetched when API quota becomes available.
+/// </summary>
+public class PendingConversionQueue : IPendingConversionQueue
+{
+    private readonly IPendingConversionRepository _repository;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PendingConversionQueue"/> class.
+    /// </summary>
+    /// <param name="repository">The repository backing the queue.</param>
+    public PendingConversionQueue(IPendingConversionRepository repository)
+    {
+        this._repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    /// <inheritdoc/>
+    public Task EnqueueAsync(DateOnly date, CancellationToken cancellationToken = default)
+    {
+        PendingConversionRequest? existing = this._repository.GetAll().FirstOrDefault(r => r.Date == date);
+
+        if (existing == null)
+        {
+            this._repository.AddOrUpdate(new PendingConversionRequest(date, Currencies.EUR, DateTime.UtcNow));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<PendingConversionRequest>> GetPendingAsync(CancellationToken cancellationToken = default)
+    {
+        List<PendingConversionRequest> pending = this._repository.GetAll()
+            .Where(r => r.Status == PendingStatus.Pending)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<PendingConversionRequest>>(pending);
+    }
+
+    /// <inheritdoc/>
+    public Task MarkProcessedAsync(DateOnly date, CancellationToken cancellationToken = default)
+    {
+        PendingConversionRequest? existing = this._repository.GetAll().FirstOrDefault(r => r.Date == date);
+
+        if (existing != null)
+        {
+            existing.MarkProcessed(DateTime.UtcNow);
+            this._repository.AddOrUpdate(existing);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task MarkFailedAsync(DateOnly date, string error, CancellationToken cancellationToken = default)
+    {
+        PendingConversionRequest? existing = this._repository.GetAll().FirstOrDefault(r => r.Date == date);
+
+        if (existing != null)
+        {
+            existing.MarkFailed(error);
+            this._repository.AddOrUpdate(existing);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/MyAccountingApp.Application/Services/PendingProcessingResult.cs
+++ b/src/MyAccountingApp.Application/Services/PendingProcessingResult.cs
@@ -1,0 +1,6 @@
+namespace MyAccountingApp.Application.Services;
+
+/// <summary>
+/// Summarizes the result of processing the pending conversion queue.
+/// </summary>
+public sealed record PendingProcessingResult(int ProcessedDays, int RequestsSpent, int Failures);

--- a/src/MyAccountingApp.ConsoleApp/Program.cs
+++ b/src/MyAccountingApp.ConsoleApp/Program.cs
@@ -21,7 +21,11 @@ string currencyApiKey = config["CurrencyApi:ApiKey"]
 CompositeConversionRepository repo = new CompositeConversionRepository("conversions.json");
 CurrencyConverter api = new CurrencyConverter(currencyApiKey);
 Currencies source = Currencies.EUR;
-CurencyRateService service = new CurencyRateService(repo, api, source);
+JsonApiQuotaRepository quotaRepo = new JsonApiQuotaRepository("api_quota.json");
+JsonPendingConversionRepository pendingRepo = new JsonPendingConversionRepository("pending_conversions.json");
+ApiQuotaManager quotaManager = new ApiQuotaManager(quotaRepo);
+PendingConversionQueue pendingQueue = new PendingConversionQueue(pendingRepo);
+CurencyRateService service = new CurencyRateService(repo, api, source, quotaManager, pendingQueue);
 
 DateTime targetDate = new DateTime(2024, 12, 1);
 

--- a/src/MyAccountingApp.Core/DTOs/ExchangeRateTimeseriesResponse.cs
+++ b/src/MyAccountingApp.Core/DTOs/ExchangeRateTimeseriesResponse.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace MyAccountingApp.Core.DTOs;
+
+/// <summary>
+/// Represents the response from the currency exchange rate API timeseries endpoint.
+/// </summary>
+public class ExchangeRateTimeseriesResponse
+{
+    /// <summary>
+    /// Gets a value indicating whether the API request was successful.
+    /// </summary>
+    [JsonPropertyName("success")]
+    public bool Success { get; init; } = false;
+
+    /// <summary>
+    /// Gets the dictionary of dates and their currency pair rates.
+    /// </summary>
+    [JsonPropertyName("rates")]
+    public Dictionary<string, Dictionary<string, decimal>> Rates { get; init; } = new();
+
+    /// <summary>
+    /// Gets the error details if the API request was not successful.
+    /// </summary>
+    [JsonPropertyName("error")]
+    public ExchangeRateResponseError? Error { get; init; } = null;
+}

--- a/src/MyAccountingApp.Core/Repositories/JsonApiQuotaRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/JsonApiQuotaRepository.cs
@@ -1,0 +1,88 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Interfaces;
+
+namespace MyAccountingApp.Core.Repositories;
+
+/// <summary>
+/// Repository for storing and retrieving the currency API usage quota using a JSON file.
+/// </summary>
+public class JsonApiQuotaRepository : IApiQuotaRepository
+{
+    private readonly string _filePath;
+    private readonly int _requestsLimit;
+    private readonly int _safetyMargin;
+    private readonly string _providerName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonApiQuotaRepository"/> class.
+    /// </summary>
+    /// <param name="filePath">The path to the JSON file.</param>
+    /// <param name="requestsLimit">The monthly request limit.</param>
+    /// <param name="safetyMargin">The number of requests reserved as a safety margin.</param>
+    /// <param name="providerName">The name of the external provider.</param>
+    public JsonApiQuotaRepository(string filePath, int requestsLimit = 100, int safetyMargin = 10, string providerName = "exchangerate.host")
+    {
+        this._filePath = filePath;
+        this._requestsLimit = requestsLimit;
+        this._safetyMargin = safetyMargin;
+        this._providerName = providerName;
+    }
+
+    /// <summary>
+    /// Gets the current quota, creating a default quota for the current month if none is stored.
+    /// </summary>
+    /// <returns>The current quota.</returns>
+    public ApiUsageQuota Get()
+    {
+        if (File.Exists(this._filePath) && new FileInfo(this._filePath).Length > 0)
+        {
+            string json = File.ReadAllText(this._filePath);
+            JsonSerializerOptions options = new() { PropertyNameCaseInsensitive = true, Converters = { new JsonStringEnumConverter() } };
+            ApiUsageQuota? quota = JsonSerializer.Deserialize<ApiUsageQuota>(json, options);
+
+            if (quota != null)
+            {
+                return quota;
+            }
+        }
+
+        return this.CreateDefault();
+    }
+
+    /// <summary>
+    /// Saves the quota to the JSON file.
+    /// </summary>
+    /// <param name="quota">The quota to save.</param>
+    public void Save(ApiUsageQuota quota)
+    {
+        this.EnsureDirectory();
+        JsonSerializerOptions options = new()
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter() },
+        };
+
+        string json = JsonSerializer.Serialize(quota, options);
+        File.WriteAllText(this._filePath, json);
+    }
+
+    private ApiUsageQuota CreateDefault()
+    {
+        DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        DateOnly periodStart = new(today.Year, today.Month, 1);
+        DateOnly periodEnd = periodStart.AddMonths(1).AddDays(-1);
+        return new ApiUsageQuota(this._providerName, periodStart, periodEnd, 0, this._requestsLimit, this._safetyMargin, DateTime.UtcNow);
+    }
+
+    private void EnsureDirectory()
+    {
+        string? directory = Path.GetDirectoryName(this._filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+}

--- a/src/MyAccountingApp.Core/Repositories/JsonPendingConversionRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/JsonPendingConversionRepository.cs
@@ -1,0 +1,84 @@
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Interfaces;
+
+namespace MyAccountingApp.Core.Repositories;
+
+/// <summary>
+/// Repository for storing and retrieving queued conversion requests using a JSON file.
+/// </summary>
+public class JsonPendingConversionRepository : IPendingConversionRepository
+{
+    private readonly string _filePath;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonPendingConversionRepository"/> class.
+    /// </summary>
+    /// <param name="filePath">The path to the JSON file.</param>
+    public JsonPendingConversionRepository(string filePath)
+    {
+        this._filePath = filePath;
+    }
+
+    /// <summary>
+    /// Gets all queued conversion requests.
+    /// </summary>
+    /// <returns>All queued conversion requests.</returns>
+    public IEnumerable<PendingConversionRequest> GetAll()
+    {
+        if (File.Exists(this._filePath) && new FileInfo(this._filePath).Length > 0)
+        {
+            string json = File.ReadAllText(this._filePath);
+            JsonSerializerOptions options = new() { PropertyNameCaseInsensitive = true, Converters = { new JsonStringEnumConverter() } };
+            List<PendingConversionRequest>? requests = JsonSerializer.Deserialize<List<PendingConversionRequest>>(json, options);
+
+            if (requests != null)
+            {
+                return requests;
+            }
+        }
+
+        return new List<PendingConversionRequest>();
+    }
+
+    /// <summary>
+    /// Adds a new request or updates an existing request for the same date.
+    /// </summary>
+    /// <param name="request">The request to add or update.</param>
+    public void AddOrUpdate(PendingConversionRequest request)
+    {
+        List<PendingConversionRequest> requests = this.GetAll().ToList();
+        requests.RemoveAll(r => r.Date == request.Date);
+        requests.Add(request);
+        this.Initialize(requests);
+    }
+
+    /// <summary>
+    /// Replaces all stored requests with the given collection.
+    /// </summary>
+    /// <param name="requests">The requests to store.</param>
+    public void Initialize(IEnumerable<PendingConversionRequest> requests)
+    {
+        this.EnsureDirectory();
+        JsonSerializerOptions options = new()
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter() },
+        };
+
+        string json = JsonSerializer.Serialize(requests, options);
+        File.WriteAllText(this._filePath, json);
+    }
+
+    private void EnsureDirectory()
+    {
+        string? directory = Path.GetDirectoryName(this._filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+}

--- a/src/MyAccountingApp.Core/Services/CurrencyConverter.cs
+++ b/src/MyAccountingApp.Core/Services/CurrencyConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using MyAccountingApp.Core.DTOs;
 using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Exceptions;
 using MyAccountingApp.Domain.Interfaces;
 
 namespace MyAccountingApp.Core.Services;
@@ -12,41 +13,108 @@ public class CurrencyConverter : ICurrencyConverter
 {
     private readonly string _apiKey;
     private readonly HttpClient _httpClient;
+    private readonly IReadOnlyCollection<string> _excludedCurrencies;
 
-    public CurrencyConverter(string apiKey, HttpClient? httpClient = null)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CurrencyConverter"/> class.
+    /// </summary>
+    /// <param name="apiKey">The API key for the external service.</param>
+    /// <param name="httpClient">Optional HTTP client; a new one is created if not provided.</param>
+    /// <param name="excludedCurrencies">Optional list of currency codes to exclude from requests.</param>
+    public CurrencyConverter(string apiKey, HttpClient? httpClient = null, IReadOnlyCollection<string>? excludedCurrencies = null)
     {
         this._apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
         this._httpClient = httpClient ?? new HttpClient();
+        this._excludedCurrencies = excludedCurrencies ?? Array.Empty<string>();
     }
 
-    /// <summary>
-    /// Asynchronously fetches conversion rates for all supported currencies based on the specified source currency and date.
-    /// </summary>
-    /// <param name="source">The base currency for conversion.</param>
-    /// <param name="date">The date for which to fetch conversion rates.</param>
-    /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains a dictionary
-    /// mapping currency pair codes (e.g., "EURUSD") to their conversion rates.
-    /// </returns>
-    /// <exception cref="Exception">Thrown if the API response is invalid or unsuccessful.</exception>
+    /// <inheritdoc/>
     public async Task<Dictionary<string, decimal>> FetchAllRatesAsync(Currencies source, DateTime date)
     {
         string dateString = date.ToString("yyyy-MM-dd");
-        string currencyList = string.Join(",", Enum.GetValues<Currencies>().Where(c => c != source).Select(c => c.ToString()));
+        string currencyList = string.Join(",", this.GetTargetCurrencies(source).Select(c => c.ToString()));
 
         string url = $"https://api.exchangerate.host/historical?access_key={this._apiKey}&date={dateString}&source={source}&currencies={currencyList}";
 
-        HttpResponseMessage response = await this._httpClient.GetAsync(url);
-        response.EnsureSuccessStatusCode();
-
+        HttpResponseMessage response = await this.GetAsync(url);
         string json = await response.Content.ReadAsStringAsync();
         ExchangeRateResponse? result = JsonSerializer.Deserialize<ExchangeRateResponse>(json);
 
-        if (result == null || !result.Success)
+        ThrowIfFailed(result?.Success == true, result?.Error);
+
+        return result!.Quotes;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>>> FetchRangeAsync(
+        Currencies source,
+        DateOnly start,
+        DateOnly end,
+        IReadOnlyCollection<Currencies>? targets = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (end < start)
         {
-            throw new Exception($"Error in API response: {result?.Error?.Info}");
+            throw new ArgumentException("The end date must be greater than or equal to the start date.", nameof(end));
         }
 
-        return result.Quotes;
+        string currencyList = string.Join(",", (targets ?? this.GetTargetCurrencies(source)).Select(c => c.ToString()));
+
+        string url = $"https://api.exchangerate.host/timeseries?access_key={this._apiKey}&start_date={start:yyyy-MM-dd}&end_date={end:yyyy-MM-dd}&source={source}&currencies={currencyList}";
+
+        HttpResponseMessage response = await this.GetAsync(url, cancellationToken);
+        string json = await response.Content.ReadAsStringAsync(cancellationToken);
+        ExchangeRateTimeseriesResponse? result = JsonSerializer.Deserialize<ExchangeRateTimeseriesResponse>(json);
+
+        ThrowIfFailed(result?.Success == true, result?.Error);
+
+        Dictionary<DateOnly, Dictionary<string, decimal>> mapped = new();
+
+        foreach (KeyValuePair<string, Dictionary<string, decimal>> entry in result!.Rates)
+        {
+            if (DateOnly.TryParse(entry.Key, out DateOnly date))
+            {
+                Dictionary<string, decimal> quotes = entry.Value.ToDictionary(
+                    kv => $"{source}{kv.Key}",
+                    kv => kv.Value,
+                    StringComparer.Ordinal);
+                mapped[date] = quotes;
+            }
+        }
+
+        return mapped;
+    }
+
+    private IReadOnlyCollection<Currencies> GetTargetCurrencies(Currencies source)
+    {
+        return Enum.GetValues<Currencies>()
+            .Where(c => c != source && !this._excludedCurrencies.Contains(c.ToString(), StringComparer.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    private async Task<HttpResponseMessage> GetAsync(string url, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await this._httpClient.GetAsync(url, cancellationToken);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+        {
+            throw new CurrencyApiQuotaExceededException("Currency API returned HTTP 429 (too many requests).");
+        }
+
+        response.EnsureSuccessStatusCode();
+        return response;
+    }
+
+    private static void ThrowIfFailed(bool success, ExchangeRateResponseError? error)
+    {
+        if (!success)
+        {
+            if (error?.Code == 104 || (error?.Info is not null && error.Info.Contains("limit", StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new CurrencyApiQuotaExceededException($"Currency API quota exceeded: {error?.Info}");
+            }
+
+            throw new Exception($"Error in API response: {error?.Info}");
+        }
     }
 }

--- a/src/MyAccountingApp.Domain/Entities/ApiUsageQuota.cs
+++ b/src/MyAccountingApp.Domain/Entities/ApiUsageQuota.cs
@@ -1,0 +1,119 @@
+namespace MyAccountingApp.Domain.Entities;
+
+/// <summary>
+/// Tracks the monthly request usage against the external currency API.
+/// </summary>
+public sealed class ApiUsageQuota
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApiUsageQuota"/> class.
+    /// </summary>
+    /// <param name="provider">The name of the external provider.</param>
+    /// <param name="periodStart">The first day of the current quota period.</param>
+    /// <param name="periodEnd">The last day of the current quota period.</param>
+    /// <param name="requestsUsed">The number of requests already consumed in the period.</param>
+    /// <param name="requestsLimit">The monthly request limit.</param>
+    /// <param name="safetyMargin">The number of requests reserved as a safety margin.</param>
+    /// <param name="updatedAtUtc">The UTC timestamp of the last update.</param>
+    public ApiUsageQuota(
+        string provider,
+        DateOnly periodStart,
+        DateOnly periodEnd,
+        int requestsUsed,
+        int requestsLimit,
+        int safetyMargin,
+        DateTime updatedAtUtc)
+    {
+        this.Provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        this.PeriodStart = periodStart;
+        this.PeriodEnd = periodEnd;
+        this.RequestsUsed = requestsUsed;
+        this.RequestsLimit = requestsLimit;
+        this.SafetyMargin = safetyMargin;
+        this.UpdatedAtUtc = updatedAtUtc;
+    }
+
+    /// <summary>
+    /// Gets the name of the external provider.
+    /// </summary>
+    public string Provider { get; }
+
+    /// <summary>
+    /// Gets the first day of the current quota period.
+    /// </summary>
+    public DateOnly PeriodStart { get; private set; }
+
+    /// <summary>
+    /// Gets the last day of the current quota period.
+    /// </summary>
+    public DateOnly PeriodEnd { get; private set; }
+
+    /// <summary>
+    /// Gets the number of requests already consumed in the period.
+    /// </summary>
+    public int RequestsUsed { get; private set; }
+
+    /// <summary>
+    /// Gets the monthly request limit.
+    /// </summary>
+    public int RequestsLimit { get; }
+
+    /// <summary>
+    /// Gets the number of requests reserved as a safety margin.
+    /// </summary>
+    public int SafetyMargin { get; }
+
+    /// <summary>
+    /// Gets the UTC timestamp of the last update.
+    /// </summary>
+    public DateTime UpdatedAtUtc { get; private set; }
+
+    /// <summary>
+    /// Gets the number of requests available for consumption.
+    /// </summary>
+    public int Available => Math.Max(0, this.RequestsLimit - this.SafetyMargin - this.RequestsUsed);
+
+    /// <summary>
+    /// Determines whether the given request cost can be consumed without exceeding the quota.
+    /// </summary>
+    /// <param name="cost">The number of requests the operation would consume.</param>
+    /// <returns>True if the quota can absorb the cost; otherwise, false.</returns>
+    public bool CanConsume(int cost = 1)
+    {
+        return this.Available >= cost;
+    }
+
+    /// <summary>
+    /// Registers usage of the given number of requests.
+    /// </summary>
+    /// <param name="cost">The number of requests consumed.</param>
+    public void RegisterUsage(int cost = 1)
+    {
+        this.RequestsUsed = Math.Min(this.RequestsLimit, this.RequestsUsed + cost);
+        this.UpdatedAtUtc = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Marks the quota as exhausted so no further requests are attempted.
+    /// </summary>
+    public void MarkExhausted()
+    {
+        this.RequestsUsed = this.RequestsLimit;
+        this.UpdatedAtUtc = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Resets the quota when the current period has ended and a new period begins.
+    /// </summary>
+    /// <param name="today">The current date.</param>
+    public void EnsureCurrentPeriod(DateOnly today)
+    {
+        if (today > this.PeriodEnd)
+        {
+            this.PeriodStart = new DateOnly(today.Year, today.Month, 1);
+            this.PeriodEnd = this.PeriodStart.AddMonths(1).AddDays(-1);
+            this.RequestsUsed = 0;
+            this.UpdatedAtUtc = DateTime.UtcNow;
+        }
+    }
+}

--- a/src/MyAccountingApp.Domain/Entities/Conversion.cs
+++ b/src/MyAccountingApp.Domain/Entities/Conversion.cs
@@ -23,17 +23,44 @@ public class Conversion
     public Dictionary<Currencies, decimal> Quotes { get; }
 
     /// <summary>
+    /// Gets the UTC timestamp when the conversion was retrieved from the external API.
+    /// </summary>
+    public DateTime RetrievedAtUtc { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this conversion was served without a fresh refresh (no API quota available).
+    /// </summary>
+    public bool IsStale { get; private set; }
+
+    /// <summary>
+    /// Gets the name of the provider that supplied the rates.
+    /// </summary>
+    public string SourceProvider { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="Conversion"/> class.
     /// </summary>
     /// <param name="date">The date of the conversion.</param>
     /// <param name="source">The base currency.</param>
     /// <param name="quotes">Optional dictionary of conversion quotes.</param>
+    /// <param name="retrievedAtUtc">Optional UTC timestamp of retrieval; defaults to the conversion date.</param>
+    /// <param name="isStale">Indicates whether the conversion is stale (served without refresh).</param>
+    /// <param name="sourceProvider">The name of the provider that supplied the rates.</param>
     /// <exception cref="ArgumentException">Thrown if the source currency is not EUR.</exception>
-    public Conversion(DateTime date, Currencies source, Dictionary<Currencies, decimal>? quotes = null)
+    public Conversion(
+        DateTime date,
+        Currencies source,
+        Dictionary<Currencies, decimal>? quotes = null,
+        DateTime retrievedAtUtc = default,
+        bool isStale = false,
+        string sourceProvider = "exchangerate.host")
     {
         this.Date = date.Date;
         this.Source = source;
         this.Quotes = quotes ?? new Dictionary<Currencies, decimal>();
+        this.RetrievedAtUtc = retrievedAtUtc == default ? date.Date : retrievedAtUtc;
+        this.IsStale = isStale;
+        this.SourceProvider = sourceProvider ?? throw new ArgumentNullException(nameof(sourceProvider));
 
         this.Validate();
     }
@@ -87,5 +114,23 @@ public class Conversion
     public bool MatchesDate(DateTime date)
     {
         return this.Date.Date == date.Date;
+    }
+
+    /// <summary>
+    /// Marks this conversion as stale because it was served without a fresh API refresh.
+    /// </summary>
+    public void MarkStale()
+    {
+        this.IsStale = true;
+    }
+
+    /// <summary>
+    /// Marks this conversion as fresh after being retrieved from the API.
+    /// </summary>
+    /// <param name="retrievedAtUtc">The UTC timestamp of the retrieval.</param>
+    public void MarkFresh(DateTime retrievedAtUtc)
+    {
+        this.RetrievedAtUtc = retrievedAtUtc;
+        this.IsStale = false;
     }
 }

--- a/src/MyAccountingApp.Domain/Entities/PendingConversionRequest.cs
+++ b/src/MyAccountingApp.Domain/Entities/PendingConversionRequest.cs
@@ -1,0 +1,86 @@
+using System;
+using MyAccountingApp.Domain.Enums;
+
+namespace MyAccountingApp.Domain.Entities;
+
+/// <summary>
+/// Represents a conversion date that could not be fetched immediately and was queued for later processing.
+/// </summary>
+public sealed class PendingConversionRequest
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PendingConversionRequest"/> class.
+    /// </summary>
+    /// <param name="date">The date to fetch.</param>
+    /// <param name="source">The base currency.</param>
+    /// <param name="requestedAtUtc">The UTC timestamp when the request was created.</param>
+    /// <param name="status">The initial status of the request.</param>
+    /// <param name="processedAtUtc">Optional UTC timestamp when the request was processed.</param>
+    /// <param name="lastError">Optional error message from the last processing attempt.</param>
+    public PendingConversionRequest(
+        DateOnly date,
+        Currencies source,
+        DateTime requestedAtUtc,
+        PendingStatus status = PendingStatus.Pending,
+        DateTime? processedAtUtc = null,
+        string? lastError = null)
+    {
+        this.Date = date;
+        this.Source = source;
+        this.RequestedAtUtc = requestedAtUtc;
+        this.Status = status;
+        this.ProcessedAtUtc = processedAtUtc;
+        this.LastError = lastError;
+    }
+
+    /// <summary>
+    /// Gets the date to fetch.
+    /// </summary>
+    public DateOnly Date { get; }
+
+    /// <summary>
+    /// Gets the base currency.
+    /// </summary>
+    public Currencies Source { get; }
+
+    /// <summary>
+    /// Gets the UTC timestamp when the request was created.
+    /// </summary>
+    public DateTime RequestedAtUtc { get; }
+
+    /// <summary>
+    /// Gets the current status of the request.
+    /// </summary>
+    public PendingStatus Status { get; private set; }
+
+    /// <summary>
+    /// Gets the UTC timestamp when the request was processed, if applicable.
+    /// </summary>
+    public DateTime? ProcessedAtUtc { get; private set; }
+
+    /// <summary>
+    /// Gets the error message from the last processing attempt, if any.
+    /// </summary>
+    public string? LastError { get; private set; }
+
+    /// <summary>
+    /// Marks the request as processed.
+    /// </summary>
+    /// <param name="processedAtUtc">The UTC timestamp of the processing.</param>
+    public void MarkProcessed(DateTime processedAtUtc)
+    {
+        this.Status = PendingStatus.Processed;
+        this.ProcessedAtUtc = processedAtUtc;
+        this.LastError = null;
+    }
+
+    /// <summary>
+    /// Marks the request as failed.
+    /// </summary>
+    /// <param name="error">A description of the failure.</param>
+    public void MarkFailed(string error)
+    {
+        this.Status = PendingStatus.Failed;
+        this.LastError = error;
+    }
+}

--- a/src/MyAccountingApp.Domain/Enums/PendingStatus.cs
+++ b/src/MyAccountingApp.Domain/Enums/PendingStatus.cs
@@ -1,0 +1,16 @@
+namespace MyAccountingApp.Domain.Enums;
+
+/// <summary>
+/// Specifies the state of a queued conversion request.
+/// </summary>
+public enum PendingStatus
+{
+    /// <summary>Waiting to be processed.</summary>
+    Pending = 0,
+
+    /// <summary>Successfully processed.</summary>
+    Processed = 1,
+
+    /// <summary>Processing failed.</summary>
+    Failed = 2,
+}

--- a/src/MyAccountingApp.Domain/Exceptions/ConversionNotAvailableException.cs
+++ b/src/MyAccountingApp.Domain/Exceptions/ConversionNotAvailableException.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace MyAccountingApp.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when no conversion is available for the requested date and no stale fallback exists.
+/// </summary>
+public class ConversionNotAvailableException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConversionNotAvailableException"/> class.
+    /// </summary>
+    public ConversionNotAvailableException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConversionNotAvailableException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public ConversionNotAvailableException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConversionNotAvailableException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public ConversionNotAvailableException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/MyAccountingApp.Domain/Exceptions/CurrencyApiQuotaExceededException.cs
+++ b/src/MyAccountingApp.Domain/Exceptions/CurrencyApiQuotaExceededException.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace MyAccountingApp.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when the external currency API reports that the request quota has been exceeded.
+/// </summary>
+public class CurrencyApiQuotaExceededException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CurrencyApiQuotaExceededException"/> class.
+    /// </summary>
+    public CurrencyApiQuotaExceededException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CurrencyApiQuotaExceededException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public CurrencyApiQuotaExceededException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CurrencyApiQuotaExceededException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public CurrencyApiQuotaExceededException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/MyAccountingApp.Domain/Interfaces/IApiQuotaRepository.cs
+++ b/src/MyAccountingApp.Domain/Interfaces/IApiQuotaRepository.cs
@@ -1,0 +1,21 @@
+using MyAccountingApp.Domain.Entities;
+
+namespace MyAccountingApp.Domain.Interfaces;
+
+/// <summary>
+/// Defines storage for the currency API usage quota.
+/// </summary>
+public interface IApiQuotaRepository
+{
+    /// <summary>
+    /// Gets the current quota, creating a default quota if none is stored.
+    /// </summary>
+    /// <returns>The current quota.</returns>
+    ApiUsageQuota Get();
+
+    /// <summary>
+    /// Saves the quota to persistent storage.
+    /// </summary>
+    /// <param name="quota">The quota to save.</param>
+    void Save(ApiUsageQuota quota);
+}

--- a/src/MyAccountingApp.Domain/Interfaces/ICurrencyConverter.cs
+++ b/src/MyAccountingApp.Domain/Interfaces/ICurrencyConverter.cs
@@ -3,7 +3,7 @@
 namespace MyAccountingApp.Domain.Interfaces;
 
 /// <summary>
-/// Defines a method for fetching currency conversion rates from an external source.
+/// Defines methods for fetching currency conversion rates from an external source.
 /// </summary>
 public interface ICurrencyConverter
 {
@@ -16,5 +16,24 @@ public interface ICurrencyConverter
     /// A task that represents the asynchronous operation. The task result contains a dictionary
     /// mapping currency pair codes (e.g., "EURUSD") to their conversion rates.
     /// </returns>
-    public Task<Dictionary<string, decimal>> FetchAllRatesAsync(Currencies source, DateTime date);
+    Task<Dictionary<string, decimal>> FetchAllRatesAsync(Currencies source, DateTime date);
+
+    /// <summary>
+    /// Asynchronously fetches conversion rates for a range of dates in a single request.
+    /// </summary>
+    /// <param name="source">The base currency for conversion.</param>
+    /// <param name="start">The first date of the range (inclusive).</param>
+    /// <param name="end">The last date of the range (inclusive).</param>
+    /// <param name="targets">Optional list of target currencies; defaults to all supported currencies except the source.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains a dictionary
+    /// mapping each date to a dictionary of currency pair codes (e.g., "EURUSD") to rates.
+    /// </returns>
+    Task<IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>>> FetchRangeAsync(
+        Currencies source,
+        DateOnly start,
+        DateOnly end,
+        IReadOnlyCollection<Currencies>? targets = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/MyAccountingApp.Domain/Interfaces/IPendingConversionRepository.cs
+++ b/src/MyAccountingApp.Domain/Interfaces/IPendingConversionRepository.cs
@@ -1,0 +1,27 @@
+using MyAccountingApp.Domain.Entities;
+
+namespace MyAccountingApp.Domain.Interfaces;
+
+/// <summary>
+/// Defines storage for queued conversion requests.
+/// </summary>
+public interface IPendingConversionRepository
+{
+    /// <summary>
+    /// Gets all queued conversion requests.
+    /// </summary>
+    /// <returns>All queued conversion requests.</returns>
+    IEnumerable<PendingConversionRequest> GetAll();
+
+    /// <summary>
+    /// Adds a new request or updates an existing request.
+    /// </summary>
+    /// <param name="request">The request to add or update.</param>
+    void AddOrUpdate(PendingConversionRequest request);
+
+    /// <summary>
+    /// Replaces all stored requests with the given collection.
+    /// </summary>
+    /// <param name="requests">The requests to store.</param>
+    void Initialize(IEnumerable<PendingConversionRequest> requests);
+}

--- a/tests/MyAccountingApp.Application.Tests/Services/ApiQuotaManagerTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ApiQuotaManagerTests.cs
@@ -1,0 +1,87 @@
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Core.Repositories;
+using MyAccountingApp.Domain.Entities;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class ApiQuotaManagerTests : IDisposable
+{
+    private readonly string _tempFile;
+
+    public ApiQuotaManagerTests()
+    {
+        this._tempFile = Path.GetTempFileName();
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(this._tempFile))
+        {
+            File.Delete(this._tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_ReturnsTrue_AndSaves_WhenQuotaAvailable()
+    {
+        // Arrange
+        JsonApiQuotaRepository repo = new(this._tempFile);
+        ApiQuotaManager manager = new(repo);
+
+        // Act
+        bool result = await manager.TryConsumeAsync();
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(1, repo.Get().RequestsUsed);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_ReturnsFalse_WhenQuotaExhausted()
+    {
+        // Arrange
+        JsonApiQuotaRepository repo = new(this._tempFile);
+        ApiQuotaManager manager = new(repo);
+        ApiUsageQuota exhausted = repo.Get();
+        exhausted.MarkExhausted();
+        repo.Save(exhausted);
+
+        // Act
+        bool result = await manager.TryConsumeAsync();
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(100, repo.Get().RequestsUsed);
+    }
+
+    [Fact]
+    public async Task MarkExhaustedAsync_SavesQuotaAtLimit()
+    {
+        // Arrange
+        JsonApiQuotaRepository repo = new(this._tempFile);
+        ApiQuotaManager manager = new(repo);
+
+        // Act
+        await manager.MarkExhaustedAsync();
+
+        // Assert
+        Assert.Equal(100, repo.Get().RequestsUsed);
+        Assert.False(repo.Get().CanConsume());
+    }
+
+    [Fact]
+    public async Task GetQuotaAsync_ReturnsCurrentQuota()
+    {
+        // Arrange
+        JsonApiQuotaRepository repo = new(this._tempFile);
+        ApiQuotaManager manager = new(repo);
+
+        // Act
+        ApiUsageQuota quota = await manager.GetQuotaAsync();
+
+        // Assert
+        Assert.Equal("exchangerate.host", quota.Provider);
+        Assert.Equal(0, quota.RequestsUsed);
+        Assert.Equal(90, quota.Available);
+    }
+}

--- a/tests/MyAccountingApp.Application.Tests/Services/CurrencyConversionServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/CurrencyConversionServiceTests.cs
@@ -16,9 +16,11 @@ public class CurrencyConversionServiceTests
 
         FakeConversionRepository fakeRepo = new(); // repositori in-memory per testing
         FakeCurrencyConverter fakeApi = new();     // fake API que retorna quotes
+        FakeApiQuotaManager fakeQuota = new();
+        FakePendingConversionQueue fakeQueue = new();
 
         // Act
-        Action action = () => { new CurencyRateService(fakeRepo, fakeApi, invalidSource); };
+        Action action = () => { new CurencyRateService(fakeRepo, fakeApi, invalidSource, fakeQuota, fakeQueue); };
 
         // Assert
         Assert.Throws<ArgumentException>(() => action());
@@ -31,8 +33,10 @@ public class CurrencyConversionServiceTests
         FakeConversionRepository fakeRepo = new FakeConversionRepository(); // repositori in-memory per testing
         FakeCurrencyConverter fakeApi = new FakeCurrencyConverter();     // fake API que retorna quotes
         Currencies source = Currencies.EUR;
+        FakeApiQuotaManager fakeQuota = new();
+        FakePendingConversionQueue fakeQueue = new();
 
-        CurencyRateService service = new(fakeRepo, fakeApi, source);
+        CurencyRateService service = new(fakeRepo, fakeApi, source, fakeQuota, fakeQueue);
 
         DateTime date = new DateTime(2023, 12, 1); // This date does not exist
         Currencies targetCurrency = Currencies.USD;
@@ -54,8 +58,10 @@ public class CurrencyConversionServiceTests
         FakeConversionRepository fakeRepo = new(); // repositori in-memory per testing
         FakeCurrencyConverter fakeApi = new();     // fake API que retorna quotes
         Currencies source = Currencies.EUR;
+        FakeApiQuotaManager fakeQuota = new();
+        FakePendingConversionQueue fakeQueue = new();
 
-        CurencyRateService service = new CurencyRateService(fakeRepo, fakeApi, source);
+        CurencyRateService service = new CurencyRateService(fakeRepo, fakeApi, source, fakeQuota, fakeQueue);
 
         DateTime date = new DateTime(2005, 12, 1); // This date does  exist
         Currencies targetCurrency = Currencies.USD;

--- a/tests/MyAccountingApp.Application.Tests/Services/CurrencyRateServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/CurrencyRateServiceTests.cs
@@ -1,0 +1,247 @@
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Exceptions;
+using MyAccountingApp.TestUtilities.Fakes;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class CurrencyRateServiceTests
+{
+    [Fact]
+    public async Task GetConversionAsync_ReturnsCached_WhenExists_WithoutConsumingQuota()
+    {
+        // Arrange
+        FakeConversionRepository repo = new();
+        FakeApiQuotaManager quota = new();
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = CreateService(repo, quota, queue);
+
+        // Act
+        Conversion result = await service.GetConversionAsync(new DateTime(2005, 12, 1));
+
+        // Assert
+        Assert.False(result.IsStale);
+        Assert.Equal(0, quota.Consumed);
+        Assert.Empty(queue.Enqueued);
+    }
+
+    [Fact]
+    public async Task GetConversionAsync_FetchesFromApi_WhenMissingAndQuotaAvailable()
+    {
+        // Arrange
+        FakeConversionRepository repo = new();
+        FakeApiQuotaManager quota = new();
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = CreateService(repo, quota, queue);
+
+        // Act
+        Conversion result = await service.GetConversionAsync(new DateTime(2023, 12, 1));
+
+        // Assert
+        Assert.False(result.IsStale);
+        Assert.Equal(1, quota.Consumed);
+        Assert.Equal(1.1m, result.Quotes[Currencies.USD]);
+        Assert.NotNull(repo.GetByDate(new DateTime(2023, 12, 1)));
+    }
+
+    [Fact]
+    public async Task GetConversionAsync_ReturnsStaleFallback_WhenMissingAndNoQuota()
+    {
+        // Arrange
+        FakeConversionRepository repo = new();
+        FakeApiQuotaManager quota = new() { CanConsumeResult = false };
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = CreateService(repo, quota, queue);
+
+        // Act
+        Conversion result = await service.GetConversionAsync(new DateTime(2023, 12, 1));
+
+        // Assert
+        Assert.True(result.IsStale);
+        Assert.Equal(0, quota.Consumed);
+        Assert.Contains(new DateOnly(2023, 12, 1), queue.Enqueued);
+        Assert.Equal(new DateTime(2005, 12, 1), result.Date);
+        Assert.Equal(1.1m, result.Quotes[Currencies.USD]);
+    }
+
+    [Fact]
+    public async Task GetConversionAsync_Throws_WhenMissingNoQuotaAndNoHistory()
+    {
+        // Arrange
+        FakeConversionRepository repo = new();
+        repo.Initialize(Array.Empty<Conversion>());
+        FakeApiQuotaManager quota = new() { CanConsumeResult = false };
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = CreateService(repo, quota, queue);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConversionNotAvailableException>(() => service.GetConversionAsync(new DateTime(2023, 12, 1)));
+    }
+
+    [Fact]
+    public async Task SyncRangeAsync_SavesAllDatesAndConsumesOneRequest()
+    {
+        // Arrange
+        FakeConversionRepository repo = new();
+        repo.Initialize(Array.Empty<Conversion>());
+        FakeApiQuotaManager quota = new();
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = CreateService(repo, quota, queue);
+
+        // Act
+        bool result = await service.SyncRangeAsync(new DateOnly(2023, 12, 1), new DateOnly(2023, 12, 5));
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(1, quota.Consumed);
+        Assert.Equal(5, repo.GetAll().Count());
+    }
+
+    [Fact]
+    public async Task SyncRangeAsync_ReturnsFalse_WhenNoQuota()
+    {
+        // Arrange
+        FakeApiQuotaManager quota = new() { CanConsumeResult = false };
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = CreateService(new FakeConversionRepository(), quota, queue);
+
+        // Act
+        bool result = await service.SyncRangeAsync(new DateOnly(2023, 12, 1), new DateOnly(2023, 12, 5));
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(0, quota.Consumed);
+    }
+
+    [Fact]
+    public async Task ProcessPendingAsync_GroupsContiguousDates_IntoSingleRequest()
+    {
+        // Arrange
+        FakeConversionRepository repo = new();
+        repo.Initialize(Array.Empty<Conversion>());
+        FakeApiQuotaManager quota = new();
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = CreateService(repo, quota, queue);
+
+        for (int day = 1; day <= 5; day++)
+        {
+            await queue.EnqueueAsync(new DateOnly(2023, 12, day));
+        }
+
+        // Act
+        PendingProcessingResult result = await service.ProcessPendingAsync();
+
+        // Assert
+        Assert.Equal(1, result.RequestsSpent);
+        Assert.Equal(5, result.ProcessedDays);
+        Assert.Equal(5, repo.GetAll().Count());
+    }
+
+    [Fact]
+    public async Task ProcessPendingAsync_SplitsNonContiguousDates_IntoMultipleRequests()
+    {
+        // Arrange
+        FakeConversionRepository repo = new();
+        repo.Initialize(Array.Empty<Conversion>());
+        FakeApiQuotaManager quota = new();
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = CreateService(repo, quota, queue);
+
+        await queue.EnqueueAsync(new DateOnly(2023, 12, 1));
+        await queue.EnqueueAsync(new DateOnly(2023, 12, 2));
+        await queue.EnqueueAsync(new DateOnly(2023, 12, 10));
+        await queue.EnqueueAsync(new DateOnly(2023, 12, 11));
+
+        // Act
+        PendingProcessingResult result = await service.ProcessPendingAsync();
+
+        // Assert
+        Assert.Equal(2, result.RequestsSpent);
+        Assert.Equal(4, result.ProcessedDays);
+    }
+
+    [Fact]
+    public async Task ProcessPendingAsync_StopsWhenQuotaExhausted()
+    {
+        // Arrange
+        FakeConversionRepository repo = new();
+        repo.Initialize(Array.Empty<Conversion>());
+        FakeApiQuotaManager quota = new() { MaxConsumptions = 1 };
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = CreateService(repo, quota, queue);
+
+        await queue.EnqueueAsync(new DateOnly(2023, 12, 1));
+        await queue.EnqueueAsync(new DateOnly(2023, 12, 10));
+
+        // Act
+        PendingProcessingResult result = await service.ProcessPendingAsync();
+
+        // Assert
+        Assert.Equal(1, result.RequestsSpent);
+        Assert.Equal(1, result.ProcessedDays);
+
+        IReadOnlyList<PendingConversionRequest> remaining = await queue.GetPendingAsync();
+        Assert.Single(remaining);
+        Assert.Equal(new DateOnly(2023, 12, 10), remaining[0].Date);
+    }
+
+    [Fact]
+    public async Task BackfillIfEmptyAsync_FetchesRange_WhenRepoEmpty()
+    {
+        // Arrange
+        FakeConversionRepository repo = new();
+        repo.Initialize(Array.Empty<Conversion>());
+        FakeApiQuotaManager quota = new();
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = CreateService(repo, quota, queue);
+
+        // Act
+        bool result = await service.BackfillIfEmptyAsync(3);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(1, quota.Consumed);
+        Assert.Equal(3, repo.GetAll().Count());
+    }
+
+    [Fact]
+    public async Task BackfillIfEmptyAsync_DoesNothing_WhenRepoNotEmpty()
+    {
+        // Arrange
+        FakeApiQuotaManager quota = new();
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = CreateService(new FakeConversionRepository(), quota, queue);
+
+        // Act
+        bool result = await service.BackfillIfEmptyAsync(3);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(0, quota.Consumed);
+    }
+
+    [Fact]
+    public async Task GetQuotaAsync_ReturnsQuotaFromManager()
+    {
+        // Arrange
+        FakeApiQuotaManager quota = new();
+        CurencyRateService service = CreateService(new FakeConversionRepository(), quota, new FakePendingConversionQueue());
+
+        // Act
+        ApiUsageQuota result = await service.GetQuotaAsync();
+
+        // Assert
+        Assert.Equal("test", result.Provider);
+        Assert.Equal(0, result.RequestsUsed);
+        Assert.Equal(90, result.Available);
+    }
+
+    private static CurencyRateService CreateService(
+        FakeConversionRepository repo,
+        FakeApiQuotaManager quota,
+        FakePendingConversionQueue queue)
+    {
+        return new CurencyRateService(repo, new FakeCurrencyConverter(), Currencies.EUR, quota, queue);
+    }
+}

--- a/tests/MyAccountingApp.Application.Tests/Services/PendingConversionQueueTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/PendingConversionQueueTests.cs
@@ -1,0 +1,90 @@
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Core.Repositories;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class PendingConversionQueueTests : IDisposable
+{
+    private readonly string _tempFile;
+
+    public PendingConversionQueueTests()
+    {
+        this._tempFile = Path.GetTempFileName();
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(this._tempFile))
+        {
+            File.Delete(this._tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_AddsRequest_WhenNewDate()
+    {
+        // Arrange
+        JsonPendingConversionRepository repo = new(this._tempFile);
+        PendingConversionQueue queue = new(repo);
+
+        // Act
+        await queue.EnqueueAsync(new DateOnly(2026, 7, 1));
+
+        // Assert
+        IReadOnlyList<PendingConversionRequest> pending = await queue.GetPendingAsync();
+        PendingConversionRequest item = Assert.Single(pending);
+        Assert.Equal(new DateOnly(2026, 7, 1), item.Date);
+        Assert.Equal(PendingStatus.Pending, item.Status);
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_DoesNotDuplicate_WhenSameDate()
+    {
+        // Arrange
+        JsonPendingConversionRepository repo = new(this._tempFile);
+        PendingConversionQueue queue = new(repo);
+
+        // Act
+        await queue.EnqueueAsync(new DateOnly(2026, 7, 1));
+        await queue.EnqueueAsync(new DateOnly(2026, 7, 1));
+
+        // Assert
+        IReadOnlyList<PendingConversionRequest> pending = await queue.GetPendingAsync();
+        Assert.Single(pending);
+    }
+
+    [Fact]
+    public async Task MarkProcessedAsync_RemovesFromPending()
+    {
+        // Arrange
+        JsonPendingConversionRepository repo = new(this._tempFile);
+        PendingConversionQueue queue = new(repo);
+        await queue.EnqueueAsync(new DateOnly(2026, 7, 1));
+
+        // Act
+        await queue.MarkProcessedAsync(new DateOnly(2026, 7, 1));
+
+        // Assert
+        IReadOnlyList<PendingConversionRequest> pending = await queue.GetPendingAsync();
+        Assert.Empty(pending);
+    }
+
+    [Fact]
+    public async Task MarkFailedAsync_RecordsError()
+    {
+        // Arrange
+        JsonPendingConversionRepository repo = new(this._tempFile);
+        PendingConversionQueue queue = new(repo);
+        await queue.EnqueueAsync(new DateOnly(2026, 7, 1));
+
+        // Act
+        await queue.MarkFailedAsync(new DateOnly(2026, 7, 1), "boom");
+
+        // Assert
+        PendingConversionRequest request = repo.GetAll().Single();
+        Assert.Equal(PendingStatus.Failed, request.Status);
+        Assert.Equal("boom", request.LastError);
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Repositories/JsonApiQuotaRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/JsonApiQuotaRepositoryTests.cs
@@ -1,0 +1,57 @@
+using MyAccountingApp.Core.Repositories;
+using MyAccountingApp.Domain.Entities;
+
+namespace MyAccountingApp.Core.Tests.Repositories;
+
+public class JsonApiQuotaRepositoryTests : IDisposable
+{
+    private readonly string _tempFile;
+
+    public JsonApiQuotaRepositoryTests()
+    {
+        this._tempFile = Path.GetTempFileName();
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(this._tempFile))
+        {
+            File.Delete(this._tempFile);
+        }
+    }
+
+    [Fact]
+    public void Get_ReturnsDefaultQuota_WhenFileDoesNotExist()
+    {
+        // Arrange
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        JsonApiQuotaRepository repo = new(path);
+
+        // Act
+        ApiUsageQuota quota = repo.Get();
+
+        // Assert
+        Assert.Equal("exchangerate.host", quota.Provider);
+        Assert.Equal(100, quota.RequestsLimit);
+        Assert.Equal(0, quota.RequestsUsed);
+        Assert.Equal(90, quota.Available);
+    }
+
+    [Fact]
+    public void Save_ThenGet_RoundTrips()
+    {
+        // Arrange
+        JsonApiQuotaRepository repo = new(this._tempFile);
+        DateOnly start = new(2026, 7, 1);
+        ApiUsageQuota quota = new("exchangerate.host", start, start.AddMonths(1).AddDays(-1), 25, 100, 10, DateTime.UtcNow);
+
+        // Act
+        repo.Save(quota);
+        ApiUsageQuota loaded = repo.Get();
+
+        // Assert
+        Assert.Equal(25, loaded.RequestsUsed);
+        Assert.Equal(65, loaded.Available);
+        Assert.Equal(start, loaded.PeriodStart);
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Repositories/JsonConversionRepositoryMigrationTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/JsonConversionRepositoryMigrationTests.cs
@@ -1,0 +1,68 @@
+using MyAccountingApp.Core.Repositories;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+
+namespace MyAccountingApp.Core.Tests.Repositories;
+
+public class JsonConversionRepositoryMigrationTests : IDisposable
+{
+    private readonly string _tempFile;
+
+    public JsonConversionRepositoryMigrationTests()
+    {
+        this._tempFile = Path.GetTempFileName();
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(this._tempFile))
+        {
+            File.Delete(this._tempFile);
+        }
+    }
+
+    [Fact]
+    public void GetByDate_LoadsLegacyFormat_WithoutNewFields()
+    {
+        // Arrange
+        string legacyJson = """[{"Date":"2022-06-15T00:00:00","Source":"EUR","Quotes":{"USD":1.05,"CAD":1.3}}]""";
+        File.WriteAllText(this._tempFile, legacyJson);
+        JsonConversionRepository repo = new(this._tempFile);
+
+        // Act
+        Conversion? conversion = repo.GetByDate(new DateTime(2022, 6, 15));
+
+        // Assert
+        Assert.NotNull(conversion);
+        Assert.Equal(1.05m, conversion!.Quotes[Currencies.USD]);
+        Assert.Equal(1.3m, conversion.Quotes[Currencies.CAD]);
+        Assert.False(conversion.IsStale);
+        Assert.Equal("exchangerate.host", conversion.SourceProvider);
+        Assert.Equal(new DateTime(2022, 6, 15), conversion.RetrievedAtUtc);
+    }
+
+    [Fact]
+    public void AddOrUpdate_RoundTripsNewFields()
+    {
+        // Arrange
+        JsonConversionRepository repo = new(this._tempFile);
+        Dictionary<Currencies, decimal> quotes = new() { { Currencies.USD, 1.1m } };
+        Conversion conversion = new(
+            new DateTime(2023, 1, 1),
+            Currencies.EUR,
+            quotes,
+            new DateTime(2023, 1, 1, 10, 30, 0),
+            isStale: true,
+            sourceProvider: "exchangerate.host");
+
+        // Act
+        repo.AddOrUpdate(conversion);
+        Conversion? loaded = repo.GetByDate(new DateTime(2023, 1, 1));
+
+        // Assert
+        Assert.NotNull(loaded);
+        Assert.True(loaded!.IsStale);
+        Assert.Equal("exchangerate.host", loaded.SourceProvider);
+        Assert.Equal(new DateTime(2023, 1, 1, 10, 30, 0), loaded.RetrievedAtUtc);
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Repositories/JsonPendingConversionRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/JsonPendingConversionRepositoryTests.cs
@@ -1,0 +1,72 @@
+using MyAccountingApp.Core.Repositories;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+
+namespace MyAccountingApp.Core.Tests.Repositories;
+
+public class JsonPendingConversionRepositoryTests : IDisposable
+{
+    private readonly string _tempFile;
+
+    public JsonPendingConversionRepositoryTests()
+    {
+        this._tempFile = Path.GetTempFileName();
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(this._tempFile))
+        {
+            File.Delete(this._tempFile);
+        }
+    }
+
+    [Fact]
+    public void GetAll_ReturnsEmpty_WhenFileDoesNotExist()
+    {
+        // Arrange
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        JsonPendingConversionRepository repo = new(path);
+
+        // Act
+        IEnumerable<PendingConversionRequest> result = repo.GetAll();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void AddOrUpdate_ThenGetAll_RoundTrips()
+    {
+        // Arrange
+        JsonPendingConversionRepository repo = new(this._tempFile);
+        PendingConversionRequest request = new(new DateOnly(2026, 7, 1), Currencies.EUR, DateTime.UtcNow);
+
+        // Act
+        repo.AddOrUpdate(request);
+        IEnumerable<PendingConversionRequest> loaded = repo.GetAll();
+
+        // Assert
+        PendingConversionRequest item = Assert.Single(loaded);
+        Assert.Equal(new DateOnly(2026, 7, 1), item.Date);
+        Assert.Equal(PendingStatus.Pending, item.Status);
+    }
+
+    [Fact]
+    public void AddOrUpdate_SameDate_UpdatesExisting()
+    {
+        // Arrange
+        JsonPendingConversionRepository repo = new(this._tempFile);
+        PendingConversionRequest failed = new(new DateOnly(2026, 7, 1), Currencies.EUR, DateTime.UtcNow);
+        failed.MarkFailed("boom");
+
+        // Act
+        repo.AddOrUpdate(failed);
+        repo.AddOrUpdate(new PendingConversionRequest(new DateOnly(2026, 7, 1), Currencies.EUR, DateTime.UtcNow));
+
+        // Assert
+        PendingConversionRequest loaded = Assert.Single(repo.GetAll());
+        Assert.Equal(PendingStatus.Pending, loaded.Status);
+        Assert.Null(loaded.LastError);
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Services/CurrencyConverterTimeseriesTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/CurrencyConverterTimeseriesTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using MyAccountingApp.Core.Services;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Exceptions;
+using MyAccountingApp.TestUtilities.Fakes;
+
+namespace MyAccountingApp.Core.Tests.Services;
+
+public class CurrencyConverterTimeseriesTests
+{
+    [Fact]
+    public async Task FetchRangeAsync_ReturnsRatesForEachDate()
+    {
+        // Arrange
+        string responseContent = """{"success":true,"rates":{"2025-01-01":{"USD":1.05,"CAD":1.5},"2025-01-02":{"USD":1.06,"CAD":1.51}}}""";
+        HttpClient client = FakeHttpClient.CreateFakeHttpClient(responseContent, HttpStatusCode.OK);
+        CurrencyConverter converter = new("key", client);
+
+        // Act
+        IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>> result = await converter.FetchRangeAsync(
+            Currencies.EUR, new DateOnly(2025, 1, 1), new DateOnly(2025, 1, 2));
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1.05m, result[new DateOnly(2025, 1, 1)]["EURUSD"]);
+        Assert.Equal(1.06m, result[new DateOnly(2025, 1, 2)]["EURUSD"]);
+        Assert.Equal(1.51m, result[new DateOnly(2025, 1, 2)]["EURCAD"]);
+    }
+
+    [Fact]
+    public async Task FetchRangeAsync_ThrowsArgumentException_WhenStartAfterEnd()
+    {
+        // Arrange
+        HttpClient client = FakeHttpClient.CreateFakeHttpClient("""{"success":true,"rates":{}}""", HttpStatusCode.OK);
+        CurrencyConverter converter = new("key", client);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => converter.FetchRangeAsync(
+            Currencies.EUR, new DateOnly(2025, 1, 5), new DateOnly(2025, 1, 1)));
+    }
+
+    [Fact]
+    public async Task FetchRangeAsync_ThrowsQuotaExceeded_WhenApiReportsQuotaError()
+    {
+        // Arrange
+        string responseContent = """{"success":false,"error":{"code":104,"info":"Your monthly API request volume limit has been reached."}}""";
+        HttpClient client = FakeHttpClient.CreateFakeHttpClient(responseContent, HttpStatusCode.OK);
+        CurrencyConverter converter = new("key", client);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<CurrencyApiQuotaExceededException>(() => converter.FetchRangeAsync(
+            Currencies.EUR, new DateOnly(2025, 1, 1), new DateOnly(2025, 1, 2)));
+    }
+
+    [Fact]
+    public async Task FetchRangeAsync_ThrowsQuotaExceeded_WhenHttp429()
+    {
+        // Arrange
+        HttpClient client = FakeHttpClient.CreateFakeHttpClient("{}", HttpStatusCode.TooManyRequests);
+        CurrencyConverter converter = new("key", client);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<CurrencyApiQuotaExceededException>(() => converter.FetchRangeAsync(
+            Currencies.EUR, new DateOnly(2025, 1, 1), new DateOnly(2025, 1, 2)));
+    }
+
+    [Fact]
+    public async Task FetchRangeAsync_ExcludesConfiguredCurrenciesFromRequest()
+    {
+        // Arrange
+        CapturingHandler handler = new();
+        HttpClient client = new(handler);
+        CurrencyConverter converter = new("key", client, new[] { "BTC" });
+
+        // Act
+        await converter.FetchRangeAsync(Currencies.EUR, new DateOnly(2025, 1, 1), new DateOnly(2025, 1, 2));
+
+        // Assert
+        Assert.NotNull(handler.LastUrl);
+        Assert.DoesNotContain("BTC", handler.LastUrl);
+        Assert.Contains("USD", handler.LastUrl);
+    }
+
+    [Fact]
+    public async Task FetchAllRatesAsync_ExcludesConfiguredCurrenciesFromRequest()
+    {
+        // Arrange
+        CapturingHandler handler = new();
+        HttpClient client = new(handler);
+        CurrencyConverter converter = new("key", client, new[] { "BTC" });
+
+        // Act
+        await converter.FetchAllRatesAsync(Currencies.EUR, new DateTime(2025, 1, 1));
+
+        // Assert
+        Assert.NotNull(handler.LastUrl);
+        Assert.DoesNotContain("BTC", handler.LastUrl);
+        Assert.Contains("USD", handler.LastUrl);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public string? LastUrl { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            this.LastUrl = request.RequestUri?.ToString();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"success":true,"rates":{}}"""),
+            });
+        }
+    }
+}

--- a/tests/MyAccountingApp.Domain.Tests/Entities/ApiUsageQuotaTests.cs
+++ b/tests/MyAccountingApp.Domain.Tests/Entities/ApiUsageQuotaTests.cs
@@ -1,0 +1,116 @@
+using MyAccountingApp.Domain.Entities;
+
+namespace MyAccountingApp.Domain.Tests.Entities;
+
+public class ApiUsageQuotaTests
+{
+    [Fact]
+    public void CanConsume_ReturnsTrue_WhenWithinLimit()
+    {
+        // Arrange
+        ApiUsageQuota quota = CreateQuota(used: 50, limit: 100, margin: 10);
+
+        // Act & Assert
+        Assert.True(quota.CanConsume());
+        Assert.Equal(40, quota.Available);
+    }
+
+    [Fact]
+    public void CanConsume_ReturnsFalse_WhenQuotaExhausted()
+    {
+        // Arrange
+        ApiUsageQuota quota = CreateQuota(used: 95, limit: 100, margin: 10);
+
+        // Act & Assert
+        Assert.False(quota.CanConsume());
+        Assert.Equal(0, quota.Available);
+    }
+
+    [Fact]
+    public void CanConsume_ReturnsFalse_WhenCostExceedsAvailable()
+    {
+        // Arrange
+        ApiUsageQuota quota = CreateQuota(used: 85, limit: 100, margin: 10);
+
+        // Act & Assert
+        Assert.False(quota.CanConsume(cost: 10));
+        Assert.True(quota.CanConsume(cost: 5));
+    }
+
+    [Fact]
+    public void RegisterUsage_IncrementsRequestsUsed()
+    {
+        // Arrange
+        ApiUsageQuota quota = CreateQuota(used: 10, limit: 100, margin: 10);
+
+        // Act
+        quota.RegisterUsage(5);
+
+        // Assert
+        Assert.Equal(15, quota.RequestsUsed);
+    }
+
+    [Fact]
+    public void RegisterUsage_DoesNotExceedLimit()
+    {
+        // Arrange
+        ApiUsageQuota quota = CreateQuota(used: 99, limit: 100, margin: 10);
+
+        // Act
+        quota.RegisterUsage(10);
+
+        // Assert
+        Assert.Equal(100, quota.RequestsUsed);
+        Assert.Equal(0, quota.Available);
+    }
+
+    [Fact]
+    public void MarkExhausted_SetsUsedToLimit()
+    {
+        // Arrange
+        ApiUsageQuota quota = CreateQuota(used: 30, limit: 100, margin: 10);
+
+        // Act
+        quota.MarkExhausted();
+
+        // Assert
+        Assert.Equal(100, quota.RequestsUsed);
+        Assert.False(quota.CanConsume());
+    }
+
+    [Fact]
+    public void EnsureCurrentPeriod_ResetsUsage_WhenNewPeriod()
+    {
+        // Arrange
+        ApiUsageQuota quota = new("test", new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 30), 80, 100, 10, DateTime.UtcNow);
+
+        // Act
+        quota.EnsureCurrentPeriod(new DateOnly(2026, 7, 10));
+
+        // Assert
+        Assert.Equal(new DateOnly(2026, 7, 1), quota.PeriodStart);
+        Assert.Equal(new DateOnly(2026, 7, 31), quota.PeriodEnd);
+        Assert.Equal(0, quota.RequestsUsed);
+        Assert.Equal(90, quota.Available);
+    }
+
+    [Fact]
+    public void EnsureCurrentPeriod_KeepsUsage_WhenSamePeriod()
+    {
+        // Arrange
+        ApiUsageQuota quota = new("test", new DateOnly(2026, 7, 1), new DateOnly(2026, 7, 31), 40, 100, 10, DateTime.UtcNow);
+
+        // Act
+        quota.EnsureCurrentPeriod(new DateOnly(2026, 7, 10));
+
+        // Assert
+        Assert.Equal(40, quota.RequestsUsed);
+        Assert.Equal(new DateOnly(2026, 7, 1), quota.PeriodStart);
+    }
+
+    private static ApiUsageQuota CreateQuota(int used, int limit, int margin)
+    {
+        DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        return new ApiUsageQuota("test", today, today.AddMonths(1).AddDays(-1), used, limit, margin, DateTime.UtcNow);
+    }
+}

--- a/tests/MyAccountingApp.TestUtilities/Fakes/FakeApiQuotaManager.cs
+++ b/tests/MyAccountingApp.TestUtilities/Fakes/FakeApiQuotaManager.cs
@@ -1,0 +1,68 @@
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Domain.Entities;
+
+namespace MyAccountingApp.TestUtilities.Fakes;
+
+/// <summary>
+/// Fake quota manager for testing, with configurable availability.
+/// </summary>
+public class FakeApiQuotaManager : IApiQuotaManager
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether quota consumption is allowed.
+    /// </summary>
+    public bool CanConsumeResult { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum number of consumptions allowed before the quota is exhausted.
+    /// </summary>
+    public int? MaxConsumptions { get; set; }
+
+    /// <summary>
+    /// Gets the total number of requests consumed.
+    /// </summary>
+    public int Consumed { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the quota was marked as exhausted.
+    /// </summary>
+    public bool Exhausted { get; private set; }
+
+    /// <inheritdoc/>
+    public Task<ApiUsageQuota> GetQuotaAsync(CancellationToken cancellationToken = default)
+    {
+        DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        ApiUsageQuota quota = new("test", today, today.AddMonths(1).AddDays(-1), this.Consumed, 100, 10, DateTime.UtcNow);
+        return Task.FromResult(quota);
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> TryConsumeAsync(int cost = 1, CancellationToken cancellationToken = default)
+    {
+        if (this.MaxConsumptions.HasValue && this.Consumed >= this.MaxConsumptions.Value)
+        {
+            return Task.FromResult(false);
+        }
+
+        if (!this.CanConsumeResult)
+        {
+            return Task.FromResult(false);
+        }
+
+        this.Consumed += cost;
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc/>
+    public Task MarkExhaustedAsync(CancellationToken cancellationToken = default)
+    {
+        this.Exhausted = true;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task EnsurePeriodAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/tests/MyAccountingApp.TestUtilities/Fakes/FakeCurrencyConverter.cs
+++ b/tests/MyAccountingApp.TestUtilities/Fakes/FakeCurrencyConverter.cs
@@ -14,4 +14,25 @@ public class FakeCurrencyConverter : ICurrencyConverter
             { "EURCAD", 1.5m },
         };
     }
+
+    public Task<IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>>> FetchRangeAsync(
+        Currencies source,
+        DateOnly start,
+        DateOnly end,
+        IReadOnlyCollection<Currencies>? targets = null,
+        CancellationToken cancellationToken = default)
+    {
+        Dictionary<DateOnly, Dictionary<string, decimal>> result = new();
+
+        for (DateOnly day = start; day <= end; day = day.AddDays(1))
+        {
+            result[day] = new Dictionary<string, decimal>
+            {
+                { "EURUSD", 1.1m },
+                { "EURCAD", 1.5m },
+            };
+        }
+
+        return Task.FromResult<IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>>>(result);
+    }
 }

--- a/tests/MyAccountingApp.TestUtilities/Fakes/FakePendingConversionQueue.cs
+++ b/tests/MyAccountingApp.TestUtilities/Fakes/FakePendingConversionQueue.cs
@@ -1,0 +1,62 @@
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+
+namespace MyAccountingApp.TestUtilities.Fakes;
+
+/// <summary>
+/// In-memory fake of the pending conversion queue for testing.
+/// </summary>
+public class FakePendingConversionQueue : IPendingConversionQueue
+{
+    private readonly List<PendingConversionRequest> _requests = new();
+
+    /// <summary>
+    /// Gets the set of dates enqueued.
+    /// </summary>
+    public IReadOnlyCollection<DateOnly> Enqueued => this._requests.Select(r => r.Date).ToList();
+
+    /// <inheritdoc/>
+    public Task EnqueueAsync(DateOnly date, CancellationToken cancellationToken = default)
+    {
+        if (this._requests.All(r => r.Date != date))
+        {
+            this._requests.Add(new PendingConversionRequest(date, Currencies.EUR, DateTime.UtcNow));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<PendingConversionRequest>> GetPendingAsync(CancellationToken cancellationToken = default)
+    {
+        List<PendingConversionRequest> pending = this._requests.Where(r => r.Status == PendingStatus.Pending).ToList();
+        return Task.FromResult<IReadOnlyList<PendingConversionRequest>>(pending);
+    }
+
+    /// <inheritdoc/>
+    public Task MarkProcessedAsync(DateOnly date, CancellationToken cancellationToken = default)
+    {
+        PendingConversionRequest? request = this._requests.FirstOrDefault(r => r.Date == date);
+
+        if (request != null)
+        {
+            request.MarkProcessed(DateTime.UtcNow);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task MarkFailedAsync(DateOnly date, string error, CancellationToken cancellationToken = default)
+    {
+        PendingConversionRequest? request = this._requests.FirstOrDefault(r => r.Date == date);
+
+        if (request != null)
+        {
+            request.MarkFailed(error);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/MyAccountingApp.TestUtilities/MyAccountingApp.TestUtilities.csproj
+++ b/tests/MyAccountingApp.TestUtilities/MyAccountingApp.TestUtilities.csproj
@@ -12,6 +12,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\MyAccountingApp.Core\MyAccountingApp.Core.csproj" />
+		<ProjectReference Include="..\..\src\MyAccountingApp.Application\MyAccountingApp.Application.csproj" />
 		<ProjectReference Include="..\..\src\MyAccountingApp.Domain\MyAccountingApp.Domain.csproj" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Quota-aware currency conversion caching

Implements the approved plan for caching currency rates while respecting the monthly API quota.

### Changes
- **Model**: `Conversion` extended with `RetrievedAtUtc`, `IsStale`, `SourceProvider`; new `ApiUsageQuota`, `PendingConversionRequest`, `PendingStatus`
- **Persistence**: `JsonApiQuotaRepository`, `JsonPendingConversionRepository` (data/api_quota.json, data/pending_conversions.json)
- **API client**: `CurrencyConverter` now supports the `/timeseries` endpoint (`FetchRangeAsync`), excluded currencies, and 429/quota error handling
- **Orchestration**: `CurencyRateService` rewritten cache-first with quota pre-check, stale fallback, pending queue, range grouping, startup backfill
- **Endpoints**: `GET /api/conversions/quota`, `POST /api/conversions/sync`, `POST /api/conversions/process-pending`
- **Tests**: 41 new tests (ApiUsageQuota, service orchestration, timeseries client, JSON repos, migration, quota manager, pending queue)

### Notes
- CI coverage gate already failing on main (pre-existing, addressed separately)