### PR TITLE
feat(web): add dedicated SelfBank import section and update docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -16,7 +16,7 @@ MyAccountingApp.Application  → Services (conversions, import, portfolio, summa
 MyAccountingApp.Core         → Infrastructure implementations
 │   Core/Persistence         → JSON + in-memory repositories (namespaces MyAccountingApp.Core.Persistence)
 │   Core/Http                → Currency (Frankfurter, ExchangeRateHost) + Market (Yahoo) clients
-│   Core/Imports             → IBKR / Degiro / Revolut / AbnAmro / Cobas / MyInvestor (funds) parsers + Common CSV helpers
+│   Core/Imports             → IBKR / Degiro / Revolut / AbnAmro / Cobas / MyInvestor / SelfBank (funds) parsers + Common CSV helpers
 │   Core/DTOs, Core/Models   → Response DTOs and IBKR record models
 MyAccountingApp.Api          → Minimal API endpoints (Endpoints/), DI wiring, pipeline, startup sync
 MyAccountingApp.ConsoleApp   → Manual CLI entry point (imports, conversions)
@@ -27,7 +27,7 @@ tests/                       → xUnit suites: Domain.Tests, Application.Tests, 
 Rules of thumb: Domain has no external dependencies; Application depends only on Domain + interfaces; Core holds all concrete I/O and third-party calls; Api is the composition root. Tests of Application use fakes from `MyAccountingApp.TestUtilities` (no JSON repositories, no real HTTP).
 
 ## Key Features
-- **Import**: Bank CSV + broker statements + investment fund statements (Cobas, MyInvestor) via folder scan or file upload (`POST /api/import/upload`). Cobas funds are mapped to asset transactions: `Suscripción`/`Traspaso de entrada` → Buy, `Reembolso`/`Traspaso de salida` → Sell, quantity = fractional `Participaciones` (symbol per share class, e.g. `COBAS_INTERNACIONAL_D`). MyInvestor account files become cash transactions (expense/income/transfer); MyInvestor fund order files become asset transactions with ISIN symbols and fractional participations
+- **Import**: Bank CSV + broker statements + investment fund statements (Cobas, MyInvestor) via folder scan or file upload (`POST /api/import/upload`). Cobas funds are mapped to asset transactions: `Suscripción`/`Traspaso de entrada` → Buy, `Reembolso`/`Traspaso de salida` → Sell, quantity = fractional `Participaciones` (symbol per share class, e.g. `COBAS_INTERNACIONAL_D`). MyInvestor account files become cash transactions (expense/income/transfer); MyInvestor fund order files become asset transactions with ISIN symbols and fractional participations. SelfBank account files become cash transactions; SelfBank fund movement files become asset transactions with normalized fund-name symbols (e.g. `SIGMA_INTERNACIONAL_A`)
 - **Transactions**: List with filters (year, category, search), sorting, pagination; full CRUD (create/edit/delete)
 - **Asset Transactions**: CRUD with Symbol, Quantity, Type fields
 - **Portfolio**: Positions table with expandable open lots, realized/unrealized P&L, coloring

--- a/src/MyAccountingApp.Web/Pages/Import.razor
+++ b/src/MyAccountingApp.Web/Pages/Import.razor
@@ -199,6 +199,34 @@
 </MudPaper>
 
 <MudPaper Class="pa-6 mb-4" Outlined="true">
+    <MudText Typo="Typo.h6" GutterBottom="true">Import SelfBank (Account &amp; Funds)</MudText>
+    <MudText Typo="Typo.body2" Class="mb-4">
+        Upload a CSV exported from SelfBank. Account statements and fund movements are detected automatically by filename.
+    </MudText>
+    <MudAlert Severity="Severity.Info" Class="mb-4" Dense="true">
+        <strong>Format detected by filename.</strong> Files starting with <strong>selfbank_found</strong> are routed to the fund movements parser; other <strong>selfbank</strong> files to the account parser.<br />
+        <strong>Account rows</strong> become cash entries (expenses, income and transfers). <strong>Fund movements</strong> (Suscripción / Suscripción traspaso) become portfolio entries with the fund name as symbol; Reembolso rows become sells; cash-only movements are skipped.
+    </MudAlert>
+    <MudGrid>
+        <MudItem xs="12" sm="8">
+            <InputFile OnChange="@OnSelfBankFileSelected" accept=".csv" class="mud-input-outlined" />
+        </MudItem>
+        <MudItem xs="12" sm="4" Class="d-flex align-center">
+            <MudButton Variant="Variant.Filled" Color="Color.Default" Size="Size.Large"
+                       OnClick="@UploadSelfBankAsync" Disabled="@(_selfBankFile is null || _loading)"
+                       StartIcon="@Icons.Material.Filled.FileUpload"
+                       FullWidth="true">
+                Import SelfBank
+            </MudButton>
+        </MudItem>
+    </MudGrid>
+    @if (_selfBankFile is not null)
+    {
+        <MudText Typo="Typo.body2" Class="mt-2 mud-text-secondary">Selected: @_selfBankFile.Name</MudText>
+    }
+</MudPaper>
+
+<MudPaper Class="pa-6 mb-4" Outlined="true">
     <MudText Typo="Typo.h6" GutterBottom="true">Import Raw CSV</MudText>
     <MudText Typo="Typo.body2" Class="mb-4">
         Upload a CSV with your own format. No transformations applied.
@@ -359,6 +387,7 @@
     private IBrowserFile? _abnAmroFile;
     private IBrowserFile? _cobasFile;
     private IBrowserFile? _myInvestorFile;
+    private IBrowserFile? _selfBankFile;
 
     private void OnFileSelected(InputFileChangeEventArgs args)
     {
@@ -399,6 +428,12 @@
     private void OnMyInvestorFileSelected(InputFileChangeEventArgs args)
     {
         _myInvestorFile = args.File;
+        _result = null;
+    }
+
+    private void OnSelfBankFileSelected(InputFileChangeEventArgs args)
+    {
+        _selfBankFile = args.File;
         _result = null;
     }
 
@@ -604,6 +639,35 @@
         catch (Exception ex)
         {
             Snackbar.Add($"MyInvestor import failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task UploadSelfBankAsync()
+    {
+        if (_selfBankFile is null) return;
+
+        _loading = true;
+        _result = null;
+        _editableSymbols = new();
+        try
+        {
+            using var content = new MultipartFormDataContent();
+            using var stream = _selfBankFile.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024);
+            content.Add(new StreamContent(stream), "file", _selfBankFile.Name);
+
+            var response = await Http.PostAsync("/api/import/upload", content);
+            _result = await response.Content.ReadFromJsonAsync<ImportResultDto>();
+            InitEditableSymbols();
+            Snackbar.Add("SelfBank import completed.", Severity.Success);
+            _selfBankFile = null;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"SelfBank import failed: {ex.Message}", Severity.Error);
         }
         finally
         {


### PR DESCRIPTION
## Secció pròpia d'import SelfBank a la UI + docs

`Import.razor` ara té la secció **"Import SelfBank (Account & Funds)"** (abans de Raw CSV), seguint el patró de Cobas/MyInvestor:

- **Upload dedicat** a `POST /api/import/upload` — el dispatcher ruta per nom de fitxer (`selfbank_found*` → fons, `selfbank*` → compte)
- **Info box**: dispatch per filename + mapeig (compte → caixa; fons → actius amb nom del fons com a símbol, Reembolso → sell, caixa pura → skip)
- **Docs**: `SUMMARY.md` — layer map (`Core/Imports` + SelfBank) i Key Features → Import actualitzats

Depèn del parser del PR #115. Verificat: build 0/0 `-warnaserror`.