### PR TITLE
feat(import): support SelfBank account and fund CSV files

### DIFF
--- a/src/MyAccountingApp.Api/DependencyInjection.cs
+++ b/src/MyAccountingApp.Api/DependencyInjection.cs
@@ -13,6 +13,7 @@ using MyAccountingApp.Core.Imports.Degiro;
 using MyAccountingApp.Core.Imports.IBKR;
 using MyAccountingApp.Core.Imports.MyInvestor;
 using MyAccountingApp.Core.Imports.Revolut;
+using MyAccountingApp.Core.Imports.SelfBank;
 using MyAccountingApp.Core.Persistence;
 using MyAccountingApp.Domain.Enums;
 using MyAccountingApp.Domain.Interfaces;
@@ -154,6 +155,8 @@ public static class DependencyInjection
         builder.Services.AddSingleton<CobasImportService>();
         builder.Services.AddSingleton<MyInvestorAccountImportService>();
         builder.Services.AddSingleton<MyInvestorFundImportService>();
+        builder.Services.AddSingleton<SelfBankAccountImportService>();
+        builder.Services.AddSingleton<SelfBankFundImportService>();
         builder.Services.AddSingleton<IBrokerImportService, BrokerImportDispatcher>();
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen();

--- a/src/MyAccountingApp.Core/Imports/Common/BrokerImportDispatcher.cs
+++ b/src/MyAccountingApp.Core/Imports/Common/BrokerImportDispatcher.cs
@@ -11,6 +11,7 @@ using MyAccountingApp.Core.Imports.Degiro;
 using MyAccountingApp.Core.Imports.IBKR;
 using MyAccountingApp.Core.Imports.MyInvestor;
 using MyAccountingApp.Core.Imports.Revolut;
+using MyAccountingApp.Core.Imports.SelfBank;
 using MyAccountingApp.Domain.Entities;
 using MyAccountingApp.Domain.Interfaces;
 
@@ -22,7 +23,7 @@ public class BrokerImportDispatcher : IBrokerImportService
     private const string RevolutCsvHeaderPrefix = "Type,Product,Started Date";
     private const string AbnAmroCsvHeaderPrefix = "accountNumber,mutationcode";
     private const string CobasCsvHeaderPrefix = "Operacion,Producto,Fecha";
-    private const string MyInvestorAccountCsvHeaderPrefix = "Fecha de operación;Fecha de valor;Concepto";
+    private const string MyInvestorAccountCsvHeaderPrefix = "Fecha de operaci";
     private const string MyInvestorFundCsvHeaderPrefix = "Fecha de la orden;ISIN;Importe estimado";
 
     private readonly InteractiveBrokersImportService ibkrService;
@@ -36,6 +37,8 @@ public class BrokerImportDispatcher : IBrokerImportService
     private readonly CobasImportService cobasService;
     private readonly MyInvestorAccountImportService myInvestorAccountService;
     private readonly MyInvestorFundImportService myInvestorFundService;
+    private readonly SelfBankAccountImportService selfBankAccountService;
+    private readonly SelfBankFundImportService selfBankFundService;
 
     public BrokerImportDispatcher(
         InteractiveBrokersImportService ibkrService,
@@ -48,7 +51,9 @@ public class BrokerImportDispatcher : IBrokerImportService
         AbnAmroImportService abnAmroService,
         CobasImportService cobasService,
         MyInvestorAccountImportService myInvestorAccountService,
-        MyInvestorFundImportService myInvestorFundService)
+        MyInvestorFundImportService myInvestorFundService,
+        SelfBankAccountImportService selfBankAccountService,
+        SelfBankFundImportService selfBankFundService)
     {
         this.ibkrService = ibkrService ?? throw new ArgumentNullException(nameof(ibkrService));
         this.bankService = bankService ?? throw new ArgumentNullException(nameof(bankService));
@@ -61,6 +66,8 @@ public class BrokerImportDispatcher : IBrokerImportService
         this.cobasService = cobasService ?? throw new ArgumentNullException(nameof(cobasService));
         this.myInvestorAccountService = myInvestorAccountService ?? throw new ArgumentNullException(nameof(myInvestorAccountService));
         this.myInvestorFundService = myInvestorFundService ?? throw new ArgumentNullException(nameof(myInvestorFundService));
+        this.selfBankAccountService = selfBankAccountService ?? throw new ArgumentNullException(nameof(selfBankAccountService));
+        this.selfBankFundService = selfBankFundService ?? throw new ArgumentNullException(nameof(selfBankFundService));
     }
 
     public Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
@@ -110,6 +117,16 @@ public class BrokerImportDispatcher : IBrokerImportService
         if (fileName.StartsWith("ABN_", StringComparison.OrdinalIgnoreCase))
         {
             return this.abnAmroService;
+        }
+
+        if (fileName.StartsWith("selfbank_found", StringComparison.OrdinalIgnoreCase))
+        {
+            return this.selfBankFundService;
+        }
+
+        if (fileName.StartsWith("selfbank", StringComparison.OrdinalIgnoreCase))
+        {
+            return this.selfBankAccountService;
         }
 
         if (fileName.EndsWith("_transactions.csv", StringComparison.OrdinalIgnoreCase))

--- a/src/MyAccountingApp.Core/Imports/SelfBank/SelfBankAccountImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/SelfBank/SelfBankAccountImportService.cs
@@ -1,0 +1,90 @@
+namespace MyAccountingApp.Core.Imports.SelfBank;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Imports.Common;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+public class SelfBankAccountImportService : IBrokerImportService
+{
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        string[] lines = await File.ReadAllLinesAsync(filePath, Encoding.Latin1, cancellationToken);
+        List<Transaction> transactions = new();
+
+        foreach (string line in lines.Skip(1))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            try
+            {
+                List<string> fields = BankCsvImportService.ParseCsvLine(line, ';');
+                if (fields.Count < 5)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(fields[2]))
+                {
+                    continue;
+                }
+
+                DateTime date = ParseDate(fields[0]);
+                string movimiento = fields[2];
+                decimal amount = decimal.Parse(fields[4], NumberStyles.Any, CultureInfo.InvariantCulture);
+
+                if (amount == 0)
+                {
+                    continue;
+                }
+
+                TransactionCategory category = amount >= 0
+                    ? TransactionCategory.INCOME
+                    : TransactionCategory.EXPENSE;
+
+                category = BankCsvImportService.DetectTransfer(movimiento, category);
+
+                Money money = new Money(Math.Abs(amount), "EUR");
+                Transaction transaction = new Transaction(date, movimiento, money, category);
+                transactions.Add(transaction);
+            }
+            catch
+            {
+            }
+        }
+
+        return (transactions, Array.Empty<AssetTransaction>(), Enumerable.Empty<OptionTransaction>());
+    }
+
+    public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Enumerable.Empty<AssetTransaction>());
+    }
+
+    private static DateTime ParseDate(string value)
+    {
+        if (DateTime.TryParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date))
+        {
+            return date;
+        }
+
+        return DateTime.Parse(value, CultureInfo.InvariantCulture);
+    }
+}

--- a/src/MyAccountingApp.Core/Imports/SelfBank/SelfBankFundImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/SelfBank/SelfBankFundImportService.cs
@@ -1,0 +1,139 @@
+namespace MyAccountingApp.Core.Imports.SelfBank;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Imports.Common;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+public class SelfBankFundImportService : IBrokerImportService
+{
+    private const string HeaderPrefix = "Fecha movimiento;Fecha valor;Movimiento;Valor";
+
+    public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        string[] lines = await File.ReadAllLinesAsync(filePath, Encoding.Latin1, cancellationToken);
+        List<AssetTransaction> assetTransactions = new();
+
+        foreach (string line in lines.Skip(1))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith(HeaderPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            try
+            {
+                List<string> fields = BankCsvImportService.ParseCsvLine(line, ';');
+                if (fields.Count < 11)
+                {
+                    continue;
+                }
+
+                AssetTransactionType? type = MapType(fields[2]);
+                if (type is null)
+                {
+                    continue;
+                }
+
+                string fundName = fields[3];
+                if (string.IsNullOrWhiteSpace(fundName))
+                {
+                    continue;
+                }
+
+                DateTime date = ParseDate(fields[0]);
+                decimal quantity = BankCsvImportService.ParseEuropeanDecimal(fields[4]);
+                decimal amount = Math.Abs(BankCsvImportService.ParseEuropeanDecimal(fields[6]));
+
+                if (quantity <= 0 || amount <= 0)
+                {
+                    continue;
+                }
+
+                string symbol = BuildSymbol(fundName);
+                TransactionCategory category = type == AssetTransactionType.Buy ? TransactionCategory.EXPENSE : TransactionCategory.INCOME;
+
+                Money money = new Money(amount, "EUR");
+                Transaction transaction = new Transaction(date, fundName, money, category);
+                AssetTransaction assetTx = new AssetTransaction(transaction, symbol, quantity, type.Value);
+                assetTransactions.Add(assetTx);
+            }
+            catch
+            {
+            }
+        }
+
+        return (Array.Empty<Transaction>(), assetTransactions, Enumerable.Empty<OptionTransaction>());
+    }
+
+    public Task<IEnumerable<AssetTransaction>> ParseCorporateActionsAsync(
+        string filePath,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Enumerable.Empty<AssetTransaction>());
+    }
+
+    private static AssetTransactionType? MapType(string movimiento)
+    {
+        if (movimiento.Contains("Suscripción", StringComparison.OrdinalIgnoreCase))
+        {
+            return AssetTransactionType.Buy;
+        }
+
+        if (movimiento.Contains("Reembolso", StringComparison.OrdinalIgnoreCase))
+        {
+            return AssetTransactionType.Sell;
+        }
+
+        return null;
+    }
+
+    private static DateTime ParseDate(string value)
+    {
+        if (DateTime.TryParseExact(value, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date))
+        {
+            return date;
+        }
+
+        return DateTime.Parse(value, CultureInfo.InvariantCulture);
+    }
+
+    private static string BuildSymbol(string fundName)
+    {
+        string normalized = RemoveDiacritics(fundName).ToUpperInvariant().Trim();
+        normalized = normalized.Replace(",", string.Empty).Replace(" FI", string.Empty).Trim();
+        return normalized.Replace(" ", "_");
+    }
+
+    private static string RemoveDiacritics(string value)
+    {
+        string normalized = value.Normalize(NormalizationForm.FormD);
+        StringBuilder builder = new();
+        foreach (char c in normalized)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
+            {
+                builder.Append(c);
+            }
+        }
+
+        return builder.ToString().Normalize(NormalizationForm.FormC);
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/BrokerImportDispatcherTests.cs
@@ -1,6 +1,7 @@
 namespace MyAccountingApp.Core.Tests.Services;
 using System;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using MyAccountingApp.Core.Imports.AbnAmro;
 using MyAccountingApp.Core.Imports.Cobas;
@@ -9,6 +10,7 @@ using MyAccountingApp.Core.Imports.Degiro;
 using MyAccountingApp.Core.Imports.IBKR;
 using MyAccountingApp.Core.Imports.MyInvestor;
 using MyAccountingApp.Core.Imports.Revolut;
+using MyAccountingApp.Core.Imports.SelfBank;
 using MyAccountingApp.Domain.Entities;
 using Xunit;
 
@@ -284,6 +286,51 @@ public class BrokerImportDispatcherTests
     }
 
     [Fact]
+    public async Task ParseAllAsync_SelfBankAccountFilename_UsesSelfBankAccountService()
+    {
+        string csv = "Fecha Operación;Fecha Valor;Movimiento;Categoría;Importe\n2025-11-10;2025-11-10;TFI RECIBIDA;Sin Categoría;240.00;";
+        string file = Path.Combine(Path.GetTempPath(), "selfbank_historical.csv");
+        try
+        {
+            await File.WriteAllTextAsync(file, csv, Encoding.Latin1);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
+
+            Transaction transaction = Assert.Single(txs);
+            Assert.Equal(240.00m, transaction.Money.Amount);
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_SelfBankFundFilename_UsesSelfBankFundService()
+    {
+        string csv = "Nombre cliente:;FRANCESC GIRBAU LLISTUELLA\nDivisa:;EUR\nFecha movimiento;Fecha valor;Movimiento;Valor;Cantidad;Precio;Importe Bruto;Comisión;Canon;Impuestos;Importe total;Plusvalía/Minusvalía;Saldo\n05/09/2025;04/09/2025;Suscripción fondo;Sigma Internacional A FI;6,63081400;18,09732700;-120,00000000;0,00000000;0,00000000;0,00000000;-120,00000000;;120,00000000;";
+        string file = Path.Combine(Path.GetTempPath(), "selfbank_founds_historical.csv");
+        try
+        {
+            await File.WriteAllTextAsync(file, csv, Encoding.Latin1);
+            BrokerImportDispatcher dispatcher = CreateDispatcher();
+
+            var (txs, assets, _) = await dispatcher.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            AssetTransaction asset = Assert.Single(assets);
+            Assert.Equal("SIGMA_INTERNACIONAL_A", asset.Symbol);
+            Assert.Equal(6.63081400m, asset.Quantity);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
     public async Task ParseCorporateActionsAsync_DelegatesToIbkr()
     {
         string file = Path.GetTempFileName();
@@ -305,7 +352,7 @@ public class BrokerImportDispatcherTests
     {
         InteractiveBrokersImportService ibkr = new(Parser, new FakeLogger<InteractiveBrokersImportService>());
         IBKRFlexQueryImportService flexQuery = new(Array.Empty<IIBKRStatementAgent>());
-        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService(), new DegiroTransactionImportService(), flexQuery, new RevolutImportService(), new AbnAmroImportService(), new CobasImportService(), new MyInvestorAccountImportService(), new MyInvestorFundImportService());
+        return new BrokerImportDispatcher(ibkr, new BankCsvImportService(), new AssetTransactionCsvImportService(), new DegiroImportService(), new DegiroTransactionImportService(), flexQuery, new RevolutImportService(), new AbnAmroImportService(), new CobasImportService(), new MyInvestorAccountImportService(), new MyInvestorFundImportService(), new SelfBankAccountImportService(), new SelfBankFundImportService());
     }
 }
 

--- a/tests/MyAccountingApp.Core.Tests/Services/SelfBankAccountImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/SelfBankAccountImportServiceTests.cs
@@ -1,0 +1,104 @@
+namespace MyAccountingApp.Core.Tests.Services;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Imports.SelfBank;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using Xunit;
+
+public class SelfBankAccountImportServiceTests
+{
+    private const string Header = "Fecha Operación;Fecha Valor;Movimiento;Categoría;Importe";
+
+    [Fact]
+    public async Task ParseAllAsync_NegativeAmount_CreatesExpenseTransaction()
+    {
+        string csv = $"{Header}\n2025-11-10;2025-11-10;Cargo TRF A COBAS Internacional FI;Sin Categoría;-120.00;";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv, Encoding.Latin1);
+            SelfBankAccountImportService service = new();
+
+            var (txs, assets, options) = await service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+            Assert.Empty(options);
+            Transaction transaction = Assert.Single(txs);
+            Assert.Equal(TransactionCategory.EXPENSE, transaction.Category);
+            Assert.Equal(120.00m, transaction.Money.Amount);
+            Assert.Equal("EUR", transaction.Money.Currency);
+            Assert.Equal(new DateTime(2025, 11, 10), transaction.Date);
+            Assert.Equal("Cargo TRF A COBAS Internacional FI", transaction.Description);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_PositiveAmount_CreatesIncomeTransaction()
+    {
+        string csv = $"{Header}\n2025-10-01;2025-10-01;TFI RECIBIDA;Sin Categoría;240.00;";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv, Encoding.Latin1);
+            SelfBankAccountImportService service = new();
+
+            var (txs, _, _) = await service.ParseAllAsync(file);
+
+            Transaction transaction = Assert.Single(txs);
+            Assert.Equal(TransactionCategory.INCOME, transaction.Category);
+            Assert.Equal(240.00m, transaction.Money.Amount);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_TransferDescription_BecomesTransfer()
+    {
+        string csv = $"{Header}\n2025-09-04;2025-09-04;Cargo TRF A FRANCESC GIRBAU LLISTUELLA;Sin Categoría;-120.00;";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv, Encoding.Latin1);
+            SelfBankAccountImportService service = new();
+
+            var (txs, _, _) = await service.ParseAllAsync(file);
+
+            Assert.Equal(TransactionCategory.TRANSFER, Assert.Single(txs).Category);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ZeroAmount_Skipped()
+    {
+        string csv = $"{Header}\n2025-01-01;2025-01-01;Movimiento nulo;Sin Categoría;0.00;";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv, Encoding.Latin1);
+            SelfBankAccountImportService service = new();
+
+            var (txs, _, _) = await service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Services/SelfBankFundImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/SelfBankFundImportServiceTests.cs
@@ -1,0 +1,133 @@
+namespace MyAccountingApp.Core.Tests.Services;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MyAccountingApp.Core.Imports.SelfBank;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using Xunit;
+
+public class SelfBankFundImportServiceTests
+{
+    private const string Preamble = "Nombre cliente:;FRANCESC GIRBAU LLISTUELLA\nIBAN:;ES4914900001182442902140\nN. de cuenta:;2442902140\nDivisa:;EUR\n";
+    private const string Header = "Fecha movimiento;Fecha valor;Movimiento;Valor;Cantidad;Precio;Importe Bruto;Comisión;Canon;Impuestos;Importe total;Plusvalía/Minusvalía;Saldo";
+
+    [Fact]
+    public async Task ParseAllAsync_Suscripcion_CreatesBuyAssetTransaction()
+    {
+        string csv = $"{Preamble}{Header}\n05/09/2025;04/09/2025;Suscripción fondo;Sigma Internacional A FI;6,63081400;18,09732700;-120,00000000;0,00000000;0,00000000;0,00000000;-120,00000000;;120,00000000;";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv, Encoding.Latin1);
+            SelfBankFundImportService service = new();
+
+            var (txs, assets, options) = await service.ParseAllAsync(file);
+
+            Assert.Empty(txs);
+            Assert.Empty(options);
+            AssetTransaction asset = Assert.Single(assets);
+            Assert.Equal(AssetTransactionType.Buy, asset.Type);
+            Assert.Equal(TransactionCategory.EXPENSE, asset.Transaction.Category);
+            Assert.Equal("SIGMA_INTERNACIONAL_A", asset.Symbol);
+            Assert.Equal(6.63081400m, asset.Quantity);
+            Assert.Equal(120.00m, asset.Transaction.Money.Amount);
+            Assert.Equal("EUR", asset.Transaction.Money.Currency);
+            Assert.Equal(new DateTime(2025, 9, 5), asset.Transaction.Date);
+            Assert.Equal("Sigma Internacional A FI", asset.Transaction.Description);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_SuscripcionTraspaso_CreatesBuyAssetTransaction()
+    {
+        string csv = $"{Header}\n16/02/2023;14/02/2023;Suscripción traspaso de fondo;Sigma Internacional A FI;448,55815400;13,10019660;-5876,20000000;0,00000000;0,00000000;0,00000000;0,00000000;;0,00000000;";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv, Encoding.Latin1);
+            SelfBankFundImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            AssetTransaction asset = Assert.Single(assets);
+            Assert.Equal(AssetTransactionType.Buy, asset.Type);
+            Assert.Equal(448.55815400m, asset.Quantity);
+            Assert.Equal(5876.20m, asset.Transaction.Money.Amount);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_TraspasoDeEfectivo_Skipped()
+    {
+        string csv = $"{Header}\n04/09/2025;04/09/2025;Traspaso de efectivo de entrada;;0,00000000;0,00000000;120,00000000;0,00000000;0,00000000;0,00000000;120,00000000;;240,00000000;";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv, Encoding.Latin1);
+            SelfBankFundImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_Reembolso_CreatesSellAssetTransaction()
+    {
+        string csv = $"{Header}\n01/06/2025;31/05/2025;Reembolso fondo;Sigma Internacional A FI;3,00000000;20,00000000;60,00000000;0,00000000;0,00000000;0,00000000;60,00000000;5,00000000;180,00000000;";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv, Encoding.Latin1);
+            SelfBankFundImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            AssetTransaction asset = Assert.Single(assets);
+            Assert.Equal(AssetTransactionType.Sell, asset.Type);
+            Assert.Equal(TransactionCategory.INCOME, asset.Transaction.Category);
+            Assert.Equal(3.00000000m, asset.Quantity);
+            Assert.Equal(60.00m, asset.Transaction.Money.Amount);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ParseAllAsync_ZeroQuantity_Skipped()
+    {
+        string csv = $"{Header}\n04/09/2025;04/09/2025;Suscripción fondo;Sigma Internacional A FI;0,00000000;18,09732700;-120,00000000;0,00000000;0,00000000;0,00000000;-120,00000000;;120,00000000;";
+        string file = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(file, csv, Encoding.Latin1);
+            SelfBankFundImportService service = new();
+
+            var (_, assets, _) = await service.ParseAllAsync(file);
+
+            Assert.Empty(assets);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+}


### PR DESCRIPTION
## Nova feature: import SelfBank (compte + fons)

Els 2 fitxers de `import/historical/` (`selfbank_historical.csv` i `selfbank_founds_historical.csv`) ara s'importen.

### 1. `selfbank_historical.csv` — compte → **Transactions**
- `Fecha Operación;Fecha Valor;Movimiento;Categoría;Importe` (separador `;`, dates ISO `2025-11-10`, decimals amb punt)
- Negatiu → EXPENSE, positiu → INCOME, transferències FRANCESC/GIRBAU → TRANSFER

### 2. `selfbank_founds_historical.csv` — moviments de fons → **AssetTransactions**
- **Encoding Latin-1/Windows-1252** (el fitxer real porta accents codificats com `0xF3`/`0xED`; llegit amb `Encoding.Latin1`)
- Té **preamble** (Nombre cliente, IBAN, N. de cuenta, Divisa) abans del header — s'omet
- `Suscripción fondo` i `Suscripción traspaso de fondo` → **Buy**; `Reembolso` → **Sell**; `Traspaso de efectivo de entrada` (caixa, ja coberta pel compte) → **skipped**
- Quantitat = participacions, import = Importe Bruto (abs), símbol normalitzat del nom del fons (`Sigma Internacional A FI` → `SIGMA_INTERNACIONAL_A`)

### Dispatch
- Per **nom de fitxer** (el de fons té preamble, així que l'sniffing de primera línia no serveix): `selfbank_found*` → fons; `selfbank*` → compte
- Prefix MyInvestor ajustat a ASCII (`Fecha de operaci`) per robustesa d'encoding

Tests: 9 casos nous + 2 de dispatch; validat amb els fitxers reals: compte **90 txs** (15 INCOME / 29 EXPENSE / 46 TRANSFER), fons **31 suscripcions** de SIGMA_INTERNACIONAL_A (673.45 participacions, 9.056,20 €). Suite: **375 tests verds**, build 0/0 `-warnaserror`.