### PR TITLE
feat(web): add dedicated MyInvestor import section and update docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -16,7 +16,7 @@ MyAccountingApp.Application  → Services (conversions, import, portfolio, summa
 MyAccountingApp.Core         → Infrastructure implementations
 │   Core/Persistence         → JSON + in-memory repositories (namespaces MyAccountingApp.Core.Persistence)
 │   Core/Http                → Currency (Frankfurter, ExchangeRateHost) + Market (Yahoo) clients
-│   Core/Imports             → IBKR / Degiro / Revolut / AbnAmro / Cobas (investment funds) parsers + Common CSV helpers
+│   Core/Imports             → IBKR / Degiro / Revolut / AbnAmro / Cobas / MyInvestor (funds) parsers + Common CSV helpers
 │   Core/DTOs, Core/Models   → Response DTOs and IBKR record models
 MyAccountingApp.Api          → Minimal API endpoints (Endpoints/), DI wiring, pipeline, startup sync
 MyAccountingApp.ConsoleApp   → Manual CLI entry point (imports, conversions)
@@ -27,7 +27,7 @@ tests/                       → xUnit suites: Domain.Tests, Application.Tests, 
 Rules of thumb: Domain has no external dependencies; Application depends only on Domain + interfaces; Core holds all concrete I/O and third-party calls; Api is the composition root. Tests of Application use fakes from `MyAccountingApp.TestUtilities` (no JSON repositories, no real HTTP).
 
 ## Key Features
-- **Import**: Bank CSV + broker statements + investment fund statements (Cobas) via folder scan or file upload (`POST /api/import/upload`). Cobas funds are mapped to asset transactions: `Suscripción`/`Traspaso de entrada` → Buy, `Reembolso`/`Traspaso de salida` → Sell, quantity = fractional `Participaciones` (symbol per share class, e.g. `COBAS_INTERNACIONAL_D`)
+- **Import**: Bank CSV + broker statements + investment fund statements (Cobas, MyInvestor) via folder scan or file upload (`POST /api/import/upload`). Cobas funds are mapped to asset transactions: `Suscripción`/`Traspaso de entrada` → Buy, `Reembolso`/`Traspaso de salida` → Sell, quantity = fractional `Participaciones` (symbol per share class, e.g. `COBAS_INTERNACIONAL_D`). MyInvestor account files become cash transactions (expense/income/transfer); MyInvestor fund order files become asset transactions with ISIN symbols and fractional participations
 - **Transactions**: List with filters (year, category, search), sorting, pagination; full CRUD (create/edit/delete)
 - **Asset Transactions**: CRUD with Symbol, Quantity, Type fields
 - **Portfolio**: Positions table with expandable open lots, realized/unrealized P&L, coloring

--- a/src/MyAccountingApp.Web/Pages/Import.razor
+++ b/src/MyAccountingApp.Web/Pages/Import.razor
@@ -171,6 +171,34 @@
 </MudPaper>
 
 <MudPaper Class="pa-6 mb-4" Outlined="true">
+    <MudText Typo="Typo.h6" GutterBottom="true">Import MyInvestor (Account &amp; Funds)</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Upload a CSV exported from MyInvestor. Account statements and fund orders are detected automatically.
+    </MudText>
+    <MudAlert Severity="Severity.Info" Class="mb-4" Dense="true">
+        <strong>Format detected automatically.</strong> Account file columns: Fecha de operación; Fecha de valor; Concepto; Importe; Divisa. Fund orders file columns: Fecha de la orden; ISIN; Importe estimado; Nº de participaciones; Estado.<br />
+        <strong>Account rows</strong> become cash entries (expenses, income and transfers). <strong>Fund orders</strong> become portfolio entries with the ISIN as symbol and fractional participations as quantity.
+    </MudAlert>
+    <MudGrid>
+        <MudItem xs="12" sm="8">
+            <InputFile OnChange="@OnMyInvestorFileSelected" accept=".csv" class="mud-input-outlined" />
+        </MudItem>
+        <MudItem xs="12" sm="4" Class="d-flex align-center">
+            <MudButton Variant="Variant.Filled" Color="Color.Tertiary" Size="Size.Large"
+                       OnClick="@UploadMyInvestorAsync" Disabled="@(_myInvestorFile is null || _loading)"
+                       StartIcon="@Icons.Material.Filled.FileUpload"
+                       FullWidth="true">
+                Import MyInvestor
+            </MudButton>
+        </MudItem>
+    </MudGrid>
+    @if (_myInvestorFile is not null)
+    {
+        <MudText Typo="Typo.body2" Class="mt-2 mud-text-secondary">Selected: @_myInvestorFile.Name</MudText>
+    }
+</MudPaper>
+
+<MudPaper Class="pa-6 mb-4" Outlined="true">
     <MudText Typo="Typo.h6" GutterBottom="true">Import Raw CSV</MudText>
     <MudText Typo="Typo.body2" Class="mb-4">
         Upload a CSV with your own format. No transformations applied.
@@ -330,6 +358,7 @@
     private IBrowserFile? _revolutFile;
     private IBrowserFile? _abnAmroFile;
     private IBrowserFile? _cobasFile;
+    private IBrowserFile? _myInvestorFile;
 
     private void OnFileSelected(InputFileChangeEventArgs args)
     {
@@ -364,6 +393,12 @@
     private void OnCobasFileSelected(InputFileChangeEventArgs args)
     {
         _cobasFile = args.File;
+        _result = null;
+    }
+
+    private void OnMyInvestorFileSelected(InputFileChangeEventArgs args)
+    {
+        _myInvestorFile = args.File;
         _result = null;
     }
 
@@ -540,6 +575,35 @@
         catch (Exception ex)
         {
             Snackbar.Add($"Cobas import failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task UploadMyInvestorAsync()
+    {
+        if (_myInvestorFile is null) return;
+
+        _loading = true;
+        _result = null;
+        _editableSymbols = new();
+        try
+        {
+            using var content = new MultipartFormDataContent();
+            using var stream = _myInvestorFile.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024);
+            content.Add(new StreamContent(stream), "file", _myInvestorFile.Name);
+
+            var response = await Http.PostAsync("/api/import/upload", content);
+            _result = await response.Content.ReadFromJsonAsync<ImportResultDto>();
+            InitEditableSymbols();
+            Snackbar.Add("MyInvestor import completed.", Severity.Success);
+            _myInvestorFile = null;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"MyInvestor import failed: {ex.Message}", Severity.Error);
         }
         finally
         {


### PR DESCRIPTION
## Secció pròpia d'import MyInvestor a la UI + docs

`Import.razor` ara té la secció **"Import MyInvestor (Account & Funds)"** (abans de Raw CSV), seguint el patró de Cobas:

- **Upload dedicat** a `POST /api/import/upload` — el dispatcher detecta per header si és fitxer de compte o d'ordres de fons (els 6 fitxers serveixen amb el mateix botó)
- **Info box**: columnes dels dos formats (`Fecha de operación;...` i `Fecha de la orden;...`) + mapeig (compte → caixa EXPENSE/INCOME/TRANSFER; fons → actius amb ISIN i participacions fraccionals)
- **Docs**: `SUMMARY.md` — layer map (`Core/Imports` + MyInvestor) i Key Features → Import actualitzats

Depèn del parser del PR #113 (la UI usa `/api/import/upload` que ja ruta per header). Verificat: build 0/0 `-warnaserror`.