### PR TITLE
test: raise combined line coverage above 80%

### DIFF
--- a/tests/MyAccountingApp.Application.Tests/Services/ImportServiceOptionsTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ImportServiceOptionsTests.cs
@@ -1,0 +1,186 @@
+using Microsoft.Extensions.Logging;
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class ImportServiceOptionsTests
+{
+    [Fact]
+    public async Task ImportFromFoldersAsync_PersistsOptionTransactions()
+    {
+        string dir = CreateTempDir();
+        File.WriteAllText(Path.Combine(dir, "options.csv"), "dummy");
+
+        Transaction tx = new(Guid.NewGuid(), new DateTime(2024, 5, 1), "VET 16JAN26 10 C", new Money(110, "USD"), TransactionCategory.EXPENSE);
+        OptionTransaction optionTx = new(tx, "VET", string.Empty, 1, AssetTransactionType.Buy);
+
+        FakeBroker broker = new() { OptionTransactions = new[] { optionTx } };
+        FakeTxRepo txRepo = new();
+        FakePfRepo pfRepo = new();
+        FakeOptionRepo optionRepo = new();
+        ImportService service = new(broker, txRepo, pfRepo, optionRepo, new TransactionValidator(), new FakeLogger<ImportService>());
+
+        ImportResult result = await service.ImportFromFoldersAsync(new[] { dir });
+
+        Assert.Single(result.OptionTransactions);
+        Assert.Single(optionRepo.GetAll());
+        Assert.Empty(txRepo.GetAll());
+    }
+
+    [Fact]
+    public async Task ImportFromFoldersAsync_MergesAssets_UpdatingExistingById()
+    {
+        string dir = CreateTempDir();
+        File.WriteAllText(Path.Combine(dir, "assets.csv"), "dummy");
+
+        Guid id = Guid.NewGuid();
+        Transaction existingTx = new(id, new DateTime(2024, 1, 1), "Old", new Money(100, "USD"), TransactionCategory.EXPENSE);
+        AssetTransaction existing = new(existingTx, "AAPL", 5, AssetTransactionType.Buy);
+
+        Transaction newTx = new(id, new DateTime(2024, 1, 1), "Updated", new Money(150, "USD"), TransactionCategory.EXPENSE);
+        AssetTransaction updated = new(newTx, "AAPL", 10, AssetTransactionType.Buy);
+
+        FakeBroker broker = new() { AssetTransactions = new[] { updated } };
+        FakeTxRepo txRepo = new();
+        FakePfRepo pfRepo = new();
+        pfRepo.Initialize(new[] { existing });
+        ImportService service = new(broker, txRepo, pfRepo, new FakeOptionRepo(), new TransactionValidator(), new FakeLogger<ImportService>());
+
+        ImportResult result = await service.ImportFromFoldersAsync(new[] { dir });
+
+        Assert.Single(result.AssetTransactions);
+        AssetTransaction merged = Assert.Single(pfRepo.GetAllTransactions());
+        Assert.Equal(10, merged.Quantity);
+        Assert.Equal("Updated", merged.Transaction.Description);
+    }
+
+    [Fact]
+    public async Task ImportFromFoldersAsync_ProcessesMultipleFolders()
+    {
+        string dir1 = CreateTempDir();
+        File.WriteAllText(Path.Combine(dir1, "a.csv"), "dummy");
+        string dir2 = CreateTempDir();
+        File.WriteAllText(Path.Combine(dir2, "b.csv"), "dummy");
+
+        Transaction tx1 = new(Guid.NewGuid(), new DateTime(2024, 2, 1), "One", new Money(10, "EUR"), TransactionCategory.INCOME);
+        Transaction tx2 = new(Guid.NewGuid(), new DateTime(2024, 2, 2), "Two", new Money(20, "EUR"), TransactionCategory.INCOME);
+
+        FakeBroker broker = new();
+        broker.Transactions = new[] { tx1 };
+        broker.TransactionsByFile = new Dictionary<string, IEnumerable<Transaction>>
+        {
+            { Path.Combine(dir2, "b.csv"), new[] { tx2 } },
+        };
+
+        FakeTxRepo txRepo = new();
+        ImportService service = new(broker, txRepo, new FakePfRepo(), new FakeOptionRepo(), new TransactionValidator(), new FakeLogger<ImportService>());
+
+        ImportResult result = await service.ImportFromFoldersAsync(new[] { dir1, dir2 });
+
+        Assert.Equal(2, result.FilesProcessed);
+        Assert.Equal(2, txRepo.GetAll().Count());
+    }
+
+    private static string CreateTempDir()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private sealed class FakeBroker : IBrokerImportService
+    {
+        public IEnumerable<Transaction> Transactions { get; set; } = Array.Empty<Transaction>();
+        public IEnumerable<AssetTransaction> AssetTransactions { get; set; } = Array.Empty<AssetTransaction>();
+        public IEnumerable<OptionTransaction> OptionTransactions { get; set; } = Array.Empty<OptionTransaction>();
+        public Dictionary<string, IEnumerable<Transaction>> TransactionsByFile { get; set; } = new();
+
+        public Task<(IEnumerable<Transaction>, IEnumerable<AssetTransaction>, IEnumerable<OptionTransaction>)> ParseAllAsync(
+            string filePath, CancellationToken cancellationToken = default)
+        {
+            IEnumerable<Transaction> tx = this.TransactionsByFile.TryGetValue(filePath, out IEnumerable<Transaction>? specific)
+                ? specific
+                : this.Transactions;
+            return Task.FromResult((tx, this.AssetTransactions, this.OptionTransactions));
+        }
+
+        public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(
+            string filePath, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(this.AssetTransactions);
+        }
+    }
+
+    private sealed class FakeTxRepo : ITransactionRepository
+    {
+        private readonly List<Transaction> _transactions = new();
+
+        public void AddOrUpdate(Transaction tx) => this._transactions.Add(tx);
+        public void Initialize(IEnumerable<Transaction> transactions)
+        {
+            this._transactions.Clear();
+            this._transactions.AddRange(transactions);
+        }
+
+        public IEnumerable<Transaction> GetAll() => this._transactions;
+        public bool Delete(Transaction transaction) => this._transactions.Remove(transaction);
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Date.Year == year);
+    }
+
+    private sealed class FakePfRepo : IPortfolioRepository
+    {
+        private readonly List<AssetTransaction> _transactions = new();
+
+        public void AddOrUpdate(AssetTransaction tx) => this._transactions.Add(tx);
+        public IEnumerable<AssetTransaction> GetAssetTransactions(string symbol) => this._transactions.Where(t => t.Symbol == symbol);
+        public IEnumerable<AssetTransaction> GetAllTransactions() => this._transactions;
+        public void Initialize(IEnumerable<AssetTransaction> transactions)
+        {
+            this._transactions.Clear();
+            this._transactions.AddRange(transactions);
+        }
+
+        public bool Delete(Guid transactionId) => true;
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
+    }
+
+    private sealed class FakeOptionRepo : IOptionTransactionRepository
+    {
+        private readonly List<OptionTransaction> _transactions = new();
+
+        public void Add(OptionTransaction tx) => this._transactions.Add(tx);
+        public IEnumerable<OptionTransaction> GetAll() => this._transactions;
+        public void Initialize(IEnumerable<OptionTransaction> transactions)
+        {
+            this._transactions.Clear();
+            this._transactions.AddRange(transactions);
+        }
+
+        public void Update(OptionTransaction tx)
+        {
+            int index = this._transactions.FindIndex(t => t.Transaction.Id == tx.Transaction.Id);
+            if (index >= 0)
+            {
+                this._transactions[index] = tx;
+            }
+        }
+
+        public bool Delete(Guid id) => true;
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
+    }
+
+    private sealed class FakeLogger<T> : ILogger<T>
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+        }
+    }
+}

--- a/tests/MyAccountingApp.Application.Tests/Services/TransactionValidatorExtraTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/TransactionValidatorExtraTests.cs
@@ -1,0 +1,23 @@
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class TransactionValidatorExtraTests
+{
+    private readonly TransactionValidator _validator = new();
+
+    [Fact]
+    public void Validate_AmountZeroOrNegative_ReturnsError()
+    {
+        Transaction tx = new(Guid.NewGuid(), new DateTime(2024, 6, 1), "Test", new Money(0, "EUR"), TransactionCategory.INCOME);
+
+        ValidationResult result = this._validator.Validate(tx);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Field == "Amount");
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Agents/IBKRFlexQueryImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Agents/IBKRFlexQueryImportServiceTests.cs
@@ -1,0 +1,122 @@
+using MyAccountingApp.Core.Agents.IBKR;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+
+namespace MyAccountingApp.Core.Tests.Agents;
+
+public class IBKRFlexQueryImportServiceTests : IDisposable
+{
+    private readonly string _tempFile;
+
+    public IBKRFlexQueryImportServiceTests()
+    {
+        this._tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(this._tempFile))
+        {
+            File.Delete(this._tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_FeedsRowsToAgentsBySection()
+    {
+        RecordingAgent recording = new("My Section");
+        IBKRFlexQueryImportService service = new(new[] { recording });
+
+        File.WriteAllText(
+            this._tempFile,
+            string.Join("\n", new[]
+            {
+                "My Section,Header,,Column1,Column2",
+                "My Section,Data,,value1,value2",
+                "My Section,Data,,value3,value4",
+                "Other Section,Header,,x,y",
+                string.Empty,
+            }));
+
+        (IEnumerable<Transaction> tx, IEnumerable<AssetTransaction> assets, IEnumerable<OptionTransaction> options) =
+            await service.ParseAllAsync(this._tempFile);
+
+        Assert.Empty(tx);
+        Assert.Empty(assets);
+        Assert.Equal(2, recording.ReceivedRows.Count);
+        Assert.Equal("value1", recording.ReceivedRows[0][3]);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_WithTradeAgent_ProducesAssetTransactions()
+    {
+        TradeAgent tradeAgent = new();
+        IBKRFlexQueryImportService service = new(new IIBKRStatementAgent[] { tradeAgent });
+
+        File.WriteAllText(
+            this._tempFile,
+            string.Join("\n", new[]
+            {
+                "Trades,Header,,,,,,,,",
+                "Trades,Data,Order,Stocks,USD,AAPL,\"2024-12-19, 10:00:00\",100,,,-15000.00,,,,,,",
+            }));
+
+        (IEnumerable<Transaction> tx, IEnumerable<AssetTransaction> assets, IEnumerable<OptionTransaction> options) =
+            await service.ParseAllAsync(this._tempFile);
+
+        AssetTransaction asset = Assert.Single(assets);
+        Assert.Equal("AAPL", asset.Symbol);
+        Assert.Equal(AssetTransactionType.Buy, asset.Type);
+        Assert.Equal(100, asset.Quantity);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ReturnsEmpty_WhenFileEmpty()
+    {
+        IBKRFlexQueryImportService service = new(new IIBKRStatementAgent[] { new RecordingAgent("X") });
+        File.WriteAllText(this._tempFile, string.Empty);
+
+        (IEnumerable<Transaction> tx, IEnumerable<AssetTransaction> assets, IEnumerable<OptionTransaction> options) =
+            await service.ParseAllAsync(this._tempFile);
+
+        Assert.Empty(tx);
+        Assert.Empty(assets);
+        Assert.Empty(options);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_Throws_WhenPathNullOrEmpty()
+    {
+        IBKRFlexQueryImportService service = new(new IIBKRStatementAgent[] { new RecordingAgent("X") });
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => service.ParseAllAsync(null!));
+        await Assert.ThrowsAsync<ArgumentException>(() => service.ParseAllAsync(string.Empty));
+    }
+
+    [Fact]
+    public async Task ParseCorporateActionsAsync_ReturnsEmpty()
+    {
+        IBKRFlexQueryImportService service = new(new IIBKRStatementAgent[] { new RecordingAgent("X") });
+
+        IEnumerable<AssetTransaction> result = await service.ParseCorporateActionsAsync("whatever.csv");
+
+        Assert.Empty(result);
+    }
+
+    private sealed class RecordingAgent : IIBKRStatementAgent
+    {
+        public RecordingAgent(string sectionName)
+        {
+            this.SectionName = sectionName;
+        }
+
+        public string SectionName { get; }
+
+        public List<string[]> ReceivedRows { get; } = new();
+
+        public void Parse(IReadOnlyList<string[]> rows, List<Transaction> transactions, List<AssetTransaction> assetTransactions, List<OptionTransaction> optionTransactions, List<string> errors)
+        {
+            this.ReceivedRows.AddRange(rows);
+        }
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Agents/IBKRStatementAgentsTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Agents/IBKRStatementAgentsTests.cs
@@ -1,0 +1,271 @@
+using MyAccountingApp.Core.Agents.IBKR;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+
+namespace MyAccountingApp.Core.Tests.Agents;
+
+public class IBKRStatementAgentsTests
+{
+    [Fact]
+    public void TradeAgent_ParsesStockBuyAndSell()
+    {
+        TradeAgent agent = new();
+        List<Transaction> tx = new();
+        List<AssetTransaction> assets = new();
+        List<OptionTransaction> options = new();
+        List<string> errors = new();
+
+        List<string[]> rows = new()
+        {
+            new[] { "Trades", "Data", "Order", "Stocks", "USD", "AAPL", "2024-12-19, 10:00:00", "100", string.Empty, string.Empty, "-15000.00", string.Empty, string.Empty, string.Empty, string.Empty },
+            new[] { "Trades", "Data", "Order", "Stocks", "USD", "MSFT", "2024-12-20, 11:00:00", "-50", string.Empty, string.Empty, "15000.00", string.Empty, string.Empty, string.Empty, string.Empty },
+        };
+
+        agent.Parse(rows, tx, assets, options, errors);
+
+        Assert.Equal(2, assets.Count);
+        Assert.Equal(AssetTransactionType.Buy, assets[0].Type);
+        Assert.Equal("AAPL", assets[0].Symbol);
+        Assert.Equal(100, assets[0].Quantity);
+        Assert.Equal(AssetTransactionType.Sell, assets[1].Type);
+    }
+
+    [Fact]
+    public void TradeAgent_ParsesOptionTransaction()
+    {
+        TradeAgent agent = new();
+        List<Transaction> tx = new();
+        List<AssetTransaction> assets = new();
+        List<OptionTransaction> options = new();
+        List<string> errors = new();
+
+        List<string[]> rows = new()
+        {
+            new[] { "Trades", "Data", "Order", "Equity and Index Options", "USD", "VET 16JAN26 10 C", "2024-12-18, 12:00:00", "1.0", string.Empty, string.Empty, "-110.11", string.Empty, string.Empty, string.Empty, string.Empty },
+        };
+
+        agent.Parse(rows, tx, assets, options, errors);
+
+        OptionTransaction option = Assert.Single(options);
+        Assert.Equal("VET", option.Symbol);
+        Assert.Equal(AssetTransactionType.Buy, option.Type);
+        Assert.Empty(assets);
+    }
+
+    [Fact]
+    public void TradeAgent_SkipsInvalidRows()
+    {
+        TradeAgent agent = new();
+        List<Transaction> tx = new();
+        List<AssetTransaction> assets = new();
+        List<OptionTransaction> options = new();
+        List<string> errors = new();
+
+        List<string[]> rows = new()
+        {
+            new[] { "Trades", "Data", "Order", "Stocks", "USD", "AAPL", "2024-12-19, 10:00:00", "100", string.Empty, string.Empty, "-15000.00", string.Empty, string.Empty, string.Empty },
+            new[] { "Trades", "Header", "Order", "Stocks", "USD", "AAPL", "2024-12-19, 10:00:00", "100", string.Empty, string.Empty, "-15000.00", string.Empty, string.Empty, string.Empty, string.Empty },
+            new[] { "Trades", "Data", "Other", "Stocks", "USD", "AAPL", "2024-12-19, 10:00:00", "100", string.Empty, string.Empty, "-15000.00", string.Empty, string.Empty, string.Empty, string.Empty },
+            new[] { "Trades", "Data", "Order", "Stocks", "USD", "AAPL", "2024-12-19, 10:00:00", "0", string.Empty, string.Empty, "-15000.00", string.Empty, string.Empty, string.Empty, string.Empty },
+            new[] { "Trades", "Data", "Order", "Stocks", "USD", "AAPL", "not-a-date", "100", string.Empty, string.Empty, "-15000.00", string.Empty, string.Empty, string.Empty, string.Empty },
+            new[] { "Trades", "Data", "Order", "Stocks", "USD", "AAPL", "2024-12-19, 10:00:00", "100", string.Empty, string.Empty, "0.00", string.Empty, string.Empty, string.Empty, string.Empty },
+            new[] { "Trades", "Data", "Order", "Stocks", "USD", "AAPL", "2024-12-19, 10:00:00", "not-qty", string.Empty, string.Empty, "-15000.00", string.Empty, string.Empty, string.Empty, string.Empty },
+        };
+
+        agent.Parse(rows, tx, assets, options, errors);
+
+        Assert.Empty(assets);
+        Assert.Empty(options);
+        Assert.Empty(tx);
+    }
+
+    [Fact]
+    public void CorporateActionAgent_AddsSell_WhenCashProceedsPositive()
+    {
+        CorporateActionAgent agent = new();
+        List<Transaction> tx = new();
+        List<AssetTransaction> assets = new();
+        List<OptionTransaction> options = new();
+        List<string> errors = new();
+
+        List<string[]> rows = new()
+        {
+            new[] { "Corporate Actions", "Data", "Stocks", "CAD", string.Empty, "2024-07-17", "CVO.ODD.C(CAODD89D1078) Merged", "-33", "203.94", string.Empty },
+        };
+
+        agent.Parse(rows, tx, assets, options, errors);
+
+        AssetTransaction asset = Assert.Single(assets);
+        Assert.Equal("CVO.ODD.C", asset.Symbol);
+        Assert.Equal(AssetTransactionType.Sell, asset.Type);
+        Assert.Equal(33, asset.Quantity);
+        Assert.Equal(TransactionCategory.INCOME, asset.Transaction.Category);
+    }
+
+    [Fact]
+    public void CorporateActionAgent_SkipsNoCashOrNegativeRows()
+    {
+        CorporateActionAgent agent = new();
+        List<Transaction> tx = new();
+        List<AssetTransaction> assets = new();
+        List<OptionTransaction> options = new();
+        List<string> errors = new();
+
+        List<string[]> rows = new()
+        {
+            new[] { "Corporate Actions", "Data", "Stocks", "CAD", string.Empty, "2024-07-17", "No cash", "-33", "0.00", string.Empty },
+            new[] { "Corporate Actions", "Data", "Stocks", "CAD", string.Empty, "2024-07-17", "Negative", "-33", "-5.00", string.Empty },
+            new[] { "Corporate Actions", "Header", "Stocks", "CAD", string.Empty, "2024-07-17", "Header", "-33", "10.00", string.Empty },
+            new[] { "Corporate Actions", "Data", "Stocks", "CAD", string.Empty, "bad-date", "Bad", "-33", "10.00", string.Empty },
+        };
+
+        agent.Parse(rows, tx, assets, options, errors);
+
+        Assert.Empty(assets);
+    }
+
+    [Theory]
+    [InlineData("5000.00", 5000, TransactionCategory.DEPOSIT)]
+    [InlineData("-2500.00", 2500, TransactionCategory.TRANSFER)]
+    public void DepositWithdrawalAgent_ClassifiesBySign(string amount, decimal expectedAmount, TransactionCategory expected)
+    {
+        DepositWithdrawalAgent agent = new();
+        List<Transaction> tx = new();
+        List<AssetTransaction> assets = new();
+        List<OptionTransaction> options = new();
+        List<string> errors = new();
+
+        List<string[]> rows = new()
+        {
+            new[] { "Deposits & Withdrawals", "Data", "EUR", "2024-12-19", "Bank transfer", amount },
+        };
+
+        agent.Parse(rows, tx, assets, options, errors);
+
+        Transaction transaction = Assert.Single(tx);
+        Assert.Equal(expected, transaction.Category);
+        Assert.Equal(expectedAmount, transaction.Money.Amount);
+        Assert.Equal("EUR", transaction.Money.Currency);
+    }
+
+    [Fact]
+    public void DepositWithdrawalAgent_SkipsInvalidRows()
+    {
+        DepositWithdrawalAgent agent = new();
+        List<Transaction> tx = new();
+        List<AssetTransaction> assets = new();
+        List<OptionTransaction> options = new();
+        List<string> errors = new();
+
+        List<string[]> rows = new()
+        {
+            new[] { "Deposits & Withdrawals", "Data", "EUR", "bad-date", "Bad", "100.00" },
+            new[] { "Deposits & Withdrawals", "Data", "EUR", "2024-12-19", "Zero", "0.00" },
+            new[] { "Deposits & Withdrawals", "Header", "EUR", "2024-12-19", "Header", "100.00" },
+        };
+
+        agent.Parse(rows, tx, assets, options, errors);
+
+        Assert.Empty(tx);
+    }
+
+    [Theory]
+    [InlineData("10.00", TransactionCategory.INCOME)]
+    [InlineData("-2.00", TransactionCategory.EXPENSE)]
+    public void InterestAgent_ClassifiesBySign(string amount, TransactionCategory expected)
+    {
+        InterestAgent agent = new();
+        List<Transaction> tx = new();
+        List<AssetTransaction> assets = new();
+        List<OptionTransaction> options = new();
+        List<string> errors = new();
+
+        List<string[]> rows = new()
+        {
+            new[] { "Interest", "Data", "USD", "2024-12-19", "Interest on cash", amount },
+        };
+
+        agent.Parse(rows, tx, assets, options, errors);
+
+        Transaction transaction = Assert.Single(tx);
+        Assert.Equal(expected, transaction.Category);
+    }
+
+    [Fact]
+    public void WithholdingTaxAgent_AddsExpense()
+    {
+        WithholdingTaxAgent agent = new();
+        List<Transaction> tx = new();
+        List<AssetTransaction> assets = new();
+        List<OptionTransaction> options = new();
+        List<string> errors = new();
+
+        List<string[]> rows = new()
+        {
+            new[] { "Withholding Tax", "Data", "USD", "2024-12-19", "US tax", "15.00" },
+        };
+
+        agent.Parse(rows, tx, assets, options, errors);
+
+        Transaction transaction = Assert.Single(tx);
+        Assert.Equal(TransactionCategory.EXPENSE, transaction.Category);
+        Assert.Equal(15, transaction.Money.Amount);
+    }
+
+    [Fact]
+    public void FeeAgent_UsesIndexThreeCurrency()
+    {
+        FeeAgent agent = new();
+        List<Transaction> tx = new();
+        List<AssetTransaction> assets = new();
+        List<OptionTransaction> options = new();
+        List<string> errors = new();
+
+        List<string[]> rows = new()
+        {
+            new[] { "Fees", "Data", "IGNORED", "USD", "2024-12-19", "Commission", "2.50" },
+        };
+
+        agent.Parse(rows, tx, assets, options, errors);
+
+        Transaction transaction = Assert.Single(tx);
+        Assert.Equal(TransactionCategory.EXPENSE, transaction.Category);
+        Assert.Equal("USD", transaction.Money.Currency);
+        Assert.Equal(2.5m, transaction.Money.Amount);
+    }
+
+    [Fact]
+    public void DividendAgent_AddsIncome()
+    {
+        DividendAgent agent = new();
+        List<Transaction> tx = new();
+        List<AssetTransaction> assets = new();
+        List<OptionTransaction> options = new();
+        List<string> errors = new();
+
+        List<string[]> rows = new()
+        {
+            new[] { "Dividends", "Data", "USD", "2024-12-19", "AAPL dividend", "1.5" },
+        };
+
+        agent.Parse(rows, tx, assets, options, errors);
+
+        Transaction transaction = Assert.Single(tx);
+        Assert.Equal(TransactionCategory.INCOME, transaction.Category);
+        Assert.Equal(1.5m, transaction.Money.Amount);
+    }
+
+    [Fact]
+    public void FeeAndDividendAgents_HandleThousandSeparator()
+    {
+        FeeAgent feeAgent = new();
+        List<Transaction> feeTx = new();
+        List<string> errors = new();
+        List<string[]> feeRows = new()
+        {
+            new[] { "Fees", "Data", "IGNORED", "USD", "2024-12-19", "Commission", "1,250.00" },
+        };
+        feeAgent.Parse(feeRows, feeTx, new List<AssetTransaction>(), new List<OptionTransaction>(), errors);
+        Assert.Equal(1250m, feeTx.Single().Money.Amount);
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Agents/InteractiveBrokersImportServiceExtraTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Agents/InteractiveBrokersImportServiceExtraTests.cs
@@ -1,0 +1,254 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using MyAccountingApp.Core.Agents;
+using MyAccountingApp.Core.Models;
+using MyAccountingApp.Core.Services;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+
+namespace MyAccountingApp.Core.Tests.Agents;
+
+public class InteractiveBrokersImportServiceExtraTests
+{
+    private readonly Mock<ICsvParser> parserMock = new();
+    private readonly InteractiveBrokersImportService agent;
+
+    public InteractiveBrokersImportServiceExtraTests()
+    {
+        Mock<ILogger<InteractiveBrokersImportService>> loggerMock = new();
+        this.agent = new InteractiveBrokersImportService(this.parserMock.Object, loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ClassifiesDeposit()
+    {
+        List<IBKRTransactionRecord> records = new()
+        {
+            Record("Deposit", "Deposit", string.Empty, "0", "EUR", "5000.00"),
+        };
+        this.Setup(records);
+
+        (IEnumerable<Transaction> tx, IEnumerable<AssetTransaction> assets, _) = await this.agent.ParseAllAsync("test.csv");
+
+        Transaction transaction = Assert.Single(tx);
+        Assert.Equal(TransactionCategory.DEPOSIT, transaction.Category);
+        Assert.Empty(assets);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ClassifiesWithholdingAndFeesAsExpense()
+    {
+        List<IBKRTransactionRecord> records = new()
+        {
+            Record("Withholding Tax", "Withholding", "-", "0", "USD", "-15.00"),
+            Record("Fee", "Commission", "-", "0", "USD", "-2.50"),
+        };
+        this.Setup(records);
+
+        (IEnumerable<Transaction> tx, _, _) = await this.agent.ParseAllAsync("test.csv");
+
+        List<Transaction> list = tx.ToList();
+        Assert.Equal(2, list.Count);
+        Assert.All(list, t => Assert.Equal(TransactionCategory.EXPENSE, t.Category));
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ClassifiesDividendAndCreditInterestAsIncome()
+    {
+        List<IBKRTransactionRecord> records = new()
+        {
+            Record("Dividend", "AAPL dividend", "-", "0", "USD", "100.00"),
+            Record("Credit Interest", "Interest on cash", "-", "0", "USD", "5.00"),
+        };
+        this.Setup(records);
+
+        (IEnumerable<Transaction> tx, _, _) = await this.agent.ParseAllAsync("test.csv");
+
+        List<Transaction> list = tx.ToList();
+        Assert.Equal(2, list.Count);
+        Assert.All(list, t => Assert.Equal(TransactionCategory.INCOME, t.Category));
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ClassifiesDebitInterestAsExpense()
+    {
+        List<IBKRTransactionRecord> records = new()
+        {
+            Record("Debit Interest", "Interest", "-", "0", "USD", "-3.00"),
+        };
+        this.Setup(records);
+
+        (IEnumerable<Transaction> tx, _, _) = await this.agent.ParseAllAsync("test.csv");
+
+        Assert.Equal(TransactionCategory.EXPENSE, tx.Single().Category);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_AssetWithZeroQuantity_InfersDirectionFromAmount()
+    {
+        List<IBKRTransactionRecord> records = new()
+        {
+            Record("Buy", "Buy AAPL", "AAPL", "0", "USD", "15000.00"),
+            Record("Sell", "Sell MSFT", "MSFT", "0", "USD", "-15000.00"),
+        };
+        this.Setup(records);
+
+        (_, IEnumerable<AssetTransaction> assets, _) = await this.agent.ParseAllAsync("test.csv");
+
+        List<AssetTransaction> list = assets.ToList();
+        Assert.Equal(2, list.Count);
+        Assert.Equal(AssetTransactionType.Sell, list[0].Type);
+        Assert.Equal(TransactionCategory.INCOME, list[0].Transaction.Category);
+        Assert.Equal(AssetTransactionType.Buy, list[1].Type);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_Assignment_IsSell()
+    {
+        List<IBKRTransactionRecord> records = new()
+        {
+            Record("Assignment", "Assignment of AAPL shares", "AAPL", "10", "USD", "-15000.00"),
+        };
+        this.Setup(records);
+
+        (_, IEnumerable<AssetTransaction> assets, _) = await this.agent.ParseAllAsync("test.csv");
+
+        AssetTransaction asset = Assert.Single(assets);
+        Assert.Equal(AssetTransactionType.Sell, asset.Type);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_Exercise_IsSell()
+    {
+        List<IBKRTransactionRecord> records = new()
+        {
+            Record("Exercise", "Exercise of MSFT shares", "MSFT", "10", "USD", "15000.00"),
+        };
+        this.Setup(records);
+
+        (_, IEnumerable<AssetTransaction> assets, _) = await this.agent.ParseAllAsync("test.csv");
+
+        AssetTransaction asset = Assert.Single(assets);
+        Assert.Equal(AssetTransactionType.Sell, asset.Type);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_OptionWithNegativeQuantity_IsIncome()
+    {
+        List<IBKRTransactionRecord> records = new()
+        {
+            Record("Sell", "VET 16JAN26 10 C", "VET 260116C00010000", "-1", "USD", "110.00"),
+        };
+        this.Setup(records);
+
+        (IEnumerable<Transaction> tx, _, _) = await this.agent.ParseAllAsync("test.csv");
+
+        Transaction transaction = Assert.Single(tx);
+        Assert.Equal(TransactionCategory.INCOME, transaction.Category);
+        Assert.Equal("VET", transaction.Description);
+    }
+
+    [Fact]
+    public async Task ParseCorporateActionsAsync_SellWithParenAndDotSymbol()
+    {
+        List<IBKRCorporateActionRecord> records = new()
+        {
+            new IBKRCorporateActionRecord
+            {
+                AssetCategory = "Stocks",
+                Currency = "CAD",
+                ReportDate = "2024-07-17",
+                Description = "CVO.ODD.C(CAODD89D1078) Merged(Voluntary Offer Allocation) for CAD 6.18 per Share",
+                Quantity = "-33",
+                Proceeds = "203.94",
+            },
+        };
+        this.parserMock
+            .Setup(p => p.ParseCorporateActionsAsync(It.IsAny<string>()))
+            .ReturnsAsync(records);
+
+        IEnumerable<AssetTransaction> result = await this.agent.ParseCorporateActionsAsync("test.csv");
+
+        AssetTransaction asset = Assert.Single(result);
+        Assert.Equal("CVO", asset.Symbol);
+        Assert.Equal(AssetTransactionType.Sell, asset.Type);
+        Assert.Equal(TransactionCategory.INCOME, asset.Transaction.Category);
+        Assert.Equal(33, asset.Quantity);
+    }
+
+    [Fact]
+    public async Task ParseCorporateActionsAsync_BuyWithUnknownSymbol()
+    {
+        List<IBKRCorporateActionRecord> records = new()
+        {
+            new IBKRCorporateActionRecord
+            {
+                AssetCategory = "Stocks",
+                Currency = "-",
+                ReportDate = "2024-01-10",
+                Description = "No symbol here",
+                Quantity = "5",
+                Proceeds = "50.00",
+            },
+        };
+        this.parserMock
+            .Setup(p => p.ParseCorporateActionsAsync(It.IsAny<string>()))
+            .ReturnsAsync(records);
+
+        IEnumerable<AssetTransaction> result = await this.agent.ParseCorporateActionsAsync("test.csv");
+
+        AssetTransaction asset = Assert.Single(result);
+        Assert.Equal("UNKNOWN", asset.Symbol);
+        Assert.Equal(AssetTransactionType.Buy, asset.Type);
+        Assert.Equal("EUR", asset.Transaction.Money.Currency);
+    }
+
+    [Fact]
+    public async Task ParseCorporateActionsAsync_ReturnsEmpty_WhenNoRecords()
+    {
+        this.parserMock
+            .Setup(p => p.ParseCorporateActionsAsync(It.IsAny<string>()))
+            .ReturnsAsync(new List<IBKRCorporateActionRecord>());
+
+        IEnumerable<AssetTransaction> result = await this.agent.ParseCorporateActionsAsync("test.csv");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_SkipsRecordThatThrows()
+    {
+        List<IBKRTransactionRecord> records = new()
+        {
+            Record("Buy", "AAPL", "AAPL", "10", "USD", "15000.00"),
+            new IBKRTransactionRecord { Symbol = "AAPL" },
+        };
+        this.Setup(records);
+
+        (_, IEnumerable<AssetTransaction> assets, _) = await this.agent.ParseAllAsync("test.csv");
+
+        Assert.Single(assets);
+    }
+
+    private void Setup(List<IBKRTransactionRecord> records)
+    {
+        this.parserMock
+            .Setup(p => p.ParseIBKRAsync(It.IsAny<string>()))
+            .ReturnsAsync(records);
+    }
+
+    private static IBKRTransactionRecord Record(string type, string description, string symbol, string quantity, string currency, string amount)
+    {
+        return new IBKRTransactionRecord
+        {
+            Date = "2024-12-19",
+            Description = description,
+            TransactionType = type,
+            Symbol = symbol,
+            Quantity = quantity,
+            PriceCurrency = currency,
+            GrossAmount = amount,
+            NetAmount = amount,
+        };
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Repositories/JsonOptionTransactionRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/JsonOptionTransactionRepositoryTests.cs
@@ -1,0 +1,142 @@
+using MyAccountingApp.Core.Repositories;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Core.Tests.Repositories;
+
+public class JsonOptionTransactionRepositoryTests : IDisposable
+{
+    private readonly string _tempFile;
+
+    public JsonOptionTransactionRepositoryTests()
+    {
+        this._tempFile = Path.GetTempFileName();
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(this._tempFile))
+        {
+            File.Delete(this._tempFile);
+        }
+    }
+
+    [Fact]
+    public void GetAll_ReturnsEmpty_WhenFileDoesNotExist()
+    {
+        JsonOptionTransactionRepository repo = new(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+
+        Assert.Empty(repo.GetAll());
+    }
+
+    [Fact]
+    public void GetAll_ReturnsEmpty_WhenFileIsCorrupt()
+    {
+        File.WriteAllText(this._tempFile, "not valid json {{{");
+        JsonOptionTransactionRepository repo = new(this._tempFile);
+
+        Assert.Empty(repo.GetAll());
+    }
+
+    [Fact]
+    public void Add_ThenGetAll_RoundTrips()
+    {
+        JsonOptionTransactionRepository repo = new(this._tempFile);
+        repo.Add(CreateOption());
+
+        OptionTransaction loaded = Assert.Single(repo.GetAll());
+        Assert.Equal("AAPL", loaded.Symbol);
+        Assert.Equal(AssetTransactionType.Buy, loaded.Type);
+    }
+
+    [Fact]
+    public void Update_ReplacesExistingTransaction()
+    {
+        JsonOptionTransactionRepository repo = new(this._tempFile);
+        OptionTransaction original = CreateOption();
+        repo.Add(original);
+
+        OptionTransaction updated = new(
+            original.Transaction,
+            "MSFT",
+            string.Empty,
+            5,
+            AssetTransactionType.Sell);
+        repo.Update(updated);
+
+        OptionTransaction loaded = Assert.Single(repo.GetAll());
+        Assert.Equal("MSFT", loaded.Symbol);
+        Assert.Equal(AssetTransactionType.Sell, loaded.Type);
+    }
+
+    [Fact]
+    public void Update_DoesNothing_WhenIdNotFound()
+    {
+        JsonOptionTransactionRepository repo = new(this._tempFile);
+        repo.Add(CreateOption());
+
+        OptionTransaction other = CreateOption(new Guid("11111111-1111-1111-1111-111111111111"));
+        repo.Update(other);
+
+        Assert.Single(repo.GetAll());
+    }
+
+    [Fact]
+    public void Delete_RemovesAndReturnsTrue()
+    {
+        JsonOptionTransactionRepository repo = new(this._tempFile);
+        OptionTransaction option = CreateOption();
+        repo.Add(option);
+
+        bool deleted = repo.Delete(option.Transaction.Id);
+
+        Assert.True(deleted);
+        Assert.Empty(repo.GetAll());
+    }
+
+    [Fact]
+    public void Delete_ReturnsFalse_WhenIdNotFound()
+    {
+        JsonOptionTransactionRepository repo = new(this._tempFile);
+        repo.Add(CreateOption());
+
+        bool deleted = repo.Delete(new Guid("11111111-1111-1111-1111-111111111111"));
+
+        Assert.False(deleted);
+        Assert.Single(repo.GetAll());
+    }
+
+    [Fact]
+    public void DeleteByYear_RemovesOnlyMatchingYear()
+    {
+        JsonOptionTransactionRepository repo = new(this._tempFile);
+        repo.Add(CreateOption(date: new DateTime(2023, 5, 1)));
+        repo.Add(CreateOption(date: new DateTime(2024, 5, 1)));
+
+        int removed = repo.DeleteByYear(2023);
+
+        Assert.Equal(1, removed);
+        Assert.Single(repo.GetAll());
+    }
+
+    [Fact]
+    public void Initialize_OverwritesExistingData()
+    {
+        JsonOptionTransactionRepository repo = new(this._tempFile);
+        repo.Add(CreateOption());
+
+        repo.Initialize(new[] { CreateOption(date: new DateTime(2024, 1, 1)) });
+
+        Assert.Single(repo.GetAll());
+        Assert.Equal(new DateTime(2024, 1, 1), repo.GetAll().Single().Transaction.Date);
+    }
+
+    private static OptionTransaction CreateOption(Guid? id = null, DateTime? date = null)
+    {
+        Guid guid = id ?? Guid.NewGuid();
+        DateTime txDate = date ?? new DateTime(2023, 10, 15);
+        Transaction tx = new(guid, txDate, "Buy AAPL", new Money(1500, "USD"), TransactionCategory.EXPENSE);
+        return new OptionTransaction(tx, "AAPL", "US0378331005", 10, AssetTransactionType.Buy);
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Services/RevolutImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/RevolutImportServiceTests.cs
@@ -1,0 +1,150 @@
+using MyAccountingApp.Core.Services;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+
+namespace MyAccountingApp.Core.Tests.Services;
+
+public class RevolutImportServiceTests : IDisposable
+{
+    private readonly string _tempFile;
+    private readonly RevolutImportService _service = new();
+
+    public RevolutImportServiceTests()
+    {
+        this._tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".csv");
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(this._tempFile))
+        {
+            File.Delete(this._tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ClassifiesDeposit()
+    {
+        this.WriteLines(new[] { "DEPOSIT,a,2024-12-19,r,Top up,1000.00,0.00,EUR,COMPLETED,x" });
+
+        (IEnumerable<Transaction> tx, _, _) = await this._service.ParseAllAsync(this._tempFile);
+
+        Transaction transaction = Assert.Single(tx);
+        Assert.Equal(TransactionCategory.DEPOSIT, transaction.Category);
+        Assert.Equal(1000, transaction.Money.Amount);
+        Assert.Equal("EUR", transaction.Money.Currency);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ClassifiesCardPaymentAndRefund()
+    {
+        this.WriteLines(new[]
+        {
+            "CARD PAYMENT,a,2024-12-19,r,Supermarket,25.50,0.00,EUR,COMPLETED,x",
+            "CARD REFUND,a,2024-12-19,r,Store,10.00,0.00,EUR,COMPLETED,x",
+        });
+
+        (IEnumerable<Transaction> tx, _, _) = await this._service.ParseAllAsync(this._tempFile);
+
+        List<Transaction> list = tx.ToList();
+        Assert.Equal(2, list.Count);
+        Assert.Equal(TransactionCategory.EXPENSE, list[0].Category);
+        Assert.Equal(TransactionCategory.INCOME, list[1].Category);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ClassifiesTransferBySign()
+    {
+        this.WriteLines(new[]
+        {
+            "TRANSFER,a,2024-12-19,r,Payment out,-50.00,0.00,EUR,COMPLETED,x",
+            "TRANSFER,a,2024-12-19,r,FROM CUENTA FLEXIBLE,300.00,0.00,EUR,COMPLETED,x",
+            "TRANSFER,a,2024-12-19,r,Refund,75.00,0.00,EUR,COMPLETED,x",
+        });
+
+        (IEnumerable<Transaction> tx, _, _) = await this._service.ParseAllAsync(this._tempFile);
+
+        List<Transaction> list = tx.ToList();
+        Assert.Equal(3, list.Count);
+        Assert.Equal(TransactionCategory.EXPENSE, list[0].Category);
+        Assert.Equal(TransactionCategory.INCOME, list[1].Category);
+        Assert.Equal(TransactionCategory.INCOME, list[2].Category);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_AddsFeeTransaction()
+    {
+        this.WriteLines(new[] { "CARD PAYMENT,a,2024-12-19,r,Merchant,20.00,2.00,EUR,COMPLETED,x" });
+
+        (IEnumerable<Transaction> tx, _, _) = await this._service.ParseAllAsync(this._tempFile);
+
+        List<Transaction> list = tx.ToList();
+        Assert.Equal(2, list.Count);
+        Assert.Equal(TransactionCategory.EXPENSE, list[1].Category);
+        Assert.Equal("Merchant (fee)", list[1].Description);
+        Assert.Equal(2, list[1].Money.Amount);
+    }
+
+    [Theory]
+    [InlineData("PENDING")]
+    [InlineData("REVERTED")]
+    public async Task ParseAllAsync_SkipsNonCompleted(string state)
+    {
+        this.WriteLines(new[] { $"DEPOSIT,a,2024-12-19,r,Top up,1000.00,0.00,EUR,{state},x" });
+
+        (IEnumerable<Transaction> tx, _, _) = await this._service.ParseAllAsync(this._tempFile);
+
+        Assert.Empty(tx);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_SkipsBalanceMigrationAndUnknownTypes()
+    {
+        this.WriteLines(new[]
+        {
+            "TRANSFER,a,2024-12-19,r,BALANCE MIGRATION,500.00,0.00,EUR,COMPLETED,x",
+            "EXCHANGE,a,2024-12-19,r,Currency exchange,100.00,0.00,EUR,COMPLETED,x",
+            "ATM,a,2024-12-19,r,Cash,40.00,0.00,EUR,COMPLETED,x",
+        });
+
+        (IEnumerable<Transaction> tx, _, _) = await this._service.ParseAllAsync(this._tempFile);
+
+        Transaction transaction = Assert.Single(tx);
+        Assert.Equal(TransactionCategory.EXPENSE, transaction.Category);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_SkipsZeroAmountAndInvalidLines()
+    {
+        this.WriteLines(new[]
+        {
+            "DEPOSIT,a,2024-12-19,r,Zero,0.00,0.00,EUR,COMPLETED,x",
+            "DEPOSIT,a,2024-12-19,r,Bad amount,abc,0.00,EUR,COMPLETED,x",
+            "DEPOSIT,a,2024-12-19,r,Short line,100.00",
+        });
+
+        (IEnumerable<Transaction> tx, _, _) = await this._service.ParseAllAsync(this._tempFile);
+
+        Assert.Empty(tx);
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_Throws_WhenPathNullOrWhiteSpace()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => this._service.ParseAllAsync(string.Empty));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => this._service.ParseAllAsync(null!));
+    }
+
+    [Fact]
+    public async Task ParseCorporateActionsAsync_ReturnsEmpty()
+    {
+        IEnumerable<AssetTransaction> result = await this._service.ParseCorporateActionsAsync("whatever.csv");
+        Assert.Empty(result);
+    }
+
+    private void WriteLines(IEnumerable<string> lines)
+    {
+        string header = "Type,Account,Date,Reference,Description,Amount,Fee,Currency,State,Extra";
+        File.WriteAllLines(this._tempFile, new[] { header }.Concat(lines));
+    }
+}


### PR DESCRIPTION
Adds tests covering previously uncovered code in:

- IBKR statement agents (Trade, CorporateAction, DepositWithdrawal, Interest, WithholdingTax, Fee, Dividend)
- IBKRFlexQueryImportService
- InteractiveBrokersImportService
- JsonOptionTransactionRepository
- RevolutImportService
- ImportService (option persistence, asset merge, multi-folder)
- TransactionValidator

CI coverage gate measured at **81.8%** combined line coverage (was 66.88% on master), and 83.3% when combined with #84.