### PR TITLE
feat: Frankfurter as default currency provider

### DIFF
--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -44,24 +44,43 @@ builder.Services.AddCors(options =>
 
 CurrencyApiOptions currencyOptions = builder.Configuration.GetSection("CurrencyApi").Get<CurrencyApiOptions>() ?? new CurrencyApiOptions();
 
-string currencyApiKey = !string.IsNullOrEmpty(currencyOptions.ApiKey)
-    ? currencyOptions.ApiKey
-    : builder.Configuration["CurrencyApi:ApiKey"]
-        ?? Environment.GetEnvironmentVariable("CURRENCY_API_KEY")
-        ?? throw new InvalidOperationException(
-            "CurrencyApi:ApiKey not found. Set it in appsettings.json or the CURRENCY_API_KEY environment variable.");
+bool useFrankfurter = string.Equals(currencyOptions.Provider, "Frankfurter", StringComparison.OrdinalIgnoreCase);
 
 CompositeConversionRepository repo = new CompositeConversionRepository("data/conversions.json");
-CurrencyConverter api = new CurrencyConverter(currencyApiKey, excludedCurrencies: currencyOptions.ExcludeCurrencies);
+
+ICurrencyConverter api;
+IApiQuotaManager quotaManager;
+JsonApiQuotaRepository? quotaRepo = null;
+
+if (useFrankfurter)
+{
+    api = new FrankfurterCurrencyConverter(excludedCurrencies: currencyOptions.ExcludeCurrencies, baseUrl: currencyOptions.BaseUrl);
+    quotaManager = new UnlimitedApiQuotaManager(currencyOptions.ProviderName);
+}
+else
+{
+    string currencyApiKey = !string.IsNullOrEmpty(currencyOptions.ApiKey)
+        ? currencyOptions.ApiKey
+        : builder.Configuration["CurrencyApi:ApiKey"]
+            ?? Environment.GetEnvironmentVariable("CURRENCY_API_KEY")
+            ?? throw new InvalidOperationException(
+                "CurrencyApi:ApiKey not found. Set it in appsettings.json or the CURRENCY_API_KEY environment variable.");
+
+    api = new CurrencyConverter(currencyApiKey, excludedCurrencies: currencyOptions.ExcludeCurrencies);
+    quotaRepo = new JsonApiQuotaRepository("data/api_quota.json", currencyOptions.RequestsLimit, currencyOptions.SafetyMargin, currencyOptions.ProviderName);
+    quotaManager = new ApiQuotaManager(quotaRepo);
+}
+
 Currencies source = Currencies.EUR;
-JsonApiQuotaRepository quotaRepo = new JsonApiQuotaRepository("data/api_quota.json", currencyOptions.RequestsLimit, currencyOptions.SafetyMargin, currencyOptions.ProviderName);
 JsonPendingConversionRepository pendingRepo = new JsonPendingConversionRepository("data/pending_conversions.json");
-ApiQuotaManager quotaManager = new ApiQuotaManager(quotaRepo);
 PendingConversionQueue pendingQueue = new PendingConversionQueue(pendingRepo);
-CurencyRateService currencyRateService = new CurencyRateService(repo, api, source, quotaManager, pendingQueue, currencyOptions.MaxTimeseriesDays);
+CurencyRateService currencyRateService = new CurencyRateService(repo, api, source, quotaManager, pendingQueue, currencyOptions.MaxTimeseriesDays, currencyOptions.ProviderName);
 
 builder.Services.AddSingleton<IConversionRepository>(repo);
-builder.Services.AddSingleton<IApiQuotaRepository>(quotaRepo);
+if (quotaRepo != null)
+{
+    builder.Services.AddSingleton<IApiQuotaRepository>(quotaRepo);
+}
 builder.Services.AddSingleton<IPendingConversionRepository>(pendingRepo);
 builder.Services.AddSingleton<IApiQuotaManager>(quotaManager);
 builder.Services.AddSingleton<IPendingConversionQueue>(pendingQueue);

--- a/src/MyAccountingApp.Application/Options/CurrencyApiOptions.cs
+++ b/src/MyAccountingApp.Application/Options/CurrencyApiOptions.cs
@@ -8,7 +8,12 @@ public sealed class CurrencyApiOptions
     /// <summary>
     /// Gets or sets the base URL of the currency API.
     /// </summary>
-    public string BaseUrl { get; set; } = "https://api.exchangerate.host";
+    public string BaseUrl { get; set; } = "https://api.frankfurter.dev";
+
+    /// <summary>
+    /// Gets or sets the name of the provider to use ("Frankfurter" or "ExchangeRateHost").
+    /// </summary>
+    public string Provider { get; set; } = "Frankfurter";
 
     /// <summary>
     /// Gets or sets the API key.
@@ -38,7 +43,7 @@ public sealed class CurrencyApiOptions
     /// <summary>
     /// Gets or sets the name of the external provider.
     /// </summary>
-    public string ProviderName { get; set; } = "exchangerate.host";
+    public string ProviderName { get; set; } = "frankfurter";
 
     /// <summary>
     /// Gets or sets the list of currencies to exclude from API requests (e.g. "BTC").

--- a/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
+++ b/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
@@ -19,6 +19,7 @@ public class CurencyRateService : ICurrencyRateService
     private readonly IApiQuotaManager _quotaManager;
     private readonly IPendingConversionQueue _pendingQueue;
     private readonly int _maxTimeseriesDays;
+    private readonly string _sourceProvider;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CurencyRateService"/> class.
@@ -29,6 +30,7 @@ public class CurencyRateService : ICurrencyRateService
     /// <param name="quotaManager">Manager for the API request quota.</param>
     /// <param name="pendingQueue">Queue for dates that could not be fetched immediately.</param>
     /// <param name="maxTimeseriesDays">Maximum number of days a single timeseries request may cover.</param>
+    /// <param name="sourceProvider">Name of the provider that supplies the rates.</param>
     /// <exception cref="ArgumentException">Thrown if the source currency is not EUR.</exception>
     public CurencyRateService(
         IConversionRepository repository,
@@ -36,7 +38,8 @@ public class CurencyRateService : ICurrencyRateService
         Currencies source,
         IApiQuotaManager quotaManager,
         IPendingConversionQueue pendingQueue,
-        int maxTimeseriesDays = 365)
+        int maxTimeseriesDays = 365,
+        string sourceProvider = "frankfurter")
     {
         this._repository = repository;
         this._api = api;
@@ -44,6 +47,7 @@ public class CurencyRateService : ICurrencyRateService
         this._quotaManager = quotaManager;
         this._pendingQueue = pendingQueue;
         this._maxTimeseriesDays = maxTimeseriesDays;
+        this._sourceProvider = sourceProvider;
         this.Validate();
     }
 
@@ -211,7 +215,7 @@ public class CurencyRateService : ICurrencyRateService
 
     private Conversion BuildConversion(DateOnly day, Dictionary<string, decimal> rates)
     {
-        Conversion conversion = new(day.ToDateTime(TimeOnly.MinValue), this._source);
+        Conversion conversion = new(day.ToDateTime(TimeOnly.MinValue), this._source, sourceProvider: this._sourceProvider);
         int prefixLength = this._source.ToString().Length;
 
         foreach (KeyValuePair<string, decimal> kv in rates)

--- a/src/MyAccountingApp.Application/Services/UnlimitedApiQuotaManager.cs
+++ b/src/MyAccountingApp.Application/Services/UnlimitedApiQuotaManager.cs
@@ -1,0 +1,48 @@
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Domain.Entities;
+
+namespace MyAccountingApp.Application.Services;
+
+/// <summary>
+/// Manages the request quota against the external currency API.
+/// </summary>
+public class UnlimitedApiQuotaManager : IApiQuotaManager
+{
+    private readonly string _providerName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnlimitedApiQuotaManager"/> class.
+    /// </summary>
+    /// <param name="providerName">The name of the external provider.</param>
+    public UnlimitedApiQuotaManager(string providerName)
+    {
+        this._providerName = providerName;
+    }
+
+    /// <inheritdoc/>
+    public Task<ApiUsageQuota> GetQuotaAsync(CancellationToken cancellationToken = default)
+    {
+        DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        DateOnly periodStart = new(today.Year, today.Month, 1);
+        ApiUsageQuota quota = new(this._providerName, periodStart, periodStart.AddMonths(1).AddDays(-1), 0, int.MaxValue, 0, DateTime.UtcNow);
+        return Task.FromResult(quota);
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> TryConsumeAsync(int cost = 1, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc/>
+    public Task MarkExhaustedAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task EnsurePeriodAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/MyAccountingApp.Core/DTOs/FrankfurterRateRecord.cs
+++ b/src/MyAccountingApp.Core/DTOs/FrankfurterRateRecord.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace MyAccountingApp.Core.DTOs;
+
+/// <summary>
+/// Represents a single rate record returned by the Frankfurter API v2.
+/// </summary>
+public class FrankfurterRateRecord
+{
+    /// <summary>
+    /// Gets the date of the rate (yyyy-MM-dd).
+    /// </summary>
+    [JsonPropertyName("date")]
+    public string Date { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the base currency.
+    /// </summary>
+    [JsonPropertyName("base")]
+    public string Base { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the quote (target) currency.
+    /// </summary>
+    [JsonPropertyName("quote")]
+    public string Quote { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the exchange rate (units of quote per unit of base).
+    /// </summary>
+    [JsonPropertyName("rate")]
+    public decimal Rate { get; init; }
+}

--- a/src/MyAccountingApp.Core/Services/FrankfurterCurrencyConverter.cs
+++ b/src/MyAccountingApp.Core/Services/FrankfurterCurrencyConverter.cs
@@ -65,6 +65,11 @@ public class FrankfurterCurrencyConverter : ICurrencyConverter
 
         foreach (FrankfurterRateRecord record in records)
         {
+            if (record.Quote == source.ToString())
+            {
+                continue;
+            }
+
             result[$"{source}{record.Quote}"] = record.Rate;
         }
 
@@ -84,14 +89,16 @@ public class FrankfurterCurrencyConverter : ICurrencyConverter
             throw new ArgumentException("The end date must be greater than or equal to the start date.", nameof(end));
         }
 
-        string quotes = string.Join(",", (targets ?? Enum.GetValues<Currencies>()).Where(this.IsRequested));
+        string quotes = string.Join(",", (targets ?? Enum.GetValues<Currencies>()).Where(currency => currency != source && this.IsRequested(currency)));
         string url = $"{this._baseUrl}/v2/rates?from={start:yyyy-MM-dd}&to={end:yyyy-MM-dd}&base={source}&quotes={quotes}";
 
         IReadOnlyList<FrankfurterRateRecord> records = await this.GetRecordsAsync(url, cancellationToken);
 
         Dictionary<DateOnly, Dictionary<string, decimal>> result = new();
 
-        foreach (IGrouping<string, FrankfurterRateRecord> group in records.GroupBy(r => r.Date, StringComparer.Ordinal))
+        foreach (IGrouping<string, FrankfurterRateRecord> group in records
+            .Where(record => record.Quote != source.ToString())
+            .GroupBy(r => r.Date, StringComparer.Ordinal))
         {
             if (DateOnly.TryParse(group.Key, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateOnly date))
             {

--- a/src/MyAccountingApp.Core/Services/FrankfurterCurrencyConverter.cs
+++ b/src/MyAccountingApp.Core/Services/FrankfurterCurrencyConverter.cs
@@ -1,0 +1,141 @@
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using MyAccountingApp.Core.DTOs;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Exceptions;
+using MyAccountingApp.Domain.Interfaces;
+
+namespace MyAccountingApp.Core.Services;
+
+/// <summary>
+/// Provides currency conversion rates from the free Frankfurter API (no API key, no monthly quota).
+/// </summary>
+public class FrankfurterCurrencyConverter : ICurrencyConverter
+{
+    private const string DefaultBaseUrl = "https://api.frankfurter.dev";
+
+    private static string? ExtractErrorMessage(string body)
+    {
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(body);
+
+            if (document.RootElement.TryGetProperty("message", out JsonElement message) && message.ValueKind == JsonValueKind.String)
+            {
+                return message.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return null;
+    }
+
+    private readonly HttpClient _httpClient;
+    private readonly IReadOnlyCollection<string> _excludedCurrencies;
+    private readonly string _baseUrl;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FrankfurterCurrencyConverter"/> class.
+    /// </summary>
+    /// <param name="httpClient">Optional HTTP client; a new one is created if not provided.</param>
+    /// <param name="excludedCurrencies">Optional list of currency codes to exclude from requests (BTC is always excluded).</param>
+    /// <param name="baseUrl">Optional base URL of the Frankfurter API.</param>
+    public FrankfurterCurrencyConverter(HttpClient? httpClient = null, IReadOnlyCollection<string>? excludedCurrencies = null, string baseUrl = DefaultBaseUrl)
+    {
+        this._httpClient = httpClient ?? new HttpClient();
+        this._excludedCurrencies = (excludedCurrencies ?? Array.Empty<string>())
+            .Append("BTC")
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        this._baseUrl = baseUrl.TrimEnd('/');
+    }
+
+    /// <inheritdoc/>
+    public async Task<Dictionary<string, decimal>> FetchAllRatesAsync(Currencies source, DateTime date)
+    {
+        string dateString = date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        string url = $"{this._baseUrl}/v2/rates?date={dateString}&base={source}&quotes={this.GetTargetCurrencies(source)}";
+
+        IReadOnlyList<FrankfurterRateRecord> records = await this.GetRecordsAsync(url);
+
+        Dictionary<string, decimal> result = new(StringComparer.Ordinal);
+
+        foreach (FrankfurterRateRecord record in records)
+        {
+            result[$"{source}{record.Quote}"] = record.Rate;
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>>> FetchRangeAsync(
+        Currencies source,
+        DateOnly start,
+        DateOnly end,
+        IReadOnlyCollection<Currencies>? targets = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (end < start)
+        {
+            throw new ArgumentException("The end date must be greater than or equal to the start date.", nameof(end));
+        }
+
+        string quotes = string.Join(",", (targets ?? Enum.GetValues<Currencies>()).Where(this.IsRequested));
+        string url = $"{this._baseUrl}/v2/rates?from={start:yyyy-MM-dd}&to={end:yyyy-MM-dd}&base={source}&quotes={quotes}";
+
+        IReadOnlyList<FrankfurterRateRecord> records = await this.GetRecordsAsync(url, cancellationToken);
+
+        Dictionary<DateOnly, Dictionary<string, decimal>> result = new();
+
+        foreach (IGrouping<string, FrankfurterRateRecord> group in records.GroupBy(r => r.Date, StringComparer.Ordinal))
+        {
+            if (DateOnly.TryParse(group.Key, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateOnly date))
+            {
+                Dictionary<string, decimal> quotesByPair = new(StringComparer.Ordinal);
+
+                foreach (FrankfurterRateRecord record in group)
+                {
+                    quotesByPair[$"{source}{record.Quote}"] = record.Rate;
+                }
+
+                result[date] = quotesByPair;
+            }
+        }
+
+        return result;
+    }
+
+    private string GetTargetCurrencies(Currencies source)
+    {
+        return string.Join(",", Enum.GetValues<Currencies>().Where(currency => currency != source && this.IsRequested(currency)));
+    }
+
+    private bool IsRequested(Currencies currency)
+    {
+        return !this._excludedCurrencies.Contains(currency.ToString(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    private async Task<IReadOnlyList<FrankfurterRateRecord>> GetRecordsAsync(string url, CancellationToken cancellationToken = default)
+    {
+        HttpResponseMessage response = await this._httpClient.GetAsync(url, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            throw new CurrencyApiQuotaExceededException("Frankfurter API returned HTTP 429 (too many requests).");
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            string body = await response.Content.ReadAsStringAsync(cancellationToken);
+            string message = ExtractErrorMessage(body) ?? $"HTTP {(int)response.StatusCode} ({response.ReasonPhrase}).";
+            throw new Exception($"Error in API response: {message}");
+        }
+
+        string json = await response.Content.ReadAsStringAsync(cancellationToken);
+        return JsonSerializer.Deserialize<List<FrankfurterRateRecord>>(json) ?? new List<FrankfurterRateRecord>();
+    }
+}

--- a/tests/MyAccountingApp.Application.Tests/Services/UnlimitedApiQuotaManagerTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/UnlimitedApiQuotaManagerTests.cs
@@ -1,0 +1,48 @@
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Domain.Entities;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class UnlimitedApiQuotaManagerTests
+{
+    private readonly UnlimitedApiQuotaManager _manager = new("frankfurter");
+
+    [Fact]
+    public async Task TryConsumeAsync_AlwaysReturnsTrue()
+    {
+        // Act
+        bool result = await this._manager.TryConsumeAsync(1);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task GetQuotaAsync_ReportsUnlimitedLimit()
+    {
+        // Act
+        ApiUsageQuota quota = await this._manager.GetQuotaAsync();
+
+        // Assert
+        Assert.Equal("frankfurter", quota.Provider);
+        Assert.Equal(0, quota.RequestsUsed);
+        Assert.Equal(int.MaxValue, quota.RequestsLimit);
+        Assert.Equal(0, quota.SafetyMargin);
+    }
+
+    [Fact]
+    public async Task MarkExhaustedAsync_DoesNotThrow()
+    {
+        // Act & Assert
+        await this._manager.MarkExhaustedAsync();
+        Assert.True(await this._manager.TryConsumeAsync(1));
+    }
+
+    [Fact]
+    public async Task EnsurePeriodAsync_DoesNotThrow()
+    {
+        // Act & Assert
+        await this._manager.EnsurePeriodAsync();
+        Assert.True(await this._manager.TryConsumeAsync(1));
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Services/FrankfurterCurrencyConverterTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/FrankfurterCurrencyConverterTests.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using MyAccountingApp.Core.Services;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Exceptions;
+using MyAccountingApp.TestUtilities.Fakes;
+
+namespace MyAccountingApp.Core.Tests.Services;
+
+public class FrankfurterCurrencyConverterTests
+{
+    [Fact]
+    public async Task FetchAllRatesAsync_ReturnsRates_WhenApiResponseIsValid()
+    {
+        // Arrange
+        string responseContent = """[{"date":"2025-01-02","base":"EUR","quote":"USD","rate":1.07},{"date":"2025-01-02","base":"EUR","quote":"GBP","rate":0.85}]""";
+        HttpClient httpClient = FakeHttpClient.CreateFakeHttpClient(responseContent, HttpStatusCode.OK);
+        FrankfurterCurrencyConverter converter = new(httpClient);
+
+        // Act
+        Dictionary<string, decimal> result = await converter.FetchAllRatesAsync(Currencies.EUR, new DateTime(2025, 1, 2));
+
+        // Assert
+        Assert.Equal(1.07m, result["EURUSD"]);
+        Assert.Equal(0.85m, result["EURGBP"]);
+    }
+
+    [Fact]
+    public async Task FetchAllRatesAsync_ThrowsException_WhenApiReturnsErrorMessage()
+    {
+        // Arrange
+        string responseContent = """{"message":"Could not find currency ABC"}""";
+        HttpClient httpClient = FakeHttpClient.CreateFakeHttpClient(responseContent, HttpStatusCode.NotFound);
+        FrankfurterCurrencyConverter converter = new(httpClient);
+
+        // Act
+        Exception ex = await Assert.ThrowsAsync<Exception>(() => converter.FetchAllRatesAsync(Currencies.EUR, new DateTime(2025, 1, 2)));
+
+        // Assert
+        Assert.Contains("Could not find currency ABC", ex.Message);
+    }
+
+    [Fact]
+    public async Task FetchAllRatesAsync_ThrowsQuotaExceeded_WhenHttp429()
+    {
+        // Arrange
+        HttpClient httpClient = FakeHttpClient.CreateFakeHttpClient("{}", HttpStatusCode.TooManyRequests);
+        FrankfurterCurrencyConverter converter = new(httpClient);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<CurrencyApiQuotaExceededException>(() => converter.FetchAllRatesAsync(Currencies.EUR, new DateTime(2025, 1, 2)));
+    }
+
+    [Fact]
+    public async Task FetchRangeAsync_ReturnsRatesGroupedByDate()
+    {
+        // Arrange
+        string responseContent = """[{"date":"2025-01-01","base":"EUR","quote":"USD","rate":1.05},{"date":"2025-01-01","base":"EUR","quote":"CAD","rate":1.5},{"date":"2025-01-02","base":"EUR","quote":"USD","rate":1.06}]""";
+        HttpClient httpClient = FakeHttpClient.CreateFakeHttpClient(responseContent, HttpStatusCode.OK);
+        FrankfurterCurrencyConverter converter = new(httpClient);
+
+        // Act
+        IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>> result = await converter.FetchRangeAsync(
+            Currencies.EUR, new DateOnly(2025, 1, 1), new DateOnly(2025, 1, 2));
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1.05m, result[new DateOnly(2025, 1, 1)]["EURUSD"]);
+        Assert.Equal(1.5m, result[new DateOnly(2025, 1, 1)]["EURCAD"]);
+        Assert.Equal(1.06m, result[new DateOnly(2025, 1, 2)]["EURUSD"]);
+    }
+
+    [Fact]
+    public async Task FetchRangeAsync_ThrowsArgumentException_WhenStartAfterEnd()
+    {
+        // Arrange
+        HttpClient httpClient = FakeHttpClient.CreateFakeHttpClient("[]", HttpStatusCode.OK);
+        FrankfurterCurrencyConverter converter = new(httpClient);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => converter.FetchRangeAsync(
+            Currencies.EUR, new DateOnly(2025, 1, 5), new DateOnly(2025, 1, 1)));
+    }
+
+    [Fact]
+    public async Task FetchAllRatesAsync_ExcludesBtcAndConfiguredCurrenciesFromRequest()
+    {
+        // Arrange
+        CapturingHandler handler = new();
+        HttpClient httpClient = new(handler);
+        FrankfurterCurrencyConverter converter = new(httpClient, new[] { "ARS" });
+
+        // Act
+        await converter.FetchAllRatesAsync(Currencies.EUR, new DateTime(2025, 1, 2));
+
+        // Assert
+        Assert.NotNull(handler.LastUrl);
+        Assert.DoesNotContain("BTC", handler.LastUrl);
+        Assert.DoesNotContain("ARS", handler.LastUrl);
+        Assert.Contains("USD", handler.LastUrl);
+    }
+
+    [Fact]
+    public async Task FetchRangeAsync_UsesRequestedRangeAndBaseInUrl()
+    {
+        // Arrange
+        CapturingHandler handler = new();
+        HttpClient httpClient = new(handler);
+        FrankfurterCurrencyConverter converter = new(httpClient);
+
+        // Act
+        await converter.FetchRangeAsync(Currencies.EUR, new DateOnly(2025, 1, 1), new DateOnly(2025, 1, 3));
+
+        // Assert
+        Assert.NotNull(handler.LastUrl);
+        Assert.Contains("from=2025-01-01", handler.LastUrl);
+        Assert.Contains("to=2025-01-03", handler.LastUrl);
+        Assert.Contains("base=EUR", handler.LastUrl);
+        Assert.Contains("quotes=", handler.LastUrl);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public string? LastUrl { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            this.LastUrl = request.RequestUri?.ToString();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]"),
+            });
+        }
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Services/FrankfurterCurrencyConverterTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/FrankfurterCurrencyConverterTests.cs
@@ -116,6 +116,27 @@ public class FrankfurterCurrencyConverterTests
         Assert.Contains("to=2025-01-03", handler.LastUrl);
         Assert.Contains("base=EUR", handler.LastUrl);
         Assert.Contains("quotes=", handler.LastUrl);
+        string[] quoteCodes = handler.LastUrl.Split("quotes=")[1].Split(',');
+        Assert.DoesNotContain("EUR", quoteCodes);
+        Assert.DoesNotContain("BTC", quoteCodes);
+    }
+
+    [Fact]
+    public async Task FetchRangeAsync_IgnoresRatesWhereQuoteIsTheSource()
+    {
+        // Arrange
+        string responseContent = """[{"date":"2025-01-02","base":"EUR","quote":"EUR","rate":1},{"date":"2025-01-02","base":"EUR","quote":"USD","rate":1.07}]""";
+        HttpClient httpClient = FakeHttpClient.CreateFakeHttpClient(responseContent, HttpStatusCode.OK);
+        FrankfurterCurrencyConverter converter = new(httpClient);
+
+        // Act
+        IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>> result = await converter.FetchRangeAsync(
+            Currencies.EUR, new DateOnly(2025, 1, 1), new DateOnly(2025, 1, 2));
+
+        // Assert
+        Assert.Single(result);
+        Assert.DoesNotContain("EUREUR", result[new DateOnly(2025, 1, 2)]);
+        Assert.Equal(1.07m, result[new DateOnly(2025, 1, 2)]["EURUSD"]);
     }
 
     private sealed class CapturingHandler : HttpMessageHandler


### PR DESCRIPTION
Reemplaça exchangerate.host com a proveïdor de divises primari amb la Frankfurter API (gratuïta, sense clau, sense quota mensual).

- Switch de proveïdor a `CurrencyApi:Provider` (Frankfurter | ExchangeRateHost)
- UnlimitedApiQuotaManager per mantenir la infraestructura de quota/cua/persistència
- BTC sempre exclòs
- 11 tests nous, 292 totals verds