### PR TITLE
fix(di): register FxRetryHandler so currency HttpClients can be created

### DIFF
--- a/src/MyAccountingApp.Api/DependencyInjection.cs
+++ b/src/MyAccountingApp.Api/DependencyInjection.cs
@@ -51,6 +51,7 @@ public static class DependencyInjection
         {
             client.Timeout = TimeSpan.FromSeconds(30);
         }).AddHttpMessageHandler<FxRetryHandler>();
+        builder.Services.AddTransient<FxRetryHandler>();
 
         IApiQuotaManager quotaManager;
         JsonApiQuotaRepository? quotaRepo = null;

--- a/tests/MyAccountingApp.Api.Tests/DependencyInjectionTests.cs
+++ b/tests/MyAccountingApp.Api.Tests/DependencyInjectionTests.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+using MyAccountingApp.Domain.Interfaces;
+using Xunit;
+
+namespace MyAccountingApp.Api.Tests;
+
+public class DependencyInjectionTests
+{
+    [Fact]
+    public void ResolveCurrencyConverter_CreatesHttpClientWithRegisteredRetryHandler()
+    {
+        using ApiWebApplicationFactory factory = new();
+
+        ICurrencyConverter converter = factory.Services.GetRequiredService<ICurrencyConverter>();
+
+        Assert.NotNull(converter);
+    }
+}


### PR DESCRIPTION
## Fix: crash a l'arrencada del contenidor

`docker compose up` petava amb:

```
System.InvalidOperationException: No service for type 'MyAccountingApp.Api.Http.FxRetryHandler' has been registered.
```

### Causa arrel
`AddHttpMessageHandler<T>()` (línies 49/53 de `DependencyInjection.cs`) resol `T` des del DI amb `GetRequiredService`, però `FxRetryHandler` no estava registrat. L'excepció només es disparava quan es creava el client HTTP real (lazy, via `CreateClient`), que només passa quan l'hosted service `CurrencyStartupSync` arrenca amb el DI real. Els tests no ho detectaven perquè `ApiWebApplicationFactory` substitueix `ICurrencyRateService` per un fake i mai resol el client real.

### Fix
- `builder.Services.AddTransient<FxRetryHandler>();` al DI
- **Test de regressió**: `DependencyInjectionTests.ResolveCurrencyConverter_CreatesHttpClientWithRegisteredRetryHandler` — resol `ICurrencyConverter` real des del contenidor, forçant la creació del client `Frankfurter` i la resolució del handler (sense crides de xarxa: només crea el client)

Verificat: build 0/0 `-warnaserror`, **353 tests verds**, i `dotnet run` arrenca l'API i completa el startup sync sense errors.