### PR TITLE
feat(web): multi-select and bulk symbol edit on asset transactions

### DIFF
--- a/src/MyAccountingApp.Web/Models/Dtos.cs
+++ b/src/MyAccountingApp.Web/Models/Dtos.cs
@@ -72,3 +72,16 @@ public class ValidationError
     public string Message { get; set; } = string.Empty;
     public string Severity { get; set; } = string.Empty;
 }
+
+public class BatchPatchFailureDto
+{
+    public Guid Id { get; set; }
+    public string Error { get; set; } = string.Empty;
+}
+
+public class BatchPatchResultDto
+{
+    public int Requested { get; set; }
+    public int Updated { get; set; }
+    public List<BatchPatchFailureDto> Failures { get; set; } = new();
+}

--- a/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
+++ b/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
@@ -41,7 +41,22 @@
 }
 else
 {
-    <MudTable Items="@_filteredTransactions" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Outlined="true" Striped="true" SortLabel="Sort by">
+    @if (_selected.Count > 0)
+    {
+        <MudPaper Class="pa-2 mb-2 d-flex align-center" Outlined="true">
+            <MudChip T="int" Color="Color.Primary" Size="Size.Small">@_selected.Count selected</MudChip>
+            <MudText Typo="Typo.body2" Class="ml-2 mud-text-secondary">visible rows selected — bulk actions apply only to these</MudText>
+            <MudSpacer />
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                       OnClick="@OpenBulkSymbolDialog" StartIcon="@Icons.Material.Filled.Edit">
+                Change symbol
+            </MudButton>
+            <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="@ClearSelection" Size="Size.Small" />
+        </MudPaper>
+    }
+
+    <MudTable Items="@_filteredTransactions" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Outlined="true" Striped="true" SortLabel="Sort by"
+              MultiSelection="true" @bind-SelectedItems="_selected">
         <ToolBarContent>
             <MudText Typo="Typo.subtitle1">@_filteredTransactions.Count transactions</MudText>
             <MudSpacer />
@@ -168,6 +183,26 @@ else
     </DialogActions>
 </MudDialog>
 
+<MudDialog @bind-Visible="_showBulkSymbolDialog">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Change symbol</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText Typo="Typo.body2" Class="mb-4">
+            The new symbol will be applied to <strong>@_selected.Count</strong> selected asset transaction(s).
+            Portfolio positions will be regrouped under the new symbol.
+        </MudText>
+        <MudTextField @bind-Value="_bulkSymbol" Label="New symbol" Variant="Variant.Outlined" FullWidth="true" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseBulkSymbolDialog">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@ConfirmBulkSymbolAsync"
+                   Disabled="@(string.IsNullOrWhiteSpace(_bulkSymbol))">
+            Update @_selected.Count
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
 @code {
     private List<AssetTransactionDto> _allTransactions = new();
     private List<AssetTransactionDto> _filteredTransactions = new();
@@ -186,8 +221,11 @@ else
 
     private bool _showFormDialog;
     private bool _showDeleteDialog;
+    private bool _showBulkSymbolDialog;
     private Guid? _editingId;
     private AssetTransactionDto? _deletingTx;
+    private HashSet<AssetTransactionDto> _selected = new();
+    private string _bulkSymbol = "";
 
     private DateTime? _formDate;
     private string _formDescription = "";
@@ -313,6 +351,64 @@ else
                 string error = await response.Content.ReadAsStringAsync();
                 Snackbar.Add($"Failed to save: {error}", Severity.Error);
             }
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private void ClearSelection()
+    {
+        _selected.Clear();
+    }
+
+    private void OpenBulkSymbolDialog()
+    {
+        _bulkSymbol = "";
+        _showBulkSymbolDialog = true;
+    }
+
+    private void CloseBulkSymbolDialog()
+    {
+        _showBulkSymbolDialog = false;
+    }
+
+    private async Task ConfirmBulkSymbolAsync()
+    {
+        if (_selected.Count == 0 || string.IsNullOrWhiteSpace(_bulkSymbol))
+        {
+            return;
+        }
+
+        var payload = new
+        {
+            ids = _selected.Select(t => t.Transaction.Id).ToList(),
+            patch = new { symbol = _bulkSymbol.Trim() },
+        };
+
+        try
+        {
+            HttpResponseMessage response = await Http.PatchAsJsonAsync("/api/asset-transactions/batch", payload);
+            BatchPatchResultDto? result = await response.Content.ReadFromJsonAsync<BatchPatchResultDto>();
+            _showBulkSymbolDialog = false;
+            _selected.Clear();
+
+            if (result is null)
+            {
+                Snackbar.Add("Bulk update failed", Severity.Error);
+            }
+            else if (result.Failures.Count == 0)
+            {
+                Snackbar.Add($"{result.Updated} asset transaction(s) updated", Severity.Success);
+            }
+            else
+            {
+                string details = string.Join("; ", result.Failures.Select(f => f.Error));
+                Snackbar.Add($"{result.Updated} updated, {result.Failures.Count} failed: {details}", Severity.Warning);
+            }
+
+            await LoadDataAsync();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## PR2 — UI bulk Symbol (Assets)

Flux complet de multi-edició a `AssetTransactions.razor`:

### UX
- **Multi-selecció** amb checkboxes (`MudTable MultiSelection`, `@bind-SelectedItems`) — el select-all del header aplica **només a les files filtrades visibles**
- **Barra d'accions contextual** quan hi ha selecció: chip amb el recompte, "Change symbol", tancar per netejar la selecció
- **Diàleg**: camp nou símbol + text explicatiu ("es aplicarà a N files; el portfolio es reagruparà"), botó deshabilitat fins que el símbol no estigui buit
- **Resultat**: snackbar `N updated` (success) o `N updated, M failed: <detalls>` (warning, best-effort del PR1)
- Refresca la llista i neteja la selecció en acabar

### Client
- DTOs `BatchPatchResultDto` / `BatchPatchFailureDto` a `Web/Models/Dtos.cs`
- `PATCH /api/asset-transactions/batch` via `Http.PatchAsJsonAsync` (un sol round-trip) + `ReadFromJsonAsync`

### Notes
- MudBlazor 9.6: el callback de selecció és `@bind-SelectedItems` (no `SelectedItemsChanged`)
- Edició unitària (crear/editar/esborrar) intacta

Suite: **385 tests verds**, build 0/0 `-warnaserror`.

Acceptació manual: filtrar per símbol dolent → seleccionar → canviar símbol → el portfolio es reagrupa (el primer endpoint batch ja està mergejat, #117).