### PR TITLE
feat(api): batch patch asset transaction symbol

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -47,6 +47,7 @@ Rules of thumb: Domain has no external dependencies; Application depends only on
 | POST | `/api/asset-transactions` | Create asset transaction |
 | PUT | `/api/asset-transactions/{id}` | Update asset transaction |
 | DELETE | `/api/asset-transactions/{id}` | Delete asset transaction |
+| PATCH | `/api/asset-transactions/batch` | Bulk update: `{ids: [...], patch: {symbol}}` → `{requested, updated, failures}` (best-effort) |
 | GET | `/api/portfolio` | Portfolio positions |
 | GET | `/api/conversions` | Currency conversions (timeseries lookups) |
 | GET | `/api/conversions?date=YYYY-MM-DD` | Single conversion, fetched on demand and cached (stale fallback when the provider fails or quota is exhausted) |

--- a/src/MyAccountingApp.Api/DependencyInjection.cs
+++ b/src/MyAccountingApp.Api/DependencyInjection.cs
@@ -163,6 +163,7 @@ public static class DependencyInjection
         builder.Services.AddSingleton<IMarketPriceService, YahooMarketPriceService>();
         builder.Services.AddSingleton<IImportService, ImportService>();
         builder.Services.AddSingleton<ITransactionValidator, TransactionValidator>();
+        builder.Services.AddSingleton<IAssetTransactionCommandService, AssetTransactionCommandService>();
         builder.Services.AddSingleton<IPortfolioQuery, PortfolioQuery>();
         builder.Services.AddSingleton<IPositionEngine, PositionEngine>();
         builder.Services.AddSingleton<IValidationQuery, ValidationQuery>();

--- a/src/MyAccountingApp.Api/Endpoints/TransactionsEndpoints.cs
+++ b/src/MyAccountingApp.Api/Endpoints/TransactionsEndpoints.cs
@@ -140,6 +140,22 @@ public static class TransactionsEndpoints
             return Results.Ok(assetTx.ToDto());
         });
 
+        app.MapPatch($"{prefix}/asset-transactions/batch", (BatchAssetTransactionPatchRequest request, IAssetTransactionCommandService service) =>
+        {
+            if (request.Ids is null || request.Ids.Count == 0)
+            {
+                return Results.BadRequest(new { message = "ids are required." });
+            }
+
+            if (request.Patch is null || request.Patch.Symbol is null)
+            {
+                return Results.BadRequest(new { message = "patch.symbol is required." });
+            }
+
+            BatchPatchResult result = service.PatchMany(request.Ids, request.Patch);
+            return Results.Ok(result);
+        });
+
         app.MapDelete($"{prefix}/asset-transactions/{{id:guid}}", (Guid id, IPortfolioRepository repo) =>
         {
             AssetTransaction? existing = repo.GetAllTransactions().FirstOrDefault(t => t.Transaction.Id == id);
@@ -216,3 +232,4 @@ public static class TransactionsEndpoints
 record CreateTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category);
 record CreateAssetTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category, string Symbol, decimal Quantity, string Type);
 record UpdateOptionTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category, string Symbol, string Isin, decimal Quantity, string Type);
+record BatchAssetTransactionPatchRequest(List<Guid> Ids, AssetTransactionPatch Patch);

--- a/src/MyAccountingApp.Application/DTOs/BatchPatchDtos.cs
+++ b/src/MyAccountingApp.Application/DTOs/BatchPatchDtos.cs
@@ -1,0 +1,10 @@
+namespace MyAccountingApp.Application.DTOs;
+
+public sealed record AssetTransactionPatch(string? Symbol);
+
+public sealed record BatchPatchFailure(Guid Id, string Error);
+
+public sealed record BatchPatchResult(
+    int Requested,
+    int Updated,
+    IReadOnlyList<BatchPatchFailure> Failures);

--- a/src/MyAccountingApp.Application/Interfaces/IAssetTransactionCommandService.cs
+++ b/src/MyAccountingApp.Application/Interfaces/IAssetTransactionCommandService.cs
@@ -1,0 +1,8 @@
+using MyAccountingApp.Application.DTOs;
+
+namespace MyAccountingApp.Application.Interfaces;
+
+public interface IAssetTransactionCommandService
+{
+    BatchPatchResult PatchMany(IReadOnlyList<Guid> ids, AssetTransactionPatch patch);
+}

--- a/src/MyAccountingApp.Application/Services/AssetTransactionCommandService.cs
+++ b/src/MyAccountingApp.Application/Services/AssetTransactionCommandService.cs
@@ -1,0 +1,54 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Interfaces;
+
+namespace MyAccountingApp.Application.Services;
+
+public sealed class AssetTransactionCommandService : IAssetTransactionCommandService
+{
+    private readonly IPortfolioRepository _repository;
+
+    public AssetTransactionCommandService(IPortfolioRepository repository)
+    {
+        this._repository = repository;
+    }
+
+    public BatchPatchResult PatchMany(IReadOnlyList<Guid> ids, AssetTransactionPatch patch)
+    {
+        List<AssetTransaction> all = this._repository.GetAllTransactions().ToList();
+        List<BatchPatchFailure> failures = new();
+        int updated = 0;
+
+        foreach (Guid id in ids)
+        {
+            AssetTransaction? target = all.FirstOrDefault(t => t.Transaction.Id == id);
+            if (target is null)
+            {
+                failures.Add(new BatchPatchFailure(id, "Asset transaction not found."));
+                continue;
+            }
+
+            try
+            {
+                if (patch.Symbol is not null)
+                {
+                    target.UpdateSymbol(patch.Symbol);
+                }
+
+                updated++;
+            }
+            catch (ArgumentException ex)
+            {
+                failures.Add(new BatchPatchFailure(id, ex.Message));
+            }
+        }
+
+        if (updated > 0)
+        {
+            this._repository.Initialize(all);
+        }
+
+        return new BatchPatchResult(ids.Count, updated, failures);
+    }
+}

--- a/src/MyAccountingApp.Domain/Entities/AssetTransaction.cs
+++ b/src/MyAccountingApp.Domain/Entities/AssetTransaction.cs
@@ -36,6 +36,16 @@ public class AssetTransaction
         }
     }
 
+    public void UpdateSymbol(string symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            throw new ArgumentException("Symbol cannot be null or empty.");
+        }
+
+        this.Symbol = symbol;
+    }
+
     public Money UnitaryCost()
     {
         if (Quantity == 0)

--- a/tests/MyAccountingApp.Api.Tests/AssetTransactionsEndpointsTests.cs
+++ b/tests/MyAccountingApp.Api.Tests/AssetTransactionsEndpointsTests.cs
@@ -6,7 +6,7 @@ namespace MyAccountingApp.Api.Tests;
 
 public class AssetTransactionsEndpointsTests
 {
-    private static object CreateAssetTransactionBody(DateTime date, string type = "Buy", decimal amount = 100m, decimal quantity = 2m)
+    private static object CreateAssetTransactionBody(DateTime date, string type = "Buy", decimal amount = 100m, decimal quantity = 2m, string symbol = "AAPL")
     {
         return new
         {
@@ -15,7 +15,7 @@ public class AssetTransactionsEndpointsTests
             amount,
             currency = "EUR",
             category = "EXPENSE",
-            symbol = "AAPL",
+            symbol,
             quantity,
             type,
         };
@@ -84,5 +84,93 @@ public class AssetTransactionsEndpointsTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         Assert.Equal(1, document.RootElement.GetProperty("assets").GetInt32());
+    }
+
+    [Fact]
+    public async Task BatchPatch_ShouldUpdateSymbols_ForAllIds()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        List<Guid> ids = new();
+        for (int i = 0; i < 3; i++)
+        {
+            HttpResponseMessage created = await client.PostAsJsonAsync("/api/asset-transactions", CreateAssetTransactionBody(new DateTime(2026, 8, 1), symbol: $"S{i}"));
+            string location = created.Headers.Location!.ToString();
+            ids.Add(Guid.Parse(location.Split('/').Last()));
+        }
+
+        // Act
+        HttpResponseMessage response = await client.PatchAsJsonAsync(
+            "/api/asset-transactions/batch",
+            new { ids, patch = new { symbol = "COBAS_INTERNACIONAL_D" } });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(3, document.RootElement.GetProperty("requested").GetInt32());
+        Assert.Equal(3, document.RootElement.GetProperty("updated").GetInt32());
+        Assert.Empty(document.RootElement.GetProperty("failures").EnumerateArray());
+
+        HttpResponseMessage all = await client.GetAsync("/api/asset-transactions");
+        using JsonDocument allDocument = JsonDocument.Parse(await all.Content.ReadAsStringAsync());
+        Assert.All(allDocument.RootElement.EnumerateArray(), tx => Assert.Equal("COBAS_INTERNACIONAL_D", tx.GetProperty("symbol").GetString()));
+    }
+
+    [Fact]
+    public async Task BatchPatch_ShouldReportMissingId_AsFailure()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        HttpResponseMessage created = await client.PostAsJsonAsync("/api/asset-transactions", CreateAssetTransactionBody(new DateTime(2026, 8, 1)));
+        string location = created.Headers.Location!.ToString();
+        Guid existing = Guid.Parse(location.Split('/').Last());
+        Guid missing = Guid.NewGuid();
+
+        // Act
+        HttpResponseMessage response = await client.PatchAsJsonAsync(
+            "/api/asset-transactions/batch",
+            new { ids = new[] { existing, missing }, patch = new { symbol = "TSLA" } });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(2, document.RootElement.GetProperty("requested").GetInt32());
+        Assert.Equal(1, document.RootElement.GetProperty("updated").GetInt32());
+        JsonElement failure = Assert.Single(document.RootElement.GetProperty("failures").EnumerateArray());
+        Assert.Equal(missing, failure.GetProperty("id").GetGuid());
+    }
+
+    [Fact]
+    public async Task BatchPatch_EmptyIds_ShouldReturnBadRequest()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.PatchAsJsonAsync(
+            "/api/asset-transactions/batch",
+            new { ids = Array.Empty<Guid>(), patch = new { symbol = "TSLA" } });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BatchPatch_MissingSymbol_ShouldReturnBadRequest()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.PatchAsJsonAsync(
+            "/api/asset-transactions/batch",
+            new { ids = new[] { Guid.NewGuid() }, patch = new { symbol = (string?)null } });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/AssetTransactionCommandServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/AssetTransactionCommandServiceTests.cs
@@ -1,0 +1,116 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class AssetTransactionCommandServiceTests
+{
+    [Fact]
+    public void PatchMany_ShouldUpdateSymbol_ForAllMatchingIds()
+    {
+        FakePfRepo repo = new();
+        AssetTransaction first = CreateAsset("AAPL");
+        AssetTransaction second = CreateAsset("AAPL");
+        repo.AddOrUpdate(first);
+        repo.AddOrUpdate(second);
+        AssetTransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { first.Transaction.Id, second.Transaction.Id },
+            new AssetTransactionPatch("TSLA"));
+
+        Assert.Equal(2, result.Requested);
+        Assert.Equal(2, result.Updated);
+        Assert.Empty(result.Failures);
+        Assert.Equal("TSLA", repo.GetAllTransactions().First(t => t.Transaction.Id == first.Transaction.Id).Symbol);
+        Assert.Equal("TSLA", repo.GetAllTransactions().First(t => t.Transaction.Id == second.Transaction.Id).Symbol);
+    }
+
+    [Fact]
+    public void PatchMany_ShouldReportMissingIds_AsFailures()
+    {
+        FakePfRepo repo = new();
+        AssetTransaction existing = CreateAsset("AAPL");
+        repo.AddOrUpdate(existing);
+        AssetTransactionCommandService service = new(repo);
+        Guid missing = Guid.NewGuid();
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { existing.Transaction.Id, missing },
+            new AssetTransactionPatch("TSLA"));
+
+        Assert.Equal(2, result.Requested);
+        Assert.Equal(1, result.Updated);
+        BatchPatchFailure failure = Assert.Single(result.Failures);
+        Assert.Equal(missing, failure.Id);
+        Assert.Equal("Asset transaction not found.", failure.Error);
+    }
+
+    [Fact]
+    public void PatchMany_ShouldReportInvalidSymbol_AsFailure_ForEveryId()
+    {
+        FakePfRepo repo = new();
+        AssetTransaction first = CreateAsset("AAPL");
+        AssetTransaction second = CreateAsset("AAPL");
+        repo.AddOrUpdate(first);
+        repo.AddOrUpdate(second);
+        AssetTransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { first.Transaction.Id, second.Transaction.Id },
+            new AssetTransactionPatch(" "));
+
+        Assert.Equal(0, result.Updated);
+        Assert.Equal(2, result.Failures.Count);
+        Assert.All(result.Failures, failure => Assert.Contains("cannot be null or empty", failure.Error));
+        Assert.Equal("AAPL", repo.GetAllTransactions().First(t => t.Transaction.Id == first.Transaction.Id).Symbol);
+        Assert.Equal("AAPL", repo.GetAllTransactions().First(t => t.Transaction.Id == second.Transaction.Id).Symbol);
+    }
+
+    [Fact]
+    public void PatchMany_ShouldReportAllMissingIds_WhenNoneExist()
+    {
+        FakePfRepo repo = new();
+        AssetTransactionCommandService service = new(repo);
+        Guid missing = Guid.NewGuid();
+
+        BatchPatchResult result = service.PatchMany(new[] { missing }, new AssetTransactionPatch("TSLA"));
+
+        Assert.Equal(0, result.Updated);
+        Assert.Single(result.Failures);
+        Assert.Empty(repo.GetAllTransactions());
+    }
+
+    private static AssetTransaction CreateAsset(string symbol)
+    {
+        Transaction transaction = new(
+            Guid.NewGuid(),
+            new DateTime(2026, 8, 1),
+            "Test asset",
+            new Money(100, "EUR"),
+            TransactionCategory.EXPENSE);
+        return new AssetTransaction(transaction, symbol, 2, AssetTransactionType.Buy);
+    }
+
+    private sealed class FakePfRepo : IPortfolioRepository
+    {
+        private readonly List<AssetTransaction> _transactions = new();
+
+        public void AddOrUpdate(AssetTransaction tx) => this._transactions.Add(tx);
+        public IEnumerable<AssetTransaction> GetAssetTransactions(string symbol) =>
+            this._transactions.Where(t => t.Symbol == symbol);
+        public IEnumerable<AssetTransaction> GetAllTransactions() => this._transactions;
+        public void Initialize(IEnumerable<AssetTransaction> transactions)
+        {
+            this._transactions.Clear();
+            this._transactions.AddRange(transactions);
+        }
+
+        public bool Delete(Guid transactionId) => true;
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
+    }
+}

--- a/tests/MyAccountingApp.Domain.Tests/Entities/AssetTransactionTests.cs
+++ b/tests/MyAccountingApp.Domain.Tests/Entities/AssetTransactionTests.cs
@@ -44,6 +44,30 @@ public class AssetTransactionTests
     }
 
     [Fact]
+    public void UpdateSymbol_ShouldChangeSymbol_WhenValid()
+    {
+        DateTime date = new DateTime(2025, 8, 27);
+        Money money = new Money(-1500, "EUR");
+        Transaction transaction = new Transaction(date, "AAPL", money, TransactionCategory.EXPENSE);
+        AssetTransaction assetTransaction = new AssetTransaction(transaction, "AAPL", 10, AssetTransactionType.Buy);
+
+        assetTransaction.UpdateSymbol("COBAS_INTERNACIONAL_D");
+
+        Assert.Equal("COBAS_INTERNACIONAL_D", assetTransaction.Symbol);
+    }
+
+    [Fact]
+    public void UpdateSymbol_ShouldThrow_WhenSymbolIsEmpty()
+    {
+        DateTime date = new DateTime(2025, 8, 27);
+        Money money = new Money(-1500, "EUR");
+        Transaction transaction = new Transaction(date, "AAPL", money, TransactionCategory.EXPENSE);
+        AssetTransaction assetTransaction = new AssetTransaction(transaction, "AAPL", 10, AssetTransactionType.Buy);
+
+        Assert.Throws<ArgumentException>(() => assetTransaction.UpdateSymbol(string.Empty));
+    }
+
+    [Fact]
     public void UnitaryCost_ShouldCalculateCorrectly()
     {
         DateTime date = new DateTime(2025, 8, 27);


### PR DESCRIPTION
## PR1 — Batch patch de Symbol d'AssetTransactions

Implementa el primer bloc del pla de multi-edició ("Canviar símbol a N files d'un cop").

### API
`PATCH /api/asset-transactions/batch`
```json
{ "ids": ["guid1", "guid2"], "patch": { "symbol": "COBAS_INTERNACIONAL_D" } }
```
→ `{ requested, updated, failures: [{ id, error }] }`

- **Best-effort**: IDs desconeguts o símbols invàlids s'informen a `failures`, la resta del lot s'aplica
- 400 si `ids` buit o `patch.symbol` absent
- **Un sol write al repo**: llegeix → muta → `Initialize` (escriptura atòmica tmp+move al JSON)

### Layers
- **Domain**: `AssetTransaction.UpdateSymbol(string)` amb validació (sense set públic lliure)
- **Application**: `IAssetTransactionCommandService` + `AssetTransactionCommandService` (best-effort per item, errors `ArgumentException` per item) + DTOs `AssetTransactionPatch` / `BatchPatchResult` / `BatchPatchFailure`
- **Api**: endpoint al fitxer `TransactionsEndpoints` (patró existent), registre DI

### Tests (13 nous)
- Domain: 2 (`UpdateSymbol` valid/invalid)
- Application: 4 (tot OK, ID missing, símbol invàlid → tots fallen com a failures, tots missing)
- Api: 5 (round-trip batch, missing id reportat, ids buits → 400, symbol null → 400)

Suite: **385 tests verds** (84 App + 37 Domain + 223 Core + 41 Api), build 0/0 `-warnaserror`.

Proper pas: **PR2** — multi-select + diàleg a la UI (MudBlazor) per al flux complet.