### PR TITLE
test: keep Application.Tests free of JSON repository implementations

### DIFF
--- a/tests/MyAccountingApp.Application.Tests/MyAccountingApp.Application.Tests.csproj
+++ b/tests/MyAccountingApp.Application.Tests/MyAccountingApp.Application.Tests.csproj
@@ -29,7 +29,6 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\MyAccountingApp.Application\MyAccountingApp.Application.csproj" />
-		<ProjectReference Include="..\..\src\MyAccountingApp.Core\MyAccountingApp.Core.csproj" />
 		<ProjectReference Include="..\MyAccountingApp.TestUtilities\MyAccountingApp.TestUtilities.csproj" />
 	</ItemGroup>
 

--- a/tests/MyAccountingApp.Application.Tests/Services/ApiQuotaManagerTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ApiQuotaManagerTests.cs
@@ -1,31 +1,16 @@
 using MyAccountingApp.Application.Services;
-using MyAccountingApp.Core.Persistence;
 using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.TestUtilities.Fakes;
 
 namespace MyAccountingApp.Application.Tests.Services;
 
-public class ApiQuotaManagerTests : IDisposable
+public class ApiQuotaManagerTests
 {
-    private readonly string _tempFile;
-
-    public ApiQuotaManagerTests()
-    {
-        this._tempFile = Path.GetTempFileName();
-    }
-
-    public void Dispose()
-    {
-        if (File.Exists(this._tempFile))
-        {
-            File.Delete(this._tempFile);
-        }
-    }
-
     [Fact]
     public async Task TryConsumeAsync_ReturnsTrue_AndSaves_WhenQuotaAvailable()
     {
         // Arrange
-        JsonApiQuotaRepository repo = new(this._tempFile);
+        FakeApiQuotaRepository repo = new();
         ApiQuotaManager manager = new(repo);
 
         // Act
@@ -40,7 +25,7 @@ public class ApiQuotaManagerTests : IDisposable
     public async Task TryConsumeAsync_ReturnsFalse_WhenQuotaExhausted()
     {
         // Arrange
-        JsonApiQuotaRepository repo = new(this._tempFile);
+        FakeApiQuotaRepository repo = new();
         ApiQuotaManager manager = new(repo);
         ApiUsageQuota exhausted = repo.Get();
         exhausted.MarkExhausted();
@@ -58,7 +43,7 @@ public class ApiQuotaManagerTests : IDisposable
     public async Task MarkExhaustedAsync_SavesQuotaAtLimit()
     {
         // Arrange
-        JsonApiQuotaRepository repo = new(this._tempFile);
+        FakeApiQuotaRepository repo = new();
         ApiQuotaManager manager = new(repo);
 
         // Act
@@ -73,7 +58,7 @@ public class ApiQuotaManagerTests : IDisposable
     public async Task GetQuotaAsync_ReturnsCurrentQuota()
     {
         // Arrange
-        JsonApiQuotaRepository repo = new(this._tempFile);
+        FakeApiQuotaRepository repo = new();
         ApiQuotaManager manager = new(repo);
 
         // Act

--- a/tests/MyAccountingApp.Application.Tests/Services/PendingConversionQueueTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/PendingConversionQueueTests.cs
@@ -1,32 +1,17 @@
 using MyAccountingApp.Application.Services;
-using MyAccountingApp.Core.Persistence;
 using MyAccountingApp.Domain.Entities;
 using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.TestUtilities.Fakes;
 
 namespace MyAccountingApp.Application.Tests.Services;
 
-public class PendingConversionQueueTests : IDisposable
+public class PendingConversionQueueTests
 {
-    private readonly string _tempFile;
-
-    public PendingConversionQueueTests()
-    {
-        this._tempFile = Path.GetTempFileName();
-    }
-
-    public void Dispose()
-    {
-        if (File.Exists(this._tempFile))
-        {
-            File.Delete(this._tempFile);
-        }
-    }
-
     [Fact]
     public async Task EnqueueAsync_AddsRequest_WhenNewDate()
     {
         // Arrange
-        JsonPendingConversionRepository repo = new(this._tempFile);
+        FakePendingConversionRepository repo = new();
         PendingConversionQueue queue = new(repo);
 
         // Act
@@ -43,7 +28,7 @@ public class PendingConversionQueueTests : IDisposable
     public async Task EnqueueAsync_DoesNotDuplicate_WhenSameDate()
     {
         // Arrange
-        JsonPendingConversionRepository repo = new(this._tempFile);
+        FakePendingConversionRepository repo = new();
         PendingConversionQueue queue = new(repo);
 
         // Act
@@ -59,7 +44,7 @@ public class PendingConversionQueueTests : IDisposable
     public async Task MarkProcessedAsync_RemovesFromPending()
     {
         // Arrange
-        JsonPendingConversionRepository repo = new(this._tempFile);
+        FakePendingConversionRepository repo = new();
         PendingConversionQueue queue = new(repo);
         await queue.EnqueueAsync(new DateOnly(2026, 7, 1));
 
@@ -75,7 +60,7 @@ public class PendingConversionQueueTests : IDisposable
     public async Task MarkFailedAsync_RecordsError()
     {
         // Arrange
-        JsonPendingConversionRepository repo = new(this._tempFile);
+        FakePendingConversionRepository repo = new();
         PendingConversionQueue queue = new(repo);
         await queue.EnqueueAsync(new DateOnly(2026, 7, 1));
 

--- a/tests/MyAccountingApp.TestUtilities/Fakes/FakeApiQuotaRepository.cs
+++ b/tests/MyAccountingApp.TestUtilities/Fakes/FakeApiQuotaRepository.cs
@@ -1,0 +1,57 @@
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Interfaces;
+
+namespace MyAccountingApp.TestUtilities.Fakes;
+
+/// <summary>
+/// In-memory fake of the currency API quota repository for testing.
+/// </summary>
+public class FakeApiQuotaRepository : IApiQuotaRepository
+{
+    private ApiUsageQuota? _quota;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FakeApiQuotaRepository"/> class.
+    /// </summary>
+    /// <param name="requestsLimit">The monthly request limit.</param>
+    /// <param name="safetyMargin">The number of requests reserved as a safety margin.</param>
+    /// <param name="providerName">The name of the external provider.</param>
+    public FakeApiQuotaRepository(int requestsLimit = 100, int safetyMargin = 10, string providerName = "exchangerate.host")
+    {
+        this.RequestsLimit = requestsLimit;
+        this.SafetyMargin = safetyMargin;
+        this.ProviderName = providerName;
+    }
+
+    private int RequestsLimit { get; }
+
+    private int SafetyMargin { get; }
+
+    private string ProviderName { get; }
+
+    /// <summary>
+    /// Gets the current quota, creating a default quota for the current month if none is stored.
+    /// </summary>
+    /// <returns>The current quota.</returns>
+    public ApiUsageQuota Get()
+    {
+        return this._quota ?? this.CreateDefault();
+    }
+
+    /// <summary>
+    /// Saves the quota to in-memory storage.
+    /// </summary>
+    /// <param name="quota">The quota to save.</param>
+    public void Save(ApiUsageQuota quota)
+    {
+        this._quota = quota;
+    }
+
+    private ApiUsageQuota CreateDefault()
+    {
+        DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        DateOnly periodStart = new(today.Year, today.Month, 1);
+        DateOnly periodEnd = periodStart.AddMonths(1).AddDays(-1);
+        return new ApiUsageQuota(this.ProviderName, periodStart, periodEnd, 0, this.RequestsLimit, this.SafetyMargin, DateTime.UtcNow);
+    }
+}

--- a/tests/MyAccountingApp.TestUtilities/Fakes/FakePendingConversionRepository.cs
+++ b/tests/MyAccountingApp.TestUtilities/Fakes/FakePendingConversionRepository.cs
@@ -1,0 +1,48 @@
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Interfaces;
+
+namespace MyAccountingApp.TestUtilities.Fakes;
+
+/// <summary>
+/// In-memory fake of the pending conversion repository for testing.
+/// </summary>
+public class FakePendingConversionRepository : IPendingConversionRepository
+{
+    private readonly List<PendingConversionRequest> _requests = new();
+
+    /// <summary>
+    /// Gets all queued conversion requests.
+    /// </summary>
+    /// <returns>All queued conversion requests.</returns>
+    public IEnumerable<PendingConversionRequest> GetAll()
+    {
+        return this._requests;
+    }
+
+    /// <summary>
+    /// Adds a new request or updates an existing request.
+    /// </summary>
+    /// <param name="request">The request to add or update.</param>
+    public void AddOrUpdate(PendingConversionRequest request)
+    {
+        int index = this._requests.FindIndex(r => r.Date == request.Date);
+        if (index >= 0)
+        {
+            this._requests[index] = request;
+        }
+        else
+        {
+            this._requests.Add(request);
+        }
+    }
+
+    /// <summary>
+    /// Replaces all stored requests with the given collection.
+    /// </summary>
+    /// <param name="requests">The requests to store.</param>
+    public void Initialize(IEnumerable<PendingConversionRequest> requests)
+    {
+        this._requests.Clear();
+        this._requests.AddRange(requests);
+    }
+}


### PR DESCRIPTION
## P2.2 — Puresa de tests d'Application

Pla P2 (secció P2.2). `ApiQuotaManagerTests` i `PendingConversionQueueTests` usaven repos JSON reals de Core amb I/O a fitxer temporal. Ara:

- Nous fakes in-memory a TestUtilities: `FakeApiQuotaRepository`, `FakePendingConversionRepository` (mirallen el comportament dels Json*: default quota mensual, limits, etc.)
- Tests reescrits sobre els fakes; scaffolding `IDisposable`/`_tempFile` eliminat
- Bonus: `MyAccountingApp.Application.Tests.csproj` ja no referencia `MyAccountingApp.Core` (cap .cs l'usava)
- Els round-trip de serialització JSON continuen a Core.Tests

Suite completa: 339/339 verds.