### PR TITLE
refactor: move PendingProcessingResult and ConversionStatus out of Services namespace

### DIFF
--- a/src/MyAccountingApp.Application/DTOs/ConversionStatus.cs
+++ b/src/MyAccountingApp.Application/DTOs/ConversionStatus.cs
@@ -1,4 +1,4 @@
-namespace MyAccountingApp.Application.Services;
+namespace MyAccountingApp.Application.DTOs;
 
 /// <summary>
 /// Describes the current state of the local conversion store.

--- a/src/MyAccountingApp.Application/DTOs/PendingProcessingResult.cs
+++ b/src/MyAccountingApp.Application/DTOs/PendingProcessingResult.cs
@@ -1,4 +1,4 @@
-namespace MyAccountingApp.Application.Services;
+namespace MyAccountingApp.Application.DTOs;
 
 /// <summary>
 /// Summarizes the result of processing the pending conversion queue.

--- a/src/MyAccountingApp.Application/Interfaces/ICurrencyRateService.cs
+++ b/src/MyAccountingApp.Application/Interfaces/ICurrencyRateService.cs
@@ -1,4 +1,4 @@
-﻿using MyAccountingApp.Application.Services;
+﻿using MyAccountingApp.Application.DTOs;
 using MyAccountingApp.Domain.Entities;
 using MyAccountingApp.Domain.Enums;
 

--- a/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
+++ b/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
@@ -1,4 +1,5 @@
-﻿using MyAccountingApp.Application.Interfaces;
+﻿using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Interfaces;
 using MyAccountingApp.Domain.Entities;
 using MyAccountingApp.Domain.Enums;
 using MyAccountingApp.Domain.Exceptions;

--- a/tests/MyAccountingApp.Application.Tests/Services/CurrencyRateServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/CurrencyRateServiceTests.cs
@@ -1,3 +1,4 @@
+using MyAccountingApp.Application.DTOs;
 using MyAccountingApp.Application.Services;
 using MyAccountingApp.Domain.Entities;
 using MyAccountingApp.Domain.Enums;


### PR DESCRIPTION
**P1.1** del pla de millores P1 — Estructura i resiliència.

## Problema
`ICurrencyRateService` (Interfaces) referenciaba `PendingProcessingResult` definit a `Application.Services` — les interfícies no han de dependre del namespace d'implementacions. `ConversionStatus` (creat al #93) tenia exactament el mateix problema.

## Canvi (pur move, zero canvi runtime)
- `Services/PendingProcessingResult.cs` → `DTOs/PendingProcessingResult.cs`
- `Services/ConversionStatus.cs` → `DTOs/ConversionStatus.cs`
- `ICurrencyRateService` ara només usa `Application.DTOs` (cap using de Services)
- Usings actualitzats a `CurrencyRateService` i tests

## Verificació
- Build net 0/0 amb gate StyleCop, 301 tests verds