### PR TITLE
feat(import): support Cobas investment fund CSV as asset transactions

### DIFF
--- a/src/MyAccountingApp.Api/DependencyInjection.cs
+++ b/src/MyAccountingApp.Api/DependencyInjection.cs
@@ -7,6 +7,7 @@ using MyAccountingApp.Application.Services;
 using MyAccountingApp.Core.Http.Currency;
 using MyAccountingApp.Core.Http.Market;
 using MyAccountingApp.Core.Imports.AbnAmro;
+using MyAccountingApp.Core.Imports.Cobas;
 using MyAccountingApp.Core.Imports.Common;
 using MyAccountingApp.Core.Imports.Degiro;
 using MyAccountingApp.Core.Imports.IBKR;
@@ -148,6 +149,7 @@ public static class DependencyInjection
         builder.Services.AddSingleton<DegiroTransactionImportService>();
         builder.Services.AddSingleton<RevolutImportService>();
         builder.Services.AddSingleton<AbnAmroImportService>();
+        builder.Services.AddSingleton<CobasImportService>();
         builder.Services.AddSingleton<IBrokerImportService, BrokerImportDispatcher>();
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen();

--- a/src/MyAccountingApp.Core/Imports/Cobas/CobasImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/Cobas/CobasImportService.cs
@@ -1,0 +1,180 @@
+namespace MyAccountingApp.Core.Imports.Cobas;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Imports.Common;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+public class CobasImportService : IBrokerImportService
+{
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        string[] lines = await File.ReadAllLinesAsync(filePath, cancellationToken);
+        List<AssetTransaction> assetTransactions = new();
+
+        foreach (string line in lines.Skip(1))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            try
+            {
+                List<string> fields = BankCsvImportService.ParseCsvLine(line);
+                if (fields.Count < 8)
+                {
+                    continue;
+                }
+
+                if (!string.Equals(fields[4], "Finalizada", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                AssetTransactionType? type = MapType(fields[3]);
+                if (type is null)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(fields[^1]))
+                {
+                    continue;
+                }
+
+                DateTime date = ParseDate(fields[2]);
+                decimal amount = ParseEuropeanDecimal(JoinAmountFields(fields));
+                decimal quantity = ParseEuropeanDecimal(fields[^1]);
+
+                if (amount <= 0 || quantity <= 0)
+                {
+                    continue;
+                }
+
+                string producto = fields[1];
+                string symbol = BuildSymbol(producto);
+                TransactionCategory category = type == AssetTransactionType.Buy ? TransactionCategory.EXPENSE : TransactionCategory.INCOME;
+
+                Money money = new Money(amount, "EUR");
+                Transaction transaction = new Transaction(date, producto, money, category);
+                AssetTransaction assetTx = new AssetTransaction(transaction, symbol, quantity, type.Value);
+                assetTransactions.Add(assetTx);
+            }
+            catch
+            {
+            }
+        }
+
+        return (Array.Empty<Transaction>(), assetTransactions, Enumerable.Empty<OptionTransaction>());
+    }
+
+    public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Enumerable.Empty<AssetTransaction>());
+    }
+
+    private static AssetTransactionType? MapType(string tipo)
+    {
+        if (tipo.Contains("Suscripción", StringComparison.OrdinalIgnoreCase)
+            || tipo.Contains("Traspaso de entrada", StringComparison.OrdinalIgnoreCase))
+        {
+            return AssetTransactionType.Buy;
+        }
+
+        if (tipo.Contains("Reembolso", StringComparison.OrdinalIgnoreCase)
+            || tipo.Contains("Traspaso de salida", StringComparison.OrdinalIgnoreCase))
+        {
+            return AssetTransactionType.Sell;
+        }
+
+        return null;
+    }
+
+    private static DateTime ParseDate(string value)
+    {
+        if (DateTime.TryParseExact(value, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date))
+        {
+            return date;
+        }
+
+        return DateTime.Parse(value, CultureInfo.InvariantCulture);
+    }
+
+    private static string JoinAmountFields(IReadOnlyList<string> fields)
+    {
+        // Importe may be split by an unquoted comma (e.g. "2.560,32 € (Bruto)");
+        // Valor liquidativo and Participaciones are always the last two fields.
+        return string.Join(",", fields.Skip(5).Take(fields.Count - 7));
+    }
+
+    private static decimal ParseEuropeanDecimal(string value)
+    {
+        StringBuilder digits = new(value.Length);
+        foreach (char c in value)
+        {
+            if (char.IsDigit(c) || c == '.' || c == ',')
+            {
+                digits.Append(c);
+            }
+        }
+
+        string cleaned = digits.ToString();
+        int lastDot = cleaned.LastIndexOf('.');
+        int lastComma = cleaned.LastIndexOf(',');
+        if (lastComma > lastDot)
+        {
+            cleaned = cleaned.Replace(".", string.Empty).Replace(",", ".");
+        }
+        else if (lastDot > lastComma)
+        {
+            cleaned = cleaned.Replace(",", string.Empty);
+        }
+
+        return decimal.Parse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture);
+    }
+
+    private static string BuildSymbol(string producto)
+    {
+        string normalized = RemoveDiacritics(producto).ToUpperInvariant().Trim();
+        string clasePart = string.Empty;
+        int claseIdx = normalized.IndexOf(" CLASE ", StringComparison.Ordinal);
+        if (claseIdx >= 0)
+        {
+            clasePart = "_" + normalized[(claseIdx + 7) ..].Trim();
+            normalized = normalized[..claseIdx].Trim();
+        }
+
+        normalized = normalized.Replace(",", string.Empty).Replace(" FI", string.Empty).Trim();
+        return normalized.Replace(" ", "_") + clasePart;
+    }
+
+    private static string RemoveDiacritics(string value)
+    {
+        string normalized = value.Normalize(NormalizationForm.FormD);
+        StringBuilder builder = new();
+        foreach (char c in normalized)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
+            {
+                builder.Append(c);
+            }
+        }
+
+        return builder.ToString().Normalize(NormalizationForm.FormC);
+    }
+}

--- a/src/MyAccountingApp.Core/Imports/Common/BrokerImportDispatcher.cs
+++ b/src/MyAccountingApp.Core/Imports/Common/BrokerImportDispatcher.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MyAccountingApp.Core.Imports.AbnAmro;
+using MyAccountingApp.Core.Imports.Cobas;
 using MyAccountingApp.Core.Imports.Degiro;
 using MyAccountingApp.Core.Imports.IBKR;
 using MyAccountingApp.Core.Imports.Revolut;
@@ -19,6 +20,7 @@ public class BrokerImportDispatcher : IBrokerImportService
     private const string DegiroTransactionCsvHeaderPrefix = "Fecha,Hora,Producto,ISIN,Bolsa";
     private const string RevolutCsvHeaderPrefix = "Type,Product,Started Date";
     private const string AbnAmroCsvHeaderPrefix = "accountNumber,mutationcode";
+    private const string CobasCsvHeaderPrefix = "Operacion,Producto,Fecha";
 
     private readonly InteractiveBrokersImportService ibkrService;
     private readonly BankCsvImportService bankService;
@@ -28,6 +30,7 @@ public class BrokerImportDispatcher : IBrokerImportService
     private readonly IBKRFlexQueryImportService flexQueryService;
     private readonly RevolutImportService revolutService;
     private readonly AbnAmroImportService abnAmroService;
+    private readonly CobasImportService cobasService;
 
     public BrokerImportDispatcher(
         InteractiveBrokersImportService ibkrService,
@@ -37,7 +40,8 @@ public class BrokerImportDispatcher : IBrokerImportService
         DegiroTransactionImportService degiroTransactionService,
         IBKRFlexQueryImportService flexQueryService,
         RevolutImportService revolutService,
-        AbnAmroImportService abnAmroService)
+        AbnAmroImportService abnAmroService,
+        CobasImportService cobasService)
     {
         this.ibkrService = ibkrService ?? throw new ArgumentNullException(nameof(ibkrService));
         this.bankService = bankService ?? throw new ArgumentNullException(nameof(bankService));
@@ -47,6 +51,7 @@ public class BrokerImportDispatcher : IBrokerImportService
         this.flexQueryService = flexQueryService ?? throw new ArgumentNullException(nameof(flexQueryService));
         this.revolutService = revolutService ?? throw new ArgumentNullException(nameof(revolutService));
         this.abnAmroService = abnAmroService ?? throw new ArgumentNullException(nameof(abnAmroService));
+        this.cobasService = cobasService ?? throw new ArgumentNullException(nameof(cobasService));
     }
 
     public Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
@@ -134,6 +139,11 @@ public class BrokerImportDispatcher : IBrokerImportService
             if (header.StartsWith(DegiroCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 return this.degiroService;
+            }
+
+            if (header.StartsWith(CobasCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return this.cobasService;
             }
         }
 

--- a/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
@@ -3,10 +3,12 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using MyAccountingApp.Core.Imports.AbnAmro;
+using MyAccountingApp.Core.Imports.Cobas;
 using MyAccountingApp.Core.Imports.Common;
 using MyAccountingApp.Core.Imports.Degiro;
 using MyAccountingApp.Core.Imports.IBKR;
 using MyAccountingApp.Core.Imports.Revolut;
+using MyAccountingApp.Domain.Entities;
 using Xunit;
 
 public class BrokerImportDispatcherTests
@@ -213,6 +215,29 @@ public class BrokerImportDispatcherTests
     }
 
     [Fact]
+    public async Task ParseAllAsync_CobasHeader_UsesCobasService()
+    {
+        string csv = "Operacion,Producto,Fecha,Tipo,Estado,Importe,Valor liquidativo,Participaciones\nO-BEC1579,Cobas Internacional FI Clase D,11/11/2025,Suscripción,Finalizada,120,00 € (Bruto),238.733905€,0.502652";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            AssetTransaction asset = Assert.Single(assets);
+            Assert.Equal("COBAS_INTERNACIONAL_D", asset.Symbol);
+            Assert.Equal(0.502652m, asset.Quantity);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
     public async Task ParseCorporateActionsAsync_DelegatesToIbkr()
     {
         string file = Path.GetTempFileName();
@@ -234,7 +259,7 @@ public class BrokerImportDispatcherTests
     {
         InteractiveBrokersImportService ibkr = new(Parser, new FakeLogger<InteractiveBrokersImportService>());
         IBKRFlexQueryImportService flexQuery = new(Array.Empty<IIBKRStatementAgent>());
-        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService(), new DegiroTransactionImportService(), flexQuery, new RevolutImportService(), new AbnAmroImportService());
+        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService(), new DegiroTransactionImportService(), flexQuery, new RevolutImportService(), new AbnAmroImportService(), new CobasImportService());
     }
 }
 

--- a/tests/MyAccountingApp.Core.Tests/Services/CobasImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/CobasImportServiceTests.cs
@@ -1,0 +1,196 @@
+namespace MyAccountingApp.Core.Tests.Services;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Imports.Cobas;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using Xunit;
+
+public class CobasImportServiceTests
+{
+    private const string Header = "Operacion,Producto,Fecha,Tipo,Estado,Importe,Valor liquidativo,Participaciones";
+
+    [Fact]
+    public async Task ParseAllAsync_Suscripcion_CreatesBuyAssetTransaction()
+    {
+        string csv = $"{Header}\nO-BEC1579,Cobas Internacional FI Clase D,11/11/2025,Suscripción,Finalizada,120,00 € (Bruto),238.733905€,0.502652";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            CobasImportService service = new();
+
+            var (txs, assets, options) = await service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.Empty(options);
+            AssetTransaction asset = Assert.Single(assets);
+            Assert.Equal(AssetTransactionType.Buy, asset.Type);
+            Assert.Equal(TransactionCategory.EXPENSE, asset.Transaction.Category);
+            Assert.Equal("COBAS_INTERNACIONAL_D", asset.Symbol);
+            Assert.Equal(0.502652m, asset.Quantity);
+            Assert.Equal(120.00m, asset.Transaction.Money.Amount);
+            Assert.Equal("EUR", asset.Transaction.Money.Currency);
+            Assert.Equal(new DateTime(2025, 11, 11), asset.Transaction.Date);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_TraspasoDeSalida_CreatesSellAssetTransaction()
+    {
+        string csv = $"{Header}\nO-BEG2466,Cobas Internacional FI Clase D,23/02/2026,Traspaso de salida,Finalizada,2.560,32 € (Bruto),291.910724€,8.770893";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            CobasImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            AssetTransaction asset = Assert.Single(assets);
+            Assert.Equal(AssetTransactionType.Sell, asset.Type);
+            Assert.Equal(TransactionCategory.INCOME, asset.Transaction.Category);
+            Assert.Equal(8.770893m, asset.Quantity);
+            Assert.Equal(2560.32m, asset.Transaction.Money.Amount);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_TraspasoDeEntrada_CreatesBuyAssetTransaction()
+    {
+        string csv = $"{Header}\nO-BEG2447,Cobas Internacional FI Clase C,23/02/2026,Traspaso de entrada,Finalizada,2.560,32 € (Bruto),189.351849€,13.521495";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            CobasImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            AssetTransaction asset = Assert.Single(assets);
+            Assert.Equal(AssetTransactionType.Buy, asset.Type);
+            Assert.Equal("COBAS_INTERNACIONAL_C", asset.Symbol);
+            Assert.Equal(13.521495m, asset.Quantity);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_AnuladaRow_Skipped()
+    {
+        string csv = $"{Header}\nO-BAI0957,Cobas Selección FI Clase D,21/02/2023,Suscripción,Anulada,2.500,00 € (Bruto),,\nO-BAI1565,Cobas Selección FI Clase D,21/02/2023,Suscripción,Finalizada,2.500,00 € (Bruto),156.965535€,15.927063";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            CobasImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            AssetTransaction asset = Assert.Single(assets);
+            Assert.Equal("COBAS_SELECCION_D", asset.Symbol);
+            Assert.Equal(15.927063m, asset.Quantity);
+            Assert.Equal(2500.00m, asset.Transaction.Money.Amount);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_EmptyParticipaciones_Skipped()
+    {
+        string csv = $"{Header}\nO-X,Cobas Selección FI Clase D,01/01/2024,Suscripción,Finalizada,100,00 € (Bruto),150.5€,";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            CobasImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_UnknownTipo_Skipped()
+    {
+        string csv = $"{Header}\nO-X,Cobas Selección FI Clase D,01/01/2024,Compra,Finalizada,100,00 € (Bruto),150.5€,0.66";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            CobasImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_Symbol_NormalizedWithoutDiacritics()
+    {
+        string csv = $"{Header}\nO-BAL7805,Cobas Selección FI Clase C,12/12/2023,Suscripción,Finalizada,250,00 € (Bruto),153.864741€,1.624804";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            CobasImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            Assert.Equal("COBAS_SELECCION_C", Assert.Single(assets).Symbol);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_Reembolso_CreatesSellAssetTransaction()
+    {
+        string csv = $"{Header}\nO-X,Cobas Internacional FI Clase C,01/01/2024,Reembolso,Finalizada,500,00 € (Bruto),200.5€,2.493765";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            CobasImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            AssetTransaction asset = Assert.Single(assets);
+            Assert.Equal(AssetTransactionType.Sell, asset.Type);
+            Assert.Equal(2.493765m, asset.Quantity);
+            Assert.Equal(500.00m, asset.Transaction.Money.Amount);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+}


### PR DESCRIPTION
## Nova feature: import CSV de fons d'inversió Cobas

El fitxer `import/historical/cobas.csv` (estats de fons Cobas) ara es detecta i es converteix en `AssetTransaction`s.

### Mapeig del CSV
| Columna | Ús |
|---|---|
| `Producto` | Descripció de la transacció; símbol normalitzat sense diacrítics (p.e. `Cobas Internacional FI Clase D` → `COBAS_INTERNACIONAL_D`) |
| `Fecha` (dd/MM/yyyy) | Data de la transacció |
| `Tipo` | `Suscripción` / `Traspaso de entrada` → **Buy**; `Reembolso` / `Traspaso de salida` → **Sell** |
| `Estado` | Només `Finalizada`; les `Anulada` es salten |
| `Importe` | Import brut (EUR), decimals europeus (`2.560,32 € (Bruto)` → 2560.32) |
| `Participaciones` | Quantitat (fraccional, p.e. `0.502652`) |

### Implementació
- `src/MyAccountingApp.Core/Imports/Cobas/CobasImportService.cs` — nou servei `IBrokerImportService` seguint el patró de `DegiroTransactionImportService`
- `BrokerImportDispatcher` — nova regla: header `Operacion,Producto,Fecha` → `CobasImportService` (abans queia al fallback IBKR i no produïa res)
- `DependencyInjection.cs` — registre del servei
- Tests: 8 casos a `CobasImportServiceTests.cs` + 1 de dispatch; validat també amb el fitxer real (37 files → 36 transaccions, 1 Anulada saltada, 34 buys / 2 sells)

### Nota
El fons queda modelat com a `AssetTransaction` normal (símbol per classe C/D), així que l'engine FIFO, portfolio i summaries el tracten com qualsevol altre actiu. El NAV (`Valor liquidativo`) no es guarda (no hi ha camp); el cost unitari es deriva de Importe/Participaciones.