### PR TITLE
style: fix StyleCop violations and make the CI gate real

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["**"]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 permissions:
   contents: read
@@ -27,7 +27,7 @@ jobs:
       run: dotnet build --configuration Release
 
     - name: Run StyleCop (linter)
-      run: dotnet build --configuration Release -warnaserror
+      run: dotnet build --configuration Release -warnaserror --no-incremental
 
     - name: Run tests with coverage (min 80%)
       run: |

--- a/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
+++ b/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
@@ -21,6 +21,53 @@ public class CurencyRateService : ICurrencyRateService
     private readonly int _maxTimeseriesDays;
     private readonly string _sourceProvider;
 
+    private static Conversion CloneForStale(Conversion fallback)
+    {
+        Conversion clone = new(
+            fallback.Date,
+            fallback.Source,
+            new Dictionary<Currencies, decimal>(fallback.Quotes),
+            fallback.RetrievedAtUtc,
+            fallback.IsStale,
+            fallback.SourceProvider);
+        clone.MarkStale();
+        return clone;
+    }
+
+    private static List<(DateOnly Start, DateOnly End)> GroupIntoRanges(List<DateOnly> dates, int maxDays)
+    {
+        List<(DateOnly, DateOnly)> ranges = new();
+
+        if (dates.Count == 0)
+        {
+            return ranges;
+        }
+
+        DateOnly rangeStart = dates[0];
+        DateOnly rangeEnd = dates[0];
+
+        for (int i = 1; i < dates.Count; i++)
+        {
+            DateOnly day = dates[i];
+            bool consecutive = day.AddDays(-1) <= rangeEnd;
+            bool fits = day.DayNumber - rangeStart.DayNumber < maxDays;
+
+            if (consecutive && fits)
+            {
+                rangeEnd = day;
+            }
+            else
+            {
+                ranges.Add((rangeStart, rangeEnd));
+                rangeStart = day;
+                rangeEnd = day;
+            }
+        }
+
+        ranges.Add((rangeStart, rangeEnd));
+        return ranges;
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="CurencyRateService"/> class.
     /// </summary>
@@ -238,52 +285,5 @@ public class CurencyRateService : ICurrencyRateService
         return this._repository.GetAll()
             .OrderByDescending(c => c.Date)
             .FirstOrDefault(c => c.Date.Date <= date);
-    }
-
-    private static Conversion CloneForStale(Conversion fallback)
-    {
-        Conversion clone = new(
-            fallback.Date,
-            fallback.Source,
-            new Dictionary<Currencies, decimal>(fallback.Quotes),
-            fallback.RetrievedAtUtc,
-            fallback.IsStale,
-            fallback.SourceProvider);
-        clone.MarkStale();
-        return clone;
-    }
-
-    private static List<(DateOnly Start, DateOnly End)> GroupIntoRanges(List<DateOnly> dates, int maxDays)
-    {
-        List<(DateOnly, DateOnly)> ranges = new();
-
-        if (dates.Count == 0)
-        {
-            return ranges;
-        }
-
-        DateOnly rangeStart = dates[0];
-        DateOnly rangeEnd = dates[0];
-
-        for (int i = 1; i < dates.Count; i++)
-        {
-            DateOnly day = dates[i];
-            bool consecutive = day.AddDays(-1) <= rangeEnd;
-            bool fits = day.DayNumber - rangeStart.DayNumber < maxDays;
-
-            if (consecutive && fits)
-            {
-                rangeEnd = day;
-            }
-            else
-            {
-                ranges.Add((rangeStart, rangeEnd));
-                rangeStart = day;
-                rangeEnd = day;
-            }
-        }
-
-        ranges.Add((rangeStart, rangeEnd));
-        return ranges;
     }
 }

--- a/src/MyAccountingApp.Core/Agents/IBKR/CorporateActionAgent.cs
+++ b/src/MyAccountingApp.Core/Agents/IBKR/CorporateActionAgent.cs
@@ -15,8 +15,15 @@ public class CorporateActionAgent : IIBKRStatementAgent
     {
         foreach (string[] fields in rows)
         {
-            if (fields.Length < 10) continue;
-            if (fields[1] != "Data") continue;
+            if (fields.Length < 10)
+            {
+                continue;
+            }
+
+            if (fields[1] != "Data")
+            {
+                continue;
+            }
 
             string assetCategory = fields[2];
             string currency = fields[3];
@@ -25,9 +32,20 @@ public class CorporateActionAgent : IIBKRStatementAgent
             string qtyStr = fields[7];
             string proceedsStr = fields[8];
 
-            if (!TryParseDateTime(dateStr, out DateTime date)) continue;
-            if (!TryParseDecimal(qtyStr, out decimal rawQuantity) || rawQuantity == 0) continue;
-            if (!TryParseDecimal(proceedsStr, out decimal proceeds)) continue;
+            if (!TryParseDateTime(dateStr, out DateTime date))
+            {
+                continue;
+            }
+
+            if (!TryParseDecimal(qtyStr, out decimal rawQuantity) || rawQuantity == 0)
+            {
+                continue;
+            }
+
+            if (!TryParseDecimal(proceedsStr, out decimal proceeds))
+            {
+                continue;
+            }
 
             int quantity = (int)Math.Abs(rawQuantity);
             bool hasCash = Math.Abs(proceeds) > 0.01m;
@@ -58,16 +76,32 @@ public class CorporateActionAgent : IIBKRStatementAgent
     private static bool TryParseDateTime(string value, out DateTime date)
     {
         date = default;
-        if (string.IsNullOrWhiteSpace(value)) return false;
-        if (DateTime.TryParseExact(value, "yyyy-MM-dd, HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out date)) return true;
-        if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out date)) return true;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        if (DateTime.TryParseExact(value, "yyyy-MM-dd, HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out date))
+        {
+            return true;
+        }
+
+        if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out date))
+        {
+            return true;
+        }
+
         return false;
     }
 
     private static bool TryParseDecimal(string value, out decimal result)
     {
         result = 0;
-        if (string.IsNullOrWhiteSpace(value)) return false;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
         string cleaned = value.Replace(",", string.Empty).Replace("\"", string.Empty);
         return decimal.TryParse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
     }

--- a/src/MyAccountingApp.Core/Agents/IBKR/DepositWithdrawalAgent.cs
+++ b/src/MyAccountingApp.Core/Agents/IBKR/DepositWithdrawalAgent.cs
@@ -15,16 +15,30 @@ public class DepositWithdrawalAgent : IIBKRStatementAgent
     {
         foreach (string[] fields in rows)
         {
-            if (fields.Length < 5) continue;
-            if (fields[1] != "Data") continue;
+            if (fields.Length < 5)
+            {
+                continue;
+            }
+
+            if (fields[1] != "Data")
+            {
+                continue;
+            }
 
             string currency = fields[2];
             string dateStr = fields[3];
             string description = fields[4];
             string amountStr = fields[5];
 
-            if (!TryParseDate(dateStr, out DateTime date)) continue;
-            if (!TryParseDecimal(amountStr, out decimal amount) || amount == 0) continue;
+            if (!TryParseDate(dateStr, out DateTime date))
+            {
+                continue;
+            }
+
+            if (!TryParseDecimal(amountStr, out decimal amount) || amount == 0)
+            {
+                continue;
+            }
 
             bool isWithdrawal = amount < 0;
             TransactionCategory category = isWithdrawal ? TransactionCategory.TRANSFER : TransactionCategory.DEPOSIT;
@@ -42,7 +56,11 @@ public class DepositWithdrawalAgent : IIBKRStatementAgent
     private static bool TryParseDecimal(string value, out decimal result)
     {
         result = 0;
-        if (string.IsNullOrWhiteSpace(value)) return false;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
         string cleaned = value.Replace(",", string.Empty).Replace("\"", string.Empty);
         return decimal.TryParse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
     }

--- a/src/MyAccountingApp.Core/Agents/IBKR/DividendAgent.cs
+++ b/src/MyAccountingApp.Core/Agents/IBKR/DividendAgent.cs
@@ -15,16 +15,30 @@ public class DividendAgent : IIBKRStatementAgent
     {
         foreach (string[] fields in rows)
         {
-            if (fields.Length < 5) continue;
-            if (fields[1] != "Data") continue;
+            if (fields.Length < 5)
+            {
+                continue;
+            }
+
+            if (fields[1] != "Data")
+            {
+                continue;
+            }
 
             string currency = fields[2];
             string dateStr = fields[3];
             string description = fields[4];
             string amountStr = fields[5];
 
-            if (!TryParseDate(dateStr, out DateTime date)) continue;
-            if (!TryParseDecimal(amountStr, out decimal amount) || amount == 0) continue;
+            if (!TryParseDate(dateStr, out DateTime date))
+            {
+                continue;
+            }
+
+            if (!TryParseDecimal(amountStr, out decimal amount) || amount == 0)
+            {
+                continue;
+            }
 
             Money money = new Money(Math.Abs(amount), currency);
             Transaction transaction = new Transaction(date, description, money, TransactionCategory.INCOME);
@@ -40,7 +54,11 @@ public class DividendAgent : IIBKRStatementAgent
     private static bool TryParseDecimal(string value, out decimal result)
     {
         result = 0;
-        if (string.IsNullOrWhiteSpace(value)) return false;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
         string cleaned = value.Replace(",", string.Empty).Replace("\"", string.Empty);
         return decimal.TryParse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
     }

--- a/src/MyAccountingApp.Core/Agents/IBKR/FeeAgent.cs
+++ b/src/MyAccountingApp.Core/Agents/IBKR/FeeAgent.cs
@@ -15,16 +15,30 @@ public class FeeAgent : IIBKRStatementAgent
     {
         foreach (string[] fields in rows)
         {
-            if (fields.Length < 6) continue;
-            if (fields[1] != "Data") continue;
+            if (fields.Length < 6)
+            {
+                continue;
+            }
+
+            if (fields[1] != "Data")
+            {
+                continue;
+            }
 
             string currency = fields[3];
             string dateStr = fields[4];
             string description = fields[5];
             string amountStr = fields[6];
 
-            if (!TryParseDate(dateStr, out DateTime date)) continue;
-            if (!TryParseDecimal(amountStr, out decimal amount) || amount == 0) continue;
+            if (!TryParseDate(dateStr, out DateTime date))
+            {
+                continue;
+            }
+
+            if (!TryParseDecimal(amountStr, out decimal amount) || amount == 0)
+            {
+                continue;
+            }
 
             Money money = new Money(Math.Abs(amount), currency);
             Transaction transaction = new Transaction(date, description, money, TransactionCategory.EXPENSE);
@@ -40,7 +54,11 @@ public class FeeAgent : IIBKRStatementAgent
     private static bool TryParseDecimal(string value, out decimal result)
     {
         result = 0;
-        if (string.IsNullOrWhiteSpace(value)) return false;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
         string cleaned = value.Replace(",", string.Empty).Replace("\"", string.Empty);
         return decimal.TryParse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
     }

--- a/src/MyAccountingApp.Core/Agents/IBKR/IBKRFlexQueryImportService.cs
+++ b/src/MyAccountingApp.Core/Agents/IBKR/IBKRFlexQueryImportService.cs
@@ -58,10 +58,16 @@ public class IBKRFlexQueryImportService : IBrokerImportService
 
         foreach (string line in lines)
         {
-            if (string.IsNullOrWhiteSpace(line)) continue;
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
 
             string[] fields = SplitCsvLine(line);
-            if (fields.Length == 0) continue;
+            if (fields.Length == 0)
+            {
+                continue;
+            }
 
             string section = fields[0];
             if (fields.Length >= 2 && fields[1] == "Header")

--- a/src/MyAccountingApp.Core/Agents/IBKR/InterestAgent.cs
+++ b/src/MyAccountingApp.Core/Agents/IBKR/InterestAgent.cs
@@ -15,16 +15,30 @@ public class InterestAgent : IIBKRStatementAgent
     {
         foreach (string[] fields in rows)
         {
-            if (fields.Length < 5) continue;
-            if (fields[1] != "Data") continue;
+            if (fields.Length < 5)
+            {
+                continue;
+            }
+
+            if (fields[1] != "Data")
+            {
+                continue;
+            }
 
             string currency = fields[2];
             string dateStr = fields[3];
             string description = fields[4];
             string amountStr = fields[5];
 
-            if (!TryParseDate(dateStr, out DateTime date)) continue;
-            if (!TryParseDecimal(amountStr, out decimal amount) || amount == 0) continue;
+            if (!TryParseDate(dateStr, out DateTime date))
+            {
+                continue;
+            }
+
+            if (!TryParseDecimal(amountStr, out decimal amount) || amount == 0)
+            {
+                continue;
+            }
 
             bool isIncome = amount > 0;
             TransactionCategory category = isIncome ? TransactionCategory.INCOME : TransactionCategory.EXPENSE;
@@ -42,7 +56,11 @@ public class InterestAgent : IIBKRStatementAgent
     private static bool TryParseDecimal(string value, out decimal result)
     {
         result = 0;
-        if (string.IsNullOrWhiteSpace(value)) return false;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
         string cleaned = value.Replace(",", string.Empty).Replace("\"", string.Empty);
         return decimal.TryParse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
     }

--- a/src/MyAccountingApp.Core/Agents/IBKR/TradeAgent.cs
+++ b/src/MyAccountingApp.Core/Agents/IBKR/TradeAgent.cs
@@ -15,8 +15,15 @@ public class TradeAgent : IIBKRStatementAgent
     {
         foreach (string[] fields in rows)
         {
-            if (fields.Length < 15) continue;
-            if (fields[1] != "Data" || fields[2] != "Order") continue;
+            if (fields.Length < 15)
+            {
+                continue;
+            }
+
+            if (fields[1] != "Data" || fields[2] != "Order")
+            {
+                continue;
+            }
 
             string assetCategory = fields[3];
             string currency = fields[4];
@@ -25,9 +32,20 @@ public class TradeAgent : IIBKRStatementAgent
             string qtyStr = fields[7];
             string proceedsStr = fields[10];
 
-            if (!TryParseDateTime(dateTimeStr, out DateTime date)) continue;
-            if (!TryParseDecimal(qtyStr, out decimal rawQuantity) || rawQuantity == 0) continue;
-            if (!TryParseDecimal(proceedsStr, out decimal proceeds) || proceeds == 0) continue;
+            if (!TryParseDateTime(dateTimeStr, out DateTime date))
+            {
+                continue;
+            }
+
+            if (!TryParseDecimal(qtyStr, out decimal rawQuantity) || rawQuantity == 0)
+            {
+                continue;
+            }
+
+            if (!TryParseDecimal(proceedsStr, out decimal proceeds) || proceeds == 0)
+            {
+                continue;
+            }
 
             bool isBuy = proceeds < 0;
             int quantity = (int)Math.Abs(rawQuantity);
@@ -78,16 +96,32 @@ public class TradeAgent : IIBKRStatementAgent
     private static bool TryParseDateTime(string value, out DateTime date)
     {
         date = default;
-        if (string.IsNullOrWhiteSpace(value)) return false;
-        if (DateTime.TryParseExact(value, "yyyy-MM-dd, HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out date)) return true;
-        if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out date)) return true;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        if (DateTime.TryParseExact(value, "yyyy-MM-dd, HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out date))
+        {
+            return true;
+        }
+
+        if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out date))
+        {
+            return true;
+        }
+
         return false;
     }
 
     private static bool TryParseDecimal(string value, out decimal result)
     {
         result = 0;
-        if (string.IsNullOrWhiteSpace(value)) return false;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
         string cleaned = value.Replace(",", string.Empty).Replace("\"", string.Empty);
         return decimal.TryParse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
     }

--- a/src/MyAccountingApp.Core/Agents/IBKR/WithholdingTaxAgent.cs
+++ b/src/MyAccountingApp.Core/Agents/IBKR/WithholdingTaxAgent.cs
@@ -15,16 +15,30 @@ public class WithholdingTaxAgent : IIBKRStatementAgent
     {
         foreach (string[] fields in rows)
         {
-            if (fields.Length < 6) continue;
-            if (fields[1] != "Data") continue;
+            if (fields.Length < 6)
+            {
+                continue;
+            }
+
+            if (fields[1] != "Data")
+            {
+                continue;
+            }
 
             string currency = fields[2];
             string dateStr = fields[3];
             string description = fields[4];
             string amountStr = fields[5];
 
-            if (!TryParseDate(dateStr, out DateTime date)) continue;
-            if (!TryParseDecimal(amountStr, out decimal amount) || amount == 0) continue;
+            if (!TryParseDate(dateStr, out DateTime date))
+            {
+                continue;
+            }
+
+            if (!TryParseDecimal(amountStr, out decimal amount) || amount == 0)
+            {
+                continue;
+            }
 
             Money money = new Money(Math.Abs(amount), currency);
             Transaction transaction = new Transaction(date, description, money, TransactionCategory.EXPENSE);
@@ -40,7 +54,11 @@ public class WithholdingTaxAgent : IIBKRStatementAgent
     private static bool TryParseDecimal(string value, out decimal result)
     {
         result = 0;
-        if (string.IsNullOrWhiteSpace(value)) return false;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
         string cleaned = value.Replace(",", string.Empty).Replace("\"", string.Empty);
         return decimal.TryParse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
     }

--- a/src/MyAccountingApp.Core/Repositories/JsonTransactionRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/JsonTransactionRepository.cs
@@ -56,19 +56,25 @@ public class JsonTransactionRepository : ITransactionRepository
         {
             List<Transaction>? transactions = JsonSerializer.Deserialize<List<Transaction>>(json, options);
             if (transactions is null || transactions.Count == 0)
+            {
                 return new List<Transaction>();
+            }
 
             var seen = new HashSet<Guid>();
             var deduplicated = new List<Transaction>(transactions.Count);
             for (int i = transactions.Count - 1; i >= 0; i--)
             {
                 if (seen.Add(transactions[i].Id))
+                {
                     deduplicated.Add(transactions[i]);
+                }
             }
 
             deduplicated.Reverse();
             if (deduplicated.Count != transactions.Count)
+            {
                 this.WriteAll(deduplicated);
+            }
 
             return deduplicated;
         }

--- a/src/MyAccountingApp.Core/Services/CurrencyConverter.cs
+++ b/src/MyAccountingApp.Core/Services/CurrencyConverter.cs
@@ -15,6 +15,19 @@ public class CurrencyConverter : ICurrencyConverter
     private readonly HttpClient _httpClient;
     private readonly IReadOnlyCollection<string> _excludedCurrencies;
 
+    private static void ThrowIfFailed(bool success, ExchangeRateResponseError? error)
+    {
+        if (!success)
+        {
+            if (error?.Code == 104 || (error?.Info is not null && error.Info.Contains("limit", StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new CurrencyApiQuotaExceededException($"Currency API quota exceeded: {error?.Info}");
+            }
+
+            throw new Exception($"Error in API response: {error?.Info}");
+        }
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="CurrencyConverter"/> class.
     /// </summary>
@@ -103,18 +116,5 @@ public class CurrencyConverter : ICurrencyConverter
 
         response.EnsureSuccessStatusCode();
         return response;
-    }
-
-    private static void ThrowIfFailed(bool success, ExchangeRateResponseError? error)
-    {
-        if (!success)
-        {
-            if (error?.Code == 104 || (error?.Info is not null && error.Info.Contains("limit", StringComparison.OrdinalIgnoreCase)))
-            {
-                throw new CurrencyApiQuotaExceededException($"Currency API quota exceeded: {error?.Info}");
-            }
-
-            throw new Exception($"Error in API response: {error?.Info}");
-        }
     }
 }

--- a/src/MyAccountingApp.Web/Pages/Import.razor
+++ b/src/MyAccountingApp.Web/Pages/Import.razor
@@ -203,7 +203,7 @@
                             <div class="d-flex align-center">
                                 <MudTextField @bind-Value="_editableSymbols[a.Transaction.Id]"
                                               Variant="Variant.Outlined"
-                                              Dense="true"
+                                              Margin="Margin.Dense"
                                               Immediate="true"
                                               Class="flex-grow-1" />
                                 <MudIconButton Icon="@Icons.Material.Filled.Search"

--- a/src/MyAccountingApp.Web/Pages/Settings.razor
+++ b/src/MyAccountingApp.Web/Pages/Settings.razor
@@ -118,7 +118,7 @@
 
 @if (_lastRestoreMessage is not null)
 {
-    <MudAlert Severity="@_restoreSeverity" Class="mb-4" Dismissable="true">
+    <MudAlert Severity="@_restoreSeverity" Class="mb-4" ShowCloseIcon="true">
         @_lastRestoreMessage
     </MudAlert>
 }

--- a/tests/MyAccountingApp.Core.Tests/Agents/IBKRFlexQueryImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Agents/IBKRFlexQueryImportServiceTests.cs
@@ -27,16 +27,16 @@ public class IBKRFlexQueryImportServiceTests : IDisposable
         RecordingAgent recording = new("My Section");
         IBKRFlexQueryImportService service = new(new[] { recording });
 
-        File.WriteAllText(
-            this._tempFile,
-            string.Join("\n", new[]
-            {
-                "My Section,Header,,Column1,Column2",
-                "My Section,Data,,value1,value2",
-                "My Section,Data,,value3,value4",
-                "Other Section,Header,,x,y",
-                string.Empty,
-            }));
+        string[] csvLines =
+        {
+            "My Section,Header,,Column1,Column2",
+            "My Section,Data,,value1,value2",
+            "My Section,Data,,value3,value4",
+            "Other Section,Header,,x,y",
+            string.Empty,
+        };
+
+        File.WriteAllText(this._tempFile, string.Join("\n", csvLines));
 
         (IEnumerable<Transaction> tx, IEnumerable<AssetTransaction> assets, IEnumerable<OptionTransaction> options) =
             await service.ParseAllAsync(this._tempFile);
@@ -53,13 +53,13 @@ public class IBKRFlexQueryImportServiceTests : IDisposable
         TradeAgent tradeAgent = new();
         IBKRFlexQueryImportService service = new(new IIBKRStatementAgent[] { tradeAgent });
 
-        File.WriteAllText(
-            this._tempFile,
-            string.Join("\n", new[]
-            {
-                "Trades,Header,,,,,,,,",
-                "Trades,Data,Order,Stocks,USD,AAPL,\"2024-12-19, 10:00:00\",100,,,-15000.00,,,,,,",
-            }));
+        string[] csvLines =
+        {
+            "Trades,Header,,,,,,,,",
+            "Trades,Data,Order,Stocks,USD,AAPL,\"2024-12-19, 10:00:00\",100,,,-15000.00,,,,,,",
+        };
+
+        File.WriteAllText(this._tempFile, string.Join("\n", csvLines));
 
         (IEnumerable<Transaction> tx, IEnumerable<AssetTransaction> assets, IEnumerable<OptionTransaction> options) =
             await service.ParseAllAsync(this._tempFile);

--- a/tests/MyAccountingApp.Core.Tests/Agents/InteractiveBrokersImportServiceExtraTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Agents/InteractiveBrokersImportServiceExtraTests.cs
@@ -13,6 +13,21 @@ public class InteractiveBrokersImportServiceExtraTests
     private readonly Mock<ICsvParser> parserMock = new();
     private readonly InteractiveBrokersImportService agent;
 
+    private static IBKRTransactionRecord Record(string type, string description, string symbol, string quantity, string currency, string amount)
+    {
+        return new IBKRTransactionRecord
+        {
+            Date = "2024-12-19",
+            Description = description,
+            TransactionType = type,
+            Symbol = symbol,
+            Quantity = quantity,
+            PriceCurrency = currency,
+            GrossAmount = amount,
+            NetAmount = amount,
+        };
+    }
+
     public InteractiveBrokersImportServiceExtraTests()
     {
         Mock<ILogger<InteractiveBrokersImportService>> loggerMock = new();
@@ -235,20 +250,5 @@ public class InteractiveBrokersImportServiceExtraTests
         this.parserMock
             .Setup(p => p.ParseIBKRAsync(It.IsAny<string>()))
             .ReturnsAsync(records);
-    }
-
-    private static IBKRTransactionRecord Record(string type, string description, string symbol, string quantity, string currency, string amount)
-    {
-        return new IBKRTransactionRecord
-        {
-            Date = "2024-12-19",
-            Description = description,
-            TransactionType = type,
-            Symbol = symbol,
-            Quantity = quantity,
-            PriceCurrency = currency,
-            GrossAmount = amount,
-            NetAmount = amount,
-        };
     }
 }

--- a/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
@@ -239,7 +239,9 @@ public class BrokerImportDispatcherTests
 
 internal class FakeLogger<T> : Microsoft.Extensions.Logging.ILogger<T>
 {
-    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
+        => null;
     public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
     public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {


### PR DESCRIPTION
Arregla les 108 violacions StyleCop (SA1503/SA1204/SA1118/SA1127) i fa el gate real:\n\n- El pas 'Run StyleCop (linter)' era un no-op (build incremental que no re-avaluava analitzadors) → ara amb --no-incremental\n- 2 errors MudBlazor (Dismissable → ShowCloseIcon, Dense → Margin.Dense)\n- Fix del trigger pull_request (apuntava a main, la branca real és master)\n- Build net determinista amb -warnaserror: 0 warnings / 0 errors\n- 293 tests verds