### PR TITLE
refactor: replace linear FindFallback with GetLatestOnOrBefore

### DIFF
--- a/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
+++ b/src/MyAccountingApp.Application/Services/CurrencyRateService.cs
@@ -347,8 +347,6 @@ public class CurrencyRateService : ICurrencyRateService
     private Conversion? FindFallback(DateOnly day)
     {
         DateTime date = day.ToDateTime(TimeOnly.MinValue);
-        return this._repository.GetAll()
-            .OrderByDescending(c => c.Date)
-            .FirstOrDefault(c => c.Date.Date <= date);
+        return this._repository.GetLatestOnOrBefore(date);
     }
 }

--- a/src/MyAccountingApp.Core/Repositories/CompositeConversionRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/CompositeConversionRepository.cs
@@ -56,6 +56,16 @@ public class CompositeConversionRepository : IConversionRepository
     }
 
     /// <summary>
+    /// Gets the most recent conversion on or before the specified date from the in-memory repository.
+    /// </summary>
+    /// <param name="date">The upper bound for the conversion date.</param>
+    /// <returns>The latest conversion on or before the date; otherwise, null.</returns>
+    public Conversion? GetLatestOnOrBefore(DateTime date)
+    {
+        return this._memoryRepo.GetLatestOnOrBefore(date);
+    }
+
+    /// <summary>
     /// Initializes the repositories with the provided collection of conversions.
     /// <param name="conversions">The list of conversions.</param>
     /// </summary>

--- a/src/MyAccountingApp.Core/Repositories/InMemoryConversionRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/InMemoryConversionRepository.cs
@@ -42,6 +42,16 @@ public class InMemoryConversionRepository : IConversionRepository
     }
 
     /// <summary>
+    /// Gets the most recent conversion on or before the specified date, or null if none exists.
+    /// </summary>
+    /// <param name="date">The upper bound for the conversion date.</param>
+    /// <returns>The latest conversion on or before the date; otherwise, null.</returns>
+    public Conversion? GetLatestOnOrBefore(DateTime date)
+    {
+        return this._conversions.Where(c => c.Date.Date <= date).MaxBy(c => c.Date);
+    }
+
+    /// <summary>
     /// Initializes the repository with a collection of conversions, replacing any existing data.
     /// </summary>
     /// <param name="conversions">The list of conversions.</param>

--- a/src/MyAccountingApp.Core/Repositories/JsonConversionRepository.cs
+++ b/src/MyAccountingApp.Core/Repositories/JsonConversionRepository.cs
@@ -68,6 +68,18 @@ public class JsonConversionRepository : IConversionRepository
         return conversions.FirstOrDefault(c => c.MatchesDate(date));
     }
 
+    /// <summary>
+    /// Gets the most recent conversion on or before the specified date, or null if none exists.
+    /// </summary>
+    /// <param name="date">The upper bound for the conversion date.</param>
+    /// <returns>The latest conversion on or before the date; otherwise, null.</returns>
+    public Conversion? GetLatestOnOrBefore(DateTime date)
+    {
+        List<Conversion> conversions = this.GetAll().ToList();
+
+        return conversions.Where(c => c.Date.Date <= date).MaxBy(c => c.Date);
+    }
+
     public void Initialize(IEnumerable<Conversion> conversions)
     {
         JsonSerializerOptions options = new()

--- a/src/MyAccountingApp.Domain/Interfaces/IConversionRepository.cs
+++ b/src/MyAccountingApp.Domain/Interfaces/IConversionRepository.cs
@@ -21,6 +21,13 @@ public interface IConversionRepository
     public Conversion? GetByDate(DateTime date);
 
     /// <summary>
+    /// Gets the most recent conversion on or before the specified date, or null if none exists.
+    /// </summary>
+    /// <param name="date">The upper bound for the conversion date.</param>
+    /// <returns>The latest conversion on or before the date; otherwise, null.</returns>
+    public Conversion? GetLatestOnOrBefore(DateTime date);
+
+    /// <summary>
     /// Initializes the repository with a collection of conversions.
     /// </summary>
     /// <param name="conversions">The transaction to add.</param>

--- a/tests/MyAccountingApp.Core.Tests/Repositories/InMemoryConversionRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/InMemoryConversionRepositoryTests.cs
@@ -52,4 +52,65 @@ public class InMemoryConversionRepositoryTests
         // Assert
         Assert.Null(result);
     }
+
+    [Fact]
+    public void GetLatestOnOrBefore_ShouldReturnNull_WhenRepositoryEmpty()
+    {
+        // Arrange
+        InMemoryConversionRepository repo = new InMemoryConversionRepository();
+
+        // Act
+        Conversion? result = repo.GetLatestOnOrBefore(DateTime.Today);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetLatestOnOrBefore_ShouldReturnMostRecentConversion_OnOrBeforeDate()
+    {
+        // Arrange
+        InMemoryConversionRepository repo = new InMemoryConversionRepository();
+        repo.AddOrUpdate(new Conversion(new DateTime(2026, 7, 1), Currencies.EUR));
+        repo.AddOrUpdate(new Conversion(new DateTime(2026, 7, 15), Currencies.EUR));
+        repo.AddOrUpdate(new Conversion(new DateTime(2026, 8, 1), Currencies.EUR));
+
+        // Act
+        Conversion? result = repo.GetLatestOnOrBefore(new DateTime(2026, 7, 20));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new DateTime(2026, 7, 15), result.Date);
+    }
+
+    [Fact]
+    public void GetLatestOnOrBefore_ShouldReturnExactDate_WhenConversionExists()
+    {
+        // Arrange
+        InMemoryConversionRepository repo = new InMemoryConversionRepository();
+        repo.AddOrUpdate(new Conversion(new DateTime(2026, 7, 15), Currencies.EUR));
+
+        // Act
+        Conversion? result = repo.GetLatestOnOrBefore(new DateTime(2026, 7, 15));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new DateTime(2026, 7, 15), result.Date);
+    }
+
+    [Fact]
+    public void GetLatestOnOrBefore_ShouldIgnoreConversions_AfterDate()
+    {
+        // Arrange
+        InMemoryConversionRepository repo = new InMemoryConversionRepository();
+        repo.AddOrUpdate(new Conversion(new DateTime(2026, 7, 1), Currencies.EUR));
+        repo.AddOrUpdate(new Conversion(new DateTime(2026, 8, 1), Currencies.EUR));
+
+        // Act
+        Conversion? result = repo.GetLatestOnOrBefore(new DateTime(2026, 7, 31));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new DateTime(2026, 7, 1), result.Date);
+    }
 }

--- a/tests/MyAccountingApp.Core.Tests/Repositories/JsonConversionRepositoryTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Repositories/JsonConversionRepositoryTests.cs
@@ -38,6 +38,43 @@ public class JsonConversionRepositoryTests : IDisposable
     }
 
     [Fact]
+    public void GetLatestOnOrBefore_ShouldReturnMostRecentConversion_OnOrBeforeDate()
+    {
+        // Arrange
+        JsonConversionRepository repo = new JsonConversionRepository(this._tempFile);
+        repo.Initialize(new[]
+        {
+            new Conversion(new DateTime(2026, 7, 1), Currencies.EUR),
+            new Conversion(new DateTime(2026, 7, 15), Currencies.EUR),
+            new Conversion(new DateTime(2026, 8, 1), Currencies.EUR),
+        });
+
+        // Act
+        Conversion? result = repo.GetLatestOnOrBefore(new DateTime(2026, 7, 20));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new DateTime(2026, 7, 15), result.Date);
+    }
+
+    [Fact]
+    public void GetLatestOnOrBefore_ShouldReturnNull_WhenAllConversionsAfterDate()
+    {
+        // Arrange
+        JsonConversionRepository repo = new JsonConversionRepository(this._tempFile);
+        repo.Initialize(new[]
+        {
+            new Conversion(new DateTime(2026, 8, 1), Currencies.EUR),
+        });
+
+        // Act
+        Conversion? result = repo.GetLatestOnOrBefore(new DateTime(2026, 7, 31));
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
     public void GetAll_ShouldReturnEmpty_WhenFileDoesNotExist()
     {
         // Arrange

--- a/tests/MyAccountingApp.TestUtilities/Fakes/FakeConversionRepository.cs
+++ b/tests/MyAccountingApp.TestUtilities/Fakes/FakeConversionRepository.cs
@@ -42,6 +42,11 @@ public class FakeConversionRepository : IConversionRepository
         return this._conversions.FirstOrDefault(c => c.Date.Date == date.Date);
     }
 
+    public Conversion? GetLatestOnOrBefore(DateTime date)
+    {
+        return this._conversions.Where(c => c.Date.Date <= date).MaxBy(c => c.Date);
+    }
+
     public void Initialize(IEnumerable<Conversion> conversions)
     {
         this._conversions.Clear();


### PR DESCRIPTION
## P1.4 — FindFallback eficient

**Path: estructures i resiliència** · Punt 4 del pla de millores.

### Canvis
- `CurrencyRateService.FindFallback` carregava totes les conversions (`GetAll`) i les ordenava descendent per trobar l'última ≤ la data objectiu: ara delega en el mètode nou del repositori
- `IConversionRepository.GetLatestOnOrBefore(DateTime)`: selecció en una passada amb `MaxBy`, sense ordenació
- Implementat a `InMemoryConversionRepository`, `JsonConversionRepository` i `CompositeConversionRepository` (delega a memòria) + `FakeConversionRepository`

### Tests
- 6 tests nous: in-memory (buit, més recent on-or-before, data exacta, ignora posteriors) i JSON (més recent on-or-before, tot posteriors → null)
- **307 tests verds** (80 Application + 35 Domain + 192 Core); build solution Release `-warnaserror` 0/0

### Verificació en viu
- `/api/conversions/status` intacte (91 dies, frankfurter), conversions en memòria OK; 1999-01-01 fetxa de l'API sense errors (registre buit generat pel test i netejat del JSON)