### PR TITLE
refactor: rename CurencyRateService to CurrencyRateService

### DIFF
--- a/src/MyAccountingApp.Api/Program.cs
+++ b/src/MyAccountingApp.Api/Program.cs
@@ -74,7 +74,7 @@ else
 Currencies source = Currencies.EUR;
 JsonPendingConversionRepository pendingRepo = new JsonPendingConversionRepository("data/pending_conversions.json");
 PendingConversionQueue pendingQueue = new PendingConversionQueue(pendingRepo);
-CurencyRateService currencyRateService = new CurencyRateService(repo, api, source, quotaManager, pendingQueue, currencyOptions.MaxTimeseriesDays, currencyOptions.ProviderName);
+CurrencyRateService currencyRateService = new CurrencyRateService(repo, api, source, quotaManager, pendingQueue, currencyOptions.MaxTimeseriesDays, currencyOptions.ProviderName);
 
 builder.Services.AddSingleton<IConversionRepository>(repo);
 if (quotaRepo != null)

--- a/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
+++ b/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
@@ -11,7 +11,7 @@ namespace MyAccountingApp.Application.Services;
 /// Uses a repository for local storage, a quota manager to respect API limits, and
 /// a queue for dates that could not be fetched immediately.
 /// </summary>
-public class CurencyRateService : ICurrencyRateService
+public class CurrencyRateService : ICurrencyRateService
 {
     private readonly IConversionRepository _repository;
     private readonly ICurrencyConverter _api;
@@ -69,7 +69,7 @@ public class CurencyRateService : ICurrencyRateService
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="CurencyRateService"/> class.
+    /// Initializes a new instance of the <see cref="CurrencyRateService"/> class.
     /// </summary>
     /// <param name="repository">Repository for storing currency conversions.</param>
     /// <param name="api">External API for fetching currency rates.</param>
@@ -79,7 +79,7 @@ public class CurencyRateService : ICurrencyRateService
     /// <param name="maxTimeseriesDays">Maximum number of days a single timeseries request may cover.</param>
     /// <param name="sourceProvider">Name of the provider that supplies the rates.</param>
     /// <exception cref="ArgumentException">Thrown if the source currency is not EUR.</exception>
-    public CurencyRateService(
+    public CurrencyRateService(
         IConversionRepository repository,
         ICurrencyConverter api,
         Currencies source,
@@ -105,7 +105,7 @@ public class CurencyRateService : ICurrencyRateService
     /// <exception cref="ArgumentException">Thrown if the base currency is not EUR.</exception>
     private void Validate()
     {
-        string parentType = nameof(CurencyRateService);
+        string parentType = nameof(CurrencyRateService);
 
         if (this._source != Currencies.EUR)
         {

--- a/src/MyAccountingApp.ConsoleApp/Program.cs
+++ b/src/MyAccountingApp.ConsoleApp/Program.cs
@@ -25,7 +25,7 @@ JsonApiQuotaRepository quotaRepo = new JsonApiQuotaRepository("api_quota.json");
 JsonPendingConversionRepository pendingRepo = new JsonPendingConversionRepository("pending_conversions.json");
 ApiQuotaManager quotaManager = new ApiQuotaManager(quotaRepo);
 PendingConversionQueue pendingQueue = new PendingConversionQueue(pendingRepo);
-CurencyRateService service = new CurencyRateService(repo, api, source, quotaManager, pendingQueue);
+CurrencyRateService service = new CurrencyRateService(repo, api, source, quotaManager, pendingQueue);
 
 DateTime targetDate = new DateTime(2024, 12, 1);
 

--- a/tests/MyAccountingApp.Application.Tests/Services/CurrencyConversionServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/CurrencyConversionServiceTests.cs
@@ -20,7 +20,7 @@ public class CurrencyConversionServiceTests
         FakePendingConversionQueue fakeQueue = new();
 
         // Act
-        Action action = () => { new CurencyRateService(fakeRepo, fakeApi, invalidSource, fakeQuota, fakeQueue); };
+        Action action = () => { new CurrencyRateService(fakeRepo, fakeApi, invalidSource, fakeQuota, fakeQueue); };
 
         // Assert
         Assert.Throws<ArgumentException>(() => action());
@@ -36,7 +36,7 @@ public class CurrencyConversionServiceTests
         FakeApiQuotaManager fakeQuota = new();
         FakePendingConversionQueue fakeQueue = new();
 
-        CurencyRateService service = new(fakeRepo, fakeApi, source, fakeQuota, fakeQueue);
+        CurrencyRateService service = new(fakeRepo, fakeApi, source, fakeQuota, fakeQueue);
 
         DateTime date = new DateTime(2023, 12, 1); // This date does not exist
         Currencies targetCurrency = Currencies.USD;
@@ -61,7 +61,7 @@ public class CurrencyConversionServiceTests
         FakeApiQuotaManager fakeQuota = new();
         FakePendingConversionQueue fakeQueue = new();
 
-        CurencyRateService service = new CurencyRateService(fakeRepo, fakeApi, source, fakeQuota, fakeQueue);
+        CurrencyRateService service = new CurrencyRateService(fakeRepo, fakeApi, source, fakeQuota, fakeQueue);
 
         DateTime date = new DateTime(2005, 12, 1); // This date does  exist
         Currencies targetCurrency = Currencies.USD;

--- a/tests/MyAccountingApp.Application.Tests/Services/CurrencyRateServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/CurrencyRateServiceTests.cs
@@ -16,7 +16,7 @@ public class CurrencyRateServiceTests
         FakeConversionRepository repo = new();
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        CurrencyRateService service = CreateService(repo, quota, queue);
 
         // Act
         Conversion result = await service.GetConversionAsync(new DateTime(2005, 12, 1));
@@ -34,7 +34,7 @@ public class CurrencyRateServiceTests
         FakeConversionRepository repo = new();
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        CurrencyRateService service = CreateService(repo, quota, queue);
 
         // Act
         Conversion result = await service.GetConversionAsync(new DateTime(2023, 12, 1));
@@ -54,7 +54,7 @@ public class CurrencyRateServiceTests
         FakeApiQuotaManager quota = new() { CanConsumeResult = false };
         FakePendingConversionQueue queue = new();
         FakeCurrencyConverter converter = new();
-        CurencyRateService service = new(repo, converter, Currencies.EUR, quota, queue);
+        CurrencyRateService service = new(repo, converter, Currencies.EUR, quota, queue);
 
         // Act
         Conversion result = await service.GetConversionAsync(new DateTime(2023, 12, 1));
@@ -76,7 +76,7 @@ public class CurrencyRateServiceTests
         repo.Initialize(Array.Empty<Conversion>());
         FakeApiQuotaManager quota = new() { CanConsumeResult = false };
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        CurrencyRateService service = CreateService(repo, quota, queue);
 
         // Act & Assert
         await Assert.ThrowsAsync<ConversionNotAvailableException>(() => service.GetConversionAsync(new DateTime(2023, 12, 1)));
@@ -90,7 +90,7 @@ public class CurrencyRateServiceTests
         repo.Initialize(Array.Empty<Conversion>());
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        CurrencyRateService service = CreateService(repo, quota, queue);
 
         // Act
         bool result = await service.SyncRangeAsync(new DateOnly(2023, 12, 1), new DateOnly(2023, 12, 5));
@@ -109,7 +109,7 @@ public class CurrencyRateServiceTests
         FakeApiQuotaManager quota = new() { CanConsumeResult = false };
         FakePendingConversionQueue queue = new();
         FakeCurrencyConverter converter = new();
-        CurencyRateService service = new(repo, converter, Currencies.EUR, quota, queue);
+        CurrencyRateService service = new(repo, converter, Currencies.EUR, quota, queue);
 
         // Act
         bool result = await service.SyncRangeAsync(new DateOnly(2023, 12, 1), new DateOnly(2023, 12, 5));
@@ -128,7 +128,7 @@ public class CurrencyRateServiceTests
         repo.Initialize(Array.Empty<Conversion>());
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = new(repo, new FailingCurrencyConverter(), Currencies.EUR, quota, queue);
+        CurrencyRateService service = new(repo, new FailingCurrencyConverter(), Currencies.EUR, quota, queue);
 
         // Act & Assert
         await Assert.ThrowsAsync<HttpRequestException>(() => service.SyncRangeAsync(new DateOnly(2023, 12, 1), new DateOnly(2023, 12, 5)));
@@ -144,7 +144,7 @@ public class CurrencyRateServiceTests
         FakeConversionRepository repo = new();
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = new(repo, new FailingCurrencyConverter(), Currencies.EUR, quota, queue);
+        CurrencyRateService service = new(repo, new FailingCurrencyConverter(), Currencies.EUR, quota, queue);
 
         await queue.EnqueueAsync(new DateOnly(2023, 12, 1));
         await queue.EnqueueAsync(new DateOnly(2023, 12, 2));
@@ -168,7 +168,7 @@ public class CurrencyRateServiceTests
         repo.Initialize(Array.Empty<Conversion>());
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        CurrencyRateService service = CreateService(repo, quota, queue);
 
         for (int day = 1; day <= 5; day++)
         {
@@ -192,7 +192,7 @@ public class CurrencyRateServiceTests
         repo.Initialize(Array.Empty<Conversion>());
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        CurrencyRateService service = CreateService(repo, quota, queue);
 
         await queue.EnqueueAsync(new DateOnly(2023, 12, 1));
         await queue.EnqueueAsync(new DateOnly(2023, 12, 2));
@@ -215,7 +215,7 @@ public class CurrencyRateServiceTests
         repo.Initialize(Array.Empty<Conversion>());
         FakeApiQuotaManager quota = new() { MaxConsumptions = 1 };
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        CurrencyRateService service = CreateService(repo, quota, queue);
 
         await queue.EnqueueAsync(new DateOnly(2023, 12, 1));
         await queue.EnqueueAsync(new DateOnly(2023, 12, 10));
@@ -240,7 +240,7 @@ public class CurrencyRateServiceTests
         repo.Initialize(Array.Empty<Conversion>());
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        CurrencyRateService service = CreateService(repo, quota, queue);
 
         // Act
         bool result = await service.BackfillIfEmptyAsync(3);
@@ -257,7 +257,7 @@ public class CurrencyRateServiceTests
         // Arrange
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(new FakeConversionRepository(), quota, queue);
+        CurrencyRateService service = CreateService(new FakeConversionRepository(), quota, queue);
 
         // Act
         bool result = await service.BackfillIfEmptyAsync(3);
@@ -272,7 +272,7 @@ public class CurrencyRateServiceTests
     {
         // Arrange
         FakeApiQuotaManager quota = new();
-        CurencyRateService service = CreateService(new FakeConversionRepository(), quota, new FakePendingConversionQueue());
+        CurrencyRateService service = CreateService(new FakeConversionRepository(), quota, new FakePendingConversionQueue());
 
         // Act
         ApiUsageQuota result = await service.GetQuotaAsync();
@@ -290,7 +290,7 @@ public class CurrencyRateServiceTests
         FakeConversionRepository repo = new();
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = new(repo, new FailingCurrencyConverter(), Currencies.EUR, quota, queue);
+        CurrencyRateService service = new(repo, new FailingCurrencyConverter(), Currencies.EUR, quota, queue);
 
         // Act
         Conversion result = await service.GetConversionAsync(new DateTime(2023, 12, 1));
@@ -310,7 +310,7 @@ public class CurrencyRateServiceTests
         FakeConversionRepository repo = new();
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = new(repo, new QuotaExceededCurrencyConverter(), Currencies.EUR, quota, queue);
+        CurrencyRateService service = new(repo, new QuotaExceededCurrencyConverter(), Currencies.EUR, quota, queue);
 
         // Act
         Conversion result = await service.GetConversionAsync(new DateTime(2023, 12, 1));
@@ -332,7 +332,7 @@ public class CurrencyRateServiceTests
         repo.Initialize(new[] { new Conversion(seedDate, Currencies.EUR, new Dictionary<Currencies, decimal> { { Currencies.USD, 1.1m } }) });
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        CurrencyRateService service = CreateService(repo, quota, queue);
 
         // Act
         int synced = await service.SyncGapAsync(365);
@@ -351,7 +351,7 @@ public class CurrencyRateServiceTests
         repo.Initialize(Array.Empty<Conversion>());
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        CurrencyRateService service = CreateService(repo, quota, queue);
 
         // Act
         int synced = await service.SyncGapAsync(365);
@@ -370,7 +370,7 @@ public class CurrencyRateServiceTests
         repo.Initialize(new[] { new Conversion(seedDate, Currencies.EUR, new Dictionary<Currencies, decimal> { { Currencies.USD, 1.1m } }) });
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        CurrencyRateService service = CreateService(repo, quota, queue);
 
         // Act
         int synced = await service.SyncGapAsync(365);
@@ -387,7 +387,7 @@ public class CurrencyRateServiceTests
         FakeConversionRepository repo = new();
         FakeApiQuotaManager quota = new();
         FakePendingConversionQueue queue = new();
-        CurencyRateService service = CreateService(repo, quota, queue);
+        CurrencyRateService service = CreateService(repo, quota, queue);
         await queue.EnqueueAsync(new DateOnly(2023, 12, 1));
 
         // Act
@@ -400,12 +400,12 @@ public class CurrencyRateServiceTests
         Assert.Equal(1, status.PendingCount);
     }
 
-    private static CurencyRateService CreateService(
+    private static CurrencyRateService CreateService(
         FakeConversionRepository repo,
         FakeApiQuotaManager quota,
         FakePendingConversionQueue queue)
     {
-        return new CurencyRateService(repo, new FakeCurrencyConverter(), Currencies.EUR, quota, queue);
+        return new CurrencyRateService(repo, new FakeCurrencyConverter(), Currencies.EUR, quota, queue);
     }
 
     private sealed class FailingCurrencyConverter : ICurrencyConverter


### PR DESCRIPTION
**P0.3** del pla de millores P0 — [Fonaments](https://github.com/francescgirbau/MyAccountingApp/blob/master/SUMMARY.md)

## Problema
Typo `CurencyRateService` al nom del tipus, propagat a 5 fitxers font (Api, ConsoleApp, 2 fitxers de tests i la pròpia classe).

## Canvi
Rename pur `CurencyRateService` → `CurrencyRateService` (classe, constructor, XML doc, `nameof` i totes les creacions). El nom de fitxer ja era correcte.

## Verificació
- 0 coincidències de `Curency` a codi font (només artifacts bin/obj/logs)
- Interfície `ICurrencyRateService` intacta
- Build net 0/0 amb gate StyleCop, 301 tests verds