### PR TITLE
fix: consume currency API quota only after success

### DIFF
--- a/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
+++ b/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
@@ -135,11 +135,12 @@ public class CurencyRateService : ICurrencyRateService
 
         await this._quotaManager.EnsurePeriodAsync();
 
-        if (await this._quotaManager.TryConsumeAsync(1))
+        if (await this.CanConsumeAsync())
         {
             try
             {
                 Dictionary<string, decimal> rates = await this._api.FetchAllRatesAsync(this._source, date);
+                await this._quotaManager.TryConsumeAsync(1);
                 Conversion conversion = this.BuildConversion(day, rates);
                 this._repository.AddOrUpdate(conversion);
                 return conversion;
@@ -150,8 +151,8 @@ public class CurencyRateService : ICurrencyRateService
             }
             catch
             {
-                // Provider unavailable (timeout, 5xx, network error): fall back to the
-                // pending queue and the stale conversion instead of failing the request.
+                // Provider unavailable (timeout, 5xx, network error): no quota consumed.
+                // Fall back to the pending queue and the stale conversion instead of failing the request.
             }
         }
 
@@ -172,7 +173,7 @@ public class CurencyRateService : ICurrencyRateService
     {
         await this._quotaManager.EnsurePeriodAsync(cancellationToken);
 
-        if (!await this._quotaManager.TryConsumeAsync(1, cancellationToken))
+        if (!await this.CanConsumeAsync(cancellationToken))
         {
             return false;
         }
@@ -180,6 +181,7 @@ public class CurencyRateService : ICurrencyRateService
         try
         {
             IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>> rates = await this._api.FetchRangeAsync(this._source, start, end, null, cancellationToken);
+            await this._quotaManager.TryConsumeAsync(1, cancellationToken);
 
             foreach (KeyValuePair<DateOnly, Dictionary<string, decimal>> kv in rates)
             {
@@ -209,16 +211,16 @@ public class CurencyRateService : ICurrencyRateService
 
         foreach ((DateOnly start, DateOnly end) in GroupIntoRanges(pendingDays, this._maxTimeseriesDays))
         {
-            if (!await this._quotaManager.TryConsumeAsync(1, cancellationToken))
+            if (!await this.CanConsumeAsync(cancellationToken))
             {
                 break;
             }
 
-            requestsSpent++;
-
             try
             {
                 IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>> rates = await this._api.FetchRangeAsync(this._source, start, end, null, cancellationToken);
+                await this._quotaManager.TryConsumeAsync(1, cancellationToken);
+                requestsSpent++;
 
                 foreach (KeyValuePair<DateOnly, Dictionary<string, decimal>> kv in rates)
                 {
@@ -309,6 +311,17 @@ public class CurencyRateService : ICurrencyRateService
     public Task<ApiUsageQuota> GetQuotaAsync(CancellationToken cancellationToken = default)
     {
         return this._quotaManager.GetQuotaAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Checks whether the quota can absorb a request without consuming it.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>True if the quota can absorb the request; otherwise, false.</returns>
+    private async Task<bool> CanConsumeAsync(CancellationToken cancellationToken = default)
+    {
+        ApiUsageQuota quota = await this._quotaManager.GetQuotaAsync(cancellationToken);
+        return quota.CanConsume(1);
     }
 
     private Conversion BuildConversion(DateOnly day, Dictionary<string, decimal> rates)

--- a/tests/MyAccountingApp.Application.Tests/Services/CurrencyRateServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/CurrencyRateServiceTests.cs
@@ -53,7 +53,8 @@ public class CurrencyRateServiceTests
         FakeConversionRepository repo = new();
         FakeApiQuotaManager quota = new() { CanConsumeResult = false };
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        FakeCurrencyConverter converter = new();
+        CurencyRateService service = new(repo, converter, Currencies.EUR, quota, queue);
 
         // Act
         Conversion result = await service.GetConversionAsync(new DateTime(2023, 12, 1));
@@ -61,6 +62,7 @@ public class CurrencyRateServiceTests
         // Assert
         Assert.True(result.IsStale);
         Assert.Equal(0, quota.Consumed);
+        Assert.Equal(0, converter.FetchAllCalls);
         Assert.Contains(new DateOnly(2023, 12, 1), queue.Enqueued);
         Assert.Equal(new DateTime(2005, 12, 1), result.Date);
         Assert.Equal(1.1m, result.Quotes[Currencies.USD]);
@@ -103,9 +105,11 @@ public class CurrencyRateServiceTests
     public async Task SyncRangeAsync_ReturnsFalse_WhenNoQuota()
     {
         // Arrange
+        FakeConversionRepository repo = new();
         FakeApiQuotaManager quota = new() { CanConsumeResult = false };
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(new FakeConversionRepository(), quota, queue);
+        FakeCurrencyConverter converter = new();
+        CurencyRateService service = new(repo, converter, Currencies.EUR, quota, queue);
 
         // Act
         bool result = await service.SyncRangeAsync(new DateOnly(2023, 12, 1), new DateOnly(2023, 12, 5));
@@ -113,6 +117,47 @@ public class CurrencyRateServiceTests
         // Assert
         Assert.False(result);
         Assert.Equal(0, quota.Consumed);
+        Assert.Equal(0, converter.FetchRangeCalls);
+    }
+
+    [Fact]
+    public async Task SyncRangeAsync_DoesNotConsumeQuota_WhenApiFails()
+    {
+        // Arrange
+        FakeConversionRepository repo = new();
+        repo.Initialize(Array.Empty<Conversion>());
+        FakeApiQuotaManager quota = new();
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = new(repo, new FailingCurrencyConverter(), Currencies.EUR, quota, queue);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<HttpRequestException>(() => service.SyncRangeAsync(new DateOnly(2023, 12, 1), new DateOnly(2023, 12, 5)));
+        Assert.Equal(0, quota.Consumed);
+        Assert.False(quota.Exhausted);
+        Assert.Empty(repo.GetAll());
+    }
+
+    [Fact]
+    public async Task ProcessPendingAsync_DoesNotConsumeQuota_WhenRangeFetchFails()
+    {
+        // Arrange
+        FakeConversionRepository repo = new();
+        FakeApiQuotaManager quota = new();
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = new(repo, new FailingCurrencyConverter(), Currencies.EUR, quota, queue);
+
+        await queue.EnqueueAsync(new DateOnly(2023, 12, 1));
+        await queue.EnqueueAsync(new DateOnly(2023, 12, 2));
+
+        // Act
+        PendingProcessingResult result = await service.ProcessPendingAsync();
+
+        // Assert
+        Assert.Equal(0, result.RequestsSpent);
+        Assert.Equal(0, result.ProcessedDays);
+        Assert.Equal(1, result.Failures);
+        Assert.Equal(0, quota.Consumed);
+        Assert.False(quota.Exhausted);
     }
 
     [Fact]
@@ -239,7 +284,7 @@ public class CurrencyRateServiceTests
     }
 
     [Fact]
-    public async Task GetConversionAsync_FallsBackToStale_WhenApiFails()
+    public async Task GetConversionAsync_FallsBackToStale_WithoutConsumingQuota_WhenApiFails()
     {
         // Arrange
         FakeConversionRepository repo = new();
@@ -252,7 +297,28 @@ public class CurrencyRateServiceTests
 
         // Assert
         Assert.True(result.IsStale);
-        Assert.Equal(1, quota.Consumed);
+        Assert.Equal(0, quota.Consumed);
+        Assert.False(quota.Exhausted);
+        Assert.Contains(new DateOnly(2023, 12, 1), queue.Enqueued);
+        Assert.Equal(new DateTime(2005, 12, 1), result.Date);
+    }
+
+    [Fact]
+    public async Task GetConversionAsync_MarksExhausted_WithoutConsuming_WhenApiReportsQuotaExceeded()
+    {
+        // Arrange
+        FakeConversionRepository repo = new();
+        FakeApiQuotaManager quota = new();
+        FakePendingConversionQueue queue = new();
+        CurencyRateService service = new(repo, new QuotaExceededCurrencyConverter(), Currencies.EUR, quota, queue);
+
+        // Act
+        Conversion result = await service.GetConversionAsync(new DateTime(2023, 12, 1));
+
+        // Assert
+        Assert.True(result.IsStale);
+        Assert.True(quota.Exhausted);
+        Assert.Equal(0, quota.Consumed);
         Assert.Contains(new DateOnly(2023, 12, 1), queue.Enqueued);
         Assert.Equal(new DateTime(2005, 12, 1), result.Date);
     }
@@ -357,6 +423,24 @@ public class CurrencyRateServiceTests
             CancellationToken cancellationToken = default)
         {
             throw new HttpRequestException("provider unavailable");
+        }
+    }
+
+    private sealed class QuotaExceededCurrencyConverter : ICurrencyConverter
+    {
+        public Task<Dictionary<string, decimal>> FetchAllRatesAsync(Currencies source, DateTime date)
+        {
+            throw new CurrencyApiQuotaExceededException("provider reported quota exceeded");
+        }
+
+        public Task<IReadOnlyDictionary<DateOnly, Dictionary<string, decimal>>> FetchRangeAsync(
+            Currencies source,
+            DateOnly start,
+            DateOnly end,
+            IReadOnlyCollection<Currencies>? targets = null,
+            CancellationToken cancellationToken = default)
+        {
+            throw new CurrencyApiQuotaExceededException("provider reported quota exceeded");
         }
     }
 }

--- a/tests/MyAccountingApp.TestUtilities/Fakes/FakeApiQuotaManager.cs
+++ b/tests/MyAccountingApp.TestUtilities/Fakes/FakeApiQuotaManager.cs
@@ -32,7 +32,9 @@ public class FakeApiQuotaManager : IApiQuotaManager
     public Task<ApiUsageQuota> GetQuotaAsync(CancellationToken cancellationToken = default)
     {
         DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow.Date);
-        ApiUsageQuota quota = new("test", today, today.AddMonths(1).AddDays(-1), this.Consumed, 100, 10, DateTime.UtcNow);
+        bool canConsume = this.CanConsumeResult && (!this.MaxConsumptions.HasValue || this.Consumed < this.MaxConsumptions.Value);
+        int requestsUsed = canConsume ? this.Consumed : 100;
+        ApiUsageQuota quota = new("test", today, today.AddMonths(1).AddDays(-1), requestsUsed, 100, 10, DateTime.UtcNow);
         return Task.FromResult(quota);
     }
 

--- a/tests/MyAccountingApp.TestUtilities/Fakes/FakeCurrencyConverter.cs
+++ b/tests/MyAccountingApp.TestUtilities/Fakes/FakeCurrencyConverter.cs
@@ -5,8 +5,19 @@ namespace MyAccountingApp.TestUtilities.Fakes;
 
 public class FakeCurrencyConverter : ICurrencyConverter
 {
+    /// <summary>
+    /// Gets the number of times a single-day fetch was called.
+    /// </summary>
+    public int FetchAllCalls { get; private set; }
+
+    /// <summary>
+    /// Gets the number of times a range fetch was called.
+    /// </summary>
+    public int FetchRangeCalls { get; private set; }
+
     public async Task<Dictionary<string, decimal>> FetchAllRatesAsync(Currencies source, DateTime date)
     {
+        this.FetchAllCalls++;
         await Task.Delay(1); // simulate async
         return new Dictionary<string, decimal>
         {
@@ -22,6 +33,7 @@ public class FakeCurrencyConverter : ICurrencyConverter
         IReadOnlyCollection<Currencies>? targets = null,
         CancellationToken cancellationToken = default)
     {
+        this.FetchRangeCalls++;
         Dictionary<DateOnly, Dictionary<string, decimal>> result = new();
 
         for (DateOnly day = start; day <= end; day = day.AddDays(1))


### PR DESCRIPTION
**P0.1** del pla de millores P0 — [Fonaments](https://github.com/francescgirbau/MyAccountingApp/blob/master/SUMMARY.md)

## Problema
A `CurrencyRateService` es consumia la quota **abans** de la crida HTTP: un timeout/5xx/error de parse ja havia gastat 1 request. Incorrecte amb ExchangeRateHost (límit real) i enganyós amb qualsevol comptador.

## Canvi
Nou flux (opció A2 del pla, sense eixamplar la interfície):
1. `EnsurePeriod`
2. Peek: `GetQuotaAsync().CanConsume(1)` (sense persistir)
3. Cridar API
4. Només en èxit → `TryConsumeAsync(1)` + desar
5. `CurrencyApiQuotaExceeded` → `MarkExhausted` (sense consume espuri)
6. Altres errors → 0 consume, stale + cua de pendents

Aplicat a `GetConversionAsync`, `SyncRangeAsync` i `ProcessPendingAsync`.

## Tests (301 verds, gate StyleCop real 0/0)
- Miss + API OK → Consumed == 1 i desat (existent)
- Miss + error genèric → Consumed == 0, stale fallback (actualitzat: abans assertava 1)
- Miss + `CurrencyApiQuotaExceededException` → Exhausted == true, Consumed == 0 (nou)
- Miss + quota no disponible → 0 crides API, enqueue + stale (reforçat amb comptadors)
- `SyncRangeAsync` fallida de xarxa → 0 consume, propaga (nou)
- `ProcessPendingAsync` fallida de rang → RequestsSpent == 0, Consumed == 0 (nou)

Fakes: `FakeApiQuotaManager.GetQuotaAsync` ara reflecteix disponibilitat; `FakeCurrencyConverter` compta crides.

Smoke test en viu: cache hit, miss fresc i `/api/conversions/quota` OK.