### PR TITLE
feat(import): support MyInvestor account and fund CSV files

### DIFF
--- a/src/MyAccountingApp.Api/DependencyInjection.cs
+++ b/src/MyAccountingApp.Api/DependencyInjection.cs
@@ -11,6 +11,7 @@ using MyAccountingApp.Core.Imports.Cobas;
 using MyAccountingApp.Core.Imports.Common;
 using MyAccountingApp.Core.Imports.Degiro;
 using MyAccountingApp.Core.Imports.IBKR;
+using MyAccountingApp.Core.Imports.MyInvestor;
 using MyAccountingApp.Core.Imports.Revolut;
 using MyAccountingApp.Core.Persistence;
 using MyAccountingApp.Domain.Enums;
@@ -151,6 +152,8 @@ public static class DependencyInjection
         builder.Services.AddSingleton<RevolutImportService>();
         builder.Services.AddSingleton<AbnAmroImportService>();
         builder.Services.AddSingleton<CobasImportService>();
+        builder.Services.AddSingleton<MyInvestorAccountImportService>();
+        builder.Services.AddSingleton<MyInvestorFundImportService>();
         builder.Services.AddSingleton<IBrokerImportService, BrokerImportDispatcher>();
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen();

--- a/src/MyAccountingApp.Core/Imports/Common/BankCsvImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/Common/BankCsvImportService.cs
@@ -32,7 +32,7 @@ public class BankCsvImportService : IBrokerImportService
         return IsTransfer(description) ? TransactionCategory.TRANSFER : baseCategory;
     }
 
-    public static List<string> ParseCsvLine(string line)
+    public static List<string> ParseCsvLine(string line, char separator = ',')
     {
         List<string> fields = new List<string>();
         bool inQuotes = false;
@@ -46,7 +46,7 @@ public class BankCsvImportService : IBrokerImportService
             {
                 inQuotes = !inQuotes;
             }
-            else if (c == ',' && !inQuotes)
+            else if (c == separator && !inQuotes)
             {
                 fields.Add(current.ToString().Trim());
                 current.Clear();
@@ -59,6 +59,48 @@ public class BankCsvImportService : IBrokerImportService
 
         fields.Add(current.ToString().Trim());
         return fields;
+    }
+
+    public static decimal ParseEuropeanDecimal(string value)
+    {
+        string trimmed = value.Trim();
+        bool negative = trimmed.StartsWith('-');
+
+        StringBuilder digits = new StringBuilder(trimmed.Length);
+        foreach (char c in trimmed)
+        {
+            if (char.IsDigit(c) || c == '.' || c == ',')
+            {
+                digits.Append(c);
+            }
+        }
+
+        string cleaned = digits.ToString();
+        int lastDot = cleaned.LastIndexOf('.');
+        int lastComma = cleaned.LastIndexOf(',');
+        if (lastComma > lastDot)
+        {
+            cleaned = cleaned.Replace(".", string.Empty).Replace(",", ".");
+        }
+        else if (lastDot > lastComma)
+        {
+            string trailing = cleaned[(lastDot + 1) ..];
+            if (trailing.Length == 3 && lastDot > 0)
+            {
+                cleaned = cleaned.Replace(".", string.Empty);
+            }
+            else
+            {
+                cleaned = cleaned.Replace(",", string.Empty);
+            }
+        }
+
+        if (negative)
+        {
+            cleaned = "-" + cleaned;
+        }
+
+        return decimal.Parse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture);
     }
 
     public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(

--- a/src/MyAccountingApp.Core/Imports/Common/BrokerImportDispatcher.cs
+++ b/src/MyAccountingApp.Core/Imports/Common/BrokerImportDispatcher.cs
@@ -9,6 +9,7 @@ using MyAccountingApp.Core.Imports.AbnAmro;
 using MyAccountingApp.Core.Imports.Cobas;
 using MyAccountingApp.Core.Imports.Degiro;
 using MyAccountingApp.Core.Imports.IBKR;
+using MyAccountingApp.Core.Imports.MyInvestor;
 using MyAccountingApp.Core.Imports.Revolut;
 using MyAccountingApp.Domain.Entities;
 using MyAccountingApp.Domain.Interfaces;
@@ -21,6 +22,8 @@ public class BrokerImportDispatcher : IBrokerImportService
     private const string RevolutCsvHeaderPrefix = "Type,Product,Started Date";
     private const string AbnAmroCsvHeaderPrefix = "accountNumber,mutationcode";
     private const string CobasCsvHeaderPrefix = "Operacion,Producto,Fecha";
+    private const string MyInvestorAccountCsvHeaderPrefix = "Fecha de operación;Fecha de valor;Concepto";
+    private const string MyInvestorFundCsvHeaderPrefix = "Fecha de la orden;ISIN;Importe estimado";
 
     private readonly InteractiveBrokersImportService ibkrService;
     private readonly BankCsvImportService bankService;
@@ -31,6 +34,8 @@ public class BrokerImportDispatcher : IBrokerImportService
     private readonly RevolutImportService revolutService;
     private readonly AbnAmroImportService abnAmroService;
     private readonly CobasImportService cobasService;
+    private readonly MyInvestorAccountImportService myInvestorAccountService;
+    private readonly MyInvestorFundImportService myInvestorFundService;
 
     public BrokerImportDispatcher(
         InteractiveBrokersImportService ibkrService,
@@ -41,7 +46,9 @@ public class BrokerImportDispatcher : IBrokerImportService
         IBKRFlexQueryImportService flexQueryService,
         RevolutImportService revolutService,
         AbnAmroImportService abnAmroService,
-        CobasImportService cobasService)
+        CobasImportService cobasService,
+        MyInvestorAccountImportService myInvestorAccountService,
+        MyInvestorFundImportService myInvestorFundService)
     {
         this.ibkrService = ibkrService ?? throw new ArgumentNullException(nameof(ibkrService));
         this.bankService = bankService ?? throw new ArgumentNullException(nameof(bankService));
@@ -52,6 +59,8 @@ public class BrokerImportDispatcher : IBrokerImportService
         this.revolutService = revolutService ?? throw new ArgumentNullException(nameof(revolutService));
         this.abnAmroService = abnAmroService ?? throw new ArgumentNullException(nameof(abnAmroService));
         this.cobasService = cobasService ?? throw new ArgumentNullException(nameof(cobasService));
+        this.myInvestorAccountService = myInvestorAccountService ?? throw new ArgumentNullException(nameof(myInvestorAccountService));
+        this.myInvestorFundService = myInvestorFundService ?? throw new ArgumentNullException(nameof(myInvestorFundService));
     }
 
     public Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
@@ -144,6 +153,16 @@ public class BrokerImportDispatcher : IBrokerImportService
             if (header.StartsWith(CobasCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 return this.cobasService;
+            }
+
+            if (header.StartsWith(MyInvestorFundCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return this.myInvestorFundService;
+            }
+
+            if (header.StartsWith(MyInvestorAccountCsvHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return this.myInvestorAccountService;
             }
         }
 

--- a/src/MyAccountingApp.Core/Imports/MyInvestor/MyInvestorAccountImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/MyInvestor/MyInvestorAccountImportService.cs
@@ -1,0 +1,90 @@
+namespace MyAccountingApp.Core.Imports.MyInvestor;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Imports.Common;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+public class MyInvestorAccountImportService : IBrokerImportService
+{
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        string[] lines = await File.ReadAllLinesAsync(filePath, cancellationToken);
+        List<Transaction> transactions = new();
+
+        foreach (string line in lines.Skip(1))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            try
+            {
+                List<string> fields = BankCsvImportService.ParseCsvLine(line, ';');
+                if (fields.Count < 5)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(fields[2]))
+                {
+                    continue;
+                }
+
+                DateTime date = ParseDate(fields[0]);
+                string concepto = fields[2];
+                decimal amount = BankCsvImportService.ParseEuropeanDecimal(fields[3]);
+                string currency = fields[4];
+
+                if (amount == 0)
+                {
+                    continue;
+                }
+
+                TransactionCategory category = amount >= 0
+                    ? TransactionCategory.INCOME
+                    : TransactionCategory.EXPENSE;
+
+                category = BankCsvImportService.DetectTransfer(concepto, category);
+
+                Money money = new Money(Math.Abs(amount), currency);
+                Transaction transaction = new Transaction(date, concepto, money, category);
+                transactions.Add(transaction);
+            }
+            catch
+            {
+            }
+        }
+
+        return (transactions, Array.Empty<AssetTransaction>(), Enumerable.Empty<OptionTransaction>());
+    }
+
+    public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Enumerable.Empty<AssetTransaction>());
+    }
+
+    private static DateTime ParseDate(string value)
+    {
+        if (DateTime.TryParseExact(value, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date))
+        {
+            return date;
+        }
+
+        return DateTime.Parse(value, CultureInfo.InvariantCulture);
+    }
+}

--- a/src/MyAccountingApp.Core/Imports/MyInvestor/MyInvestorFundImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/MyInvestor/MyInvestorFundImportService.cs
@@ -1,0 +1,98 @@
+namespace MyAccountingApp.Core.Imports.MyInvestor;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Imports.Common;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+public class MyInvestorFundImportService : IBrokerImportService
+{
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        string[] lines = await File.ReadAllLinesAsync(filePath, cancellationToken);
+        List<AssetTransaction> assetTransactions = new();
+
+        foreach (string line in lines.Skip(1))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            try
+            {
+                List<string> fields = BankCsvImportService.ParseCsvLine(line, ';');
+                if (fields.Count < 5)
+                {
+                    continue;
+                }
+
+                if (!string.Equals(fields[4], "Finalizada", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                string isin = fields[1];
+                if (string.IsNullOrWhiteSpace(isin))
+                {
+                    continue;
+                }
+
+                DateTime date = ParseDate(fields[0]);
+                (decimal amount, string currency) = ParseAmount(fields[2]);
+                decimal quantity = BankCsvImportService.ParseEuropeanDecimal(fields[3]);
+
+                if (amount <= 0 || quantity <= 0)
+                {
+                    continue;
+                }
+
+                Money money = new Money(amount, currency);
+                Transaction transaction = new Transaction(date, isin, money, TransactionCategory.EXPENSE);
+                AssetTransaction assetTx = new AssetTransaction(transaction, isin, quantity, AssetTransactionType.Buy);
+                assetTransactions.Add(assetTx);
+            }
+            catch
+            {
+            }
+        }
+
+        return (Array.Empty<Transaction>(), assetTransactions, Enumerable.Empty<OptionTransaction>());
+    }
+
+    public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Enumerable.Empty<AssetTransaction>());
+    }
+
+    private static DateTime ParseDate(string value)
+    {
+        if (DateTime.TryParseExact(value, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date))
+        {
+            return date;
+        }
+
+        return DateTime.Parse(value, CultureInfo.InvariantCulture);
+    }
+
+    private static (decimal Amount, string Currency) ParseAmount(string value)
+    {
+        string[] parts = value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        string currency = parts.Length > 1 ? parts[^1].ToUpperInvariant() : "EUR";
+        decimal amount = BankCsvImportService.ParseEuropeanDecimal(value);
+        return (amount, currency);
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
@@ -7,6 +7,7 @@ using MyAccountingApp.Core.Imports.Cobas;
 using MyAccountingApp.Core.Imports.Common;
 using MyAccountingApp.Core.Imports.Degiro;
 using MyAccountingApp.Core.Imports.IBKR;
+using MyAccountingApp.Core.Imports.MyInvestor;
 using MyAccountingApp.Core.Imports.Revolut;
 using MyAccountingApp.Domain.Entities;
 using Xunit;
@@ -238,6 +239,51 @@ public class BrokerImportDispatcherTests
     }
 
     [Fact]
+    public async Task ParseAllAsync_MyInvestorAccountHeader_UsesMyInvestorAccountService()
+    {
+        string csv = "Fecha de operación;Fecha de valor;Concepto;Importe;Divisa\n21/12/2023;21/12/2023;PAYPAL EUROPE SARL ET CIE SCA;-12,99;EUR";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
+
+            Transaction transaction = Assert.Single(txs);
+            Assert.Equal(12.99m, transaction.Money.Amount);
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_MyInvestorFundHeader_UsesMyInvestorFundService()
+    {
+        string csv = "Fecha de la orden;ISIN;Importe estimado;Nº de participaciones;Estado\n22/12/2023;ES0165243017;250 EUR;234,913;Finalizada";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            AssetTransaction asset = Assert.Single(assets);
+            Assert.Equal("ES0165243017", asset.Symbol);
+            Assert.Equal(234.913m, asset.Quantity);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
     public async Task ParseCorporateActionsAsync_DelegatesToIbkr()
     {
         string file = Path.GetTempFileName();
@@ -259,7 +305,7 @@ public class BrokerImportDispatcherTests
     {
         InteractiveBrokersImportService ibkr = new(Parser, new FakeLogger<InteractiveBrokersImportService>());
         IBKRFlexQueryImportService flexQuery = new(Array.Empty<IIBKRStatementAgent>());
-        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService(), new DegiroTransactionImportService(), flexQuery, new RevolutImportService(), new AbnAmroImportService(), new CobasImportService());
+        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService(), new DegiroTransactionImportService(), flexQuery, new RevolutImportService(), new AbnAmroImportService(), new CobasImportService(), new MyInvestorAccountImportService(), new MyInvestorFundImportService());
     }
 }
 

--- a/tests/MyAccountingApp.Core.Tests/Services/MyInvestorAccountImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/MyInvestorAccountImportServiceTests.cs
@@ -1,0 +1,123 @@
+namespace MyAccountingApp.Core.Tests.Services;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Imports.MyInvestor;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using Xunit;
+
+public class MyInvestorAccountImportServiceTests
+{
+    private const string Header = "Fecha de operación;Fecha de valor;Concepto;Importe;Divisa";
+
+    [Fact]
+    public async Task ParseAllAsync_NegativeAmount_CreatesExpenseTransaction()
+    {
+        string csv = $"{Header}\n21/12/2023;21/12/2023;PAYPAL EUROPE SARL ET CIE SCA;-12,99;EUR";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            MyInvestorAccountImportService service = new();
+
+            var (txs, assets, options) = await service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+            Assert.Empty(options);
+            Transaction transaction = Assert.Single(txs);
+            Assert.Equal(TransactionCategory.EXPENSE, transaction.Category);
+            Assert.Equal(12.99m, transaction.Money.Amount);
+            Assert.Equal("EUR", transaction.Money.Currency);
+            Assert.Equal(new DateTime(2023, 12, 21), transaction.Date);
+            Assert.Equal("PAYPAL EUROPE SARL ET CIE SCA", transaction.Description);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_PositiveAmount_CreatesIncomeTransaction()
+    {
+        string csv = $"{Header}\n18/12/2023;18/12/2023;Imposible contratar deposito;10.000;EUR";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            MyInvestorAccountImportService service = new();
+
+            var (txs, _, _) = await service.ParseAllAsync(file);
+
+            Transaction transaction = Assert.Single(txs);
+            Assert.Equal(TransactionCategory.INCOME, transaction.Category);
+            Assert.Equal(10000.00m, transaction.Money.Amount);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_TransferDescription_BecomesTransfer()
+    {
+        string csv = $"{Header}\n15/12/2023;15/12/2023;Transferencia a FRANCESC GIRBAU;-500;EUR";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            MyInvestorAccountImportService service = new();
+
+            var (txs, _, _) = await service.ParseAllAsync(file);
+
+            Assert.Equal(TransactionCategory.TRANSFER, Assert.Single(txs).Category);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ZeroAmount_Skipped()
+    {
+        string csv = $"{Header}\n15/12/2023;15/12/2023;Movimiento nulo;0;EUR";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            MyInvestorAccountImportService service = new();
+
+            var (txs, _, _) = await service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_MalformedRow_Skipped()
+    {
+        string csv = $"{Header}\nEsto es una linea corrupta";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            MyInvestorAccountImportService service = new();
+
+            var (txs, _, _) = await service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Services/MyInvestorFundImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/MyInvestorFundImportServiceTests.cs
@@ -1,0 +1,103 @@
+namespace MyAccountingApp.Core.Tests.Services;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Imports.MyInvestor;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using Xunit;
+
+public class MyInvestorFundImportServiceTests
+{
+    private const string Header = "Fecha de la orden;ISIN;Importe estimado;Nº de participaciones;Estado";
+
+    [Fact]
+    public async Task ParseAllAsync_Finalizada_CreatesBuyAssetTransaction()
+    {
+        string csv = $"{Header}\n22/12/2023;ES0165243017;250 EUR;234,913;Finalizada";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            MyInvestorFundImportService service = new();
+
+            var (txs, assets, options) = await service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.Empty(options);
+            AssetTransaction asset = Assert.Single(assets);
+            Assert.Equal(AssetTransactionType.Buy, asset.Type);
+            Assert.Equal(TransactionCategory.EXPENSE, asset.Transaction.Category);
+            Assert.Equal("ES0165243017", asset.Symbol);
+            Assert.Equal(234.913m, asset.Quantity);
+            Assert.Equal(250.00m, asset.Transaction.Money.Amount);
+            Assert.Equal("EUR", asset.Transaction.Money.Currency);
+            Assert.Equal(new DateTime(2023, 12, 22), asset.Transaction.Date);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_NotFinalizada_Skipped()
+    {
+        string csv = $"{Header}\n22/12/2023;ES0165243017;250 EUR;234,913;Anulada";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            MyInvestorFundImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_EmptyIsin_Skipped()
+    {
+        string csv = $"{Header}\n22/12/2023;;250 EUR;234,913;Finalizada";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            MyInvestorFundImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ZeroQuantity_Skipped()
+    {
+        string csv = $"{Header}\n22/12/2023;ES0165243017;250 EUR;0;Finalizada";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv);
+            MyInvestorFundImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+}


### PR DESCRIPTION
## Nova feature: import MyInvestor (compte + fons)

Els 6 fitxers de `import/historical/` (`my_investor_2023..2025.csv` i `my_investor_found_2023..2025.csv`) ara es detecten i importen com a:

### 1. `my_investor_YYYY.csv` — compte/caixa → **Transactions**
- Header `Fecha de operación;Fecha de valor;Concepto;Importe;Divisa` (separador **`;`**)
- Negatiu → EXPENSE, positiu → INCOME, transferències → TRANSFER (mateixos criteris que el Bank)
- Decimals europeus (`10.000` → 10000, `-12,99` → -12.99)

### 2. `my_investor_found_YYYY.csv` — ordres de fons → **AssetTransactions**
- Header `Fecha de la orden;ISIN;Importe estimado;Nº de participaciones;Estado` (separador **`;`**)
- `Symbol` = ISIN, quantitat = participacions fraccionals, import de `250 EUR` (divisa extreta del sufix)
- Només `Finalizada` (Anulades saltades); totes són compres

### Implementació
- `Core/Imports/MyInvestor/MyInvestorAccountImportService.cs` + `MyInvestorFundImportService.cs`
- `BankCsvImportService.ParseCsvLine` ara accepta separador (default `,`) + helper compartit `ParseEuropeanDecimal` (gestiona signe, milers i decimals europeus)
- Dispatcher: 2 noves regles per header; DI registrat
- Tests: 9 casos nous + 2 de dispatch; validat amb els 6 fitxers reals (2023: 111 txs, 2024: 162, 2025: 134; fons per ISIN correctes)

Suite completa: **364 tests verds**, build 0/0 `-warnaserror`.