### PR TITLE
refactor: align ConsoleApp with Frankfurter as default provider

### DIFF
--- a/src/MyAccountingApp.ConsoleApp/Program.cs
+++ b/src/MyAccountingApp.ConsoleApp/Program.cs
@@ -1,11 +1,14 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Application.Options;
 using MyAccountingApp.Application.Services;
 using MyAccountingApp.Core.Agents;
 using MyAccountingApp.Core.Repositories;
 using MyAccountingApp.Core.Services;
 using MyAccountingApp.Domain.Entities;
 using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
 using MyAccountingApp.Domain.ValueObjects;
 
 IConfigurationRoot config = new ConfigurationBuilder()
@@ -13,19 +16,41 @@ IConfigurationRoot config = new ConfigurationBuilder()
     .AddEnvironmentVariables()
     .Build();
 
-string currencyApiKey = config["CurrencyApi:ApiKey"]
-    ?? Environment.GetEnvironmentVariable("CURRENCY_API_KEY")
-    ?? throw new InvalidOperationException(
-        "CurrencyApi:ApiKey not found. Set it in appsettings.json or the CURRENCY_API_KEY environment variable.");
+CurrencyApiOptions currencyOptions = config.GetSection("CurrencyApi").Get<CurrencyApiOptions>() ?? new CurrencyApiOptions();
+
+bool useFrankfurter = string.Equals(currencyOptions.Provider, "Frankfurter", StringComparison.OrdinalIgnoreCase);
 
 CompositeConversionRepository repo = new CompositeConversionRepository("conversions.json");
-CurrencyConverter api = new CurrencyConverter(currencyApiKey);
+
+HttpClient frankfurterClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+HttpClient exchangeRateHostClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+
+ICurrencyConverter api;
+IApiQuotaManager quotaManager;
+
+if (useFrankfurter)
+{
+    api = new FrankfurterCurrencyConverter(frankfurterClient, currencyOptions.ExcludeCurrencies, currencyOptions.BaseUrl);
+    quotaManager = new UnlimitedApiQuotaManager(currencyOptions.ProviderName);
+}
+else
+{
+    string currencyApiKey = !string.IsNullOrEmpty(currencyOptions.ApiKey)
+        ? currencyOptions.ApiKey
+        : config["CurrencyApi:ApiKey"]
+            ?? Environment.GetEnvironmentVariable("CURRENCY_API_KEY")
+            ?? throw new InvalidOperationException(
+                "CurrencyApi:ApiKey not found. Set it in appsettings.json or the CURRENCY_API_KEY environment variable.");
+
+    api = new CurrencyConverter(currencyApiKey, exchangeRateHostClient, currencyOptions.ExcludeCurrencies);
+    JsonApiQuotaRepository quotaRepo = new JsonApiQuotaRepository("api_quota.json", currencyOptions.RequestsLimit, currencyOptions.SafetyMargin, currencyOptions.ProviderName);
+    quotaManager = new ApiQuotaManager(quotaRepo);
+}
+
 Currencies source = Currencies.EUR;
-JsonApiQuotaRepository quotaRepo = new JsonApiQuotaRepository("api_quota.json");
 JsonPendingConversionRepository pendingRepo = new JsonPendingConversionRepository("pending_conversions.json");
-ApiQuotaManager quotaManager = new ApiQuotaManager(quotaRepo);
 PendingConversionQueue pendingQueue = new PendingConversionQueue(pendingRepo);
-CurrencyRateService service = new CurrencyRateService(repo, api, source, quotaManager, pendingQueue);
+CurrencyRateService service = new CurrencyRateService(repo, api, source, quotaManager, pendingQueue, currencyOptions.MaxTimeseriesDays, currencyOptions.ProviderName);
 
 DateTime targetDate = new DateTime(2024, 12, 1);
 


### PR DESCRIPTION
## P1.5 — Alinear la ConsoleApp amb Frankfurter

**Path: estructures i resiliència** · Punt 5 (penúltim) del pla de millores.

### Canvis
- `Program.cs`: Frankfurter com a proveïdor per defecte (sense clau), llegint `CurrencyApi` de la config com l'API
- `ExchangeRateHost` segueix disponible darrere del switch `CurrencyApi:Provider` (requereix clau, com abans)
- `HttpClient` explícits amb timeout de 30s (fi a l'`HttpClient` ocult del converter)
- `IApiQuotaManager` adequat al proveïdor: `UnlimitedApiQuotaManager` per Frankfurter, `ApiQuotaManager` + quota JSON per ExchangeRateHost
- `appsettings.json`: secció `CurrencyApi` completa (sense clau)

### Verificació
- Build solution Release `-warnaserror`: 0/0 (la ConsoleApp sí que es compila al sln)
- Execució real amb Frankfurter sense clau: preus Yahoo OK (GRF.MC 10.175 EUR, DGE.L 1790 GBP) i conversió 2024-12-01 feta i guardada (EUR→USD 1.057)
- 307 tests verds (la suite no els toca)