### PR TITLE
feat: batch patch option symbols and transaction category

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -43,11 +43,17 @@ Rules of thumb: Domain has no external dependencies; Application depends only on
 | POST | `/api/transactions` | Create transaction |
 | PUT | `/api/transactions/{id}` | Update transaction |
 | DELETE | `/api/transactions/{id}` | Delete transaction |
+| PATCH | `/api/transactions/batch` | Bulk update: `{ids: [...], patch: {category}}` → `{requested, updated, failures}` (best-effort) |
 | GET | `/api/asset-transactions` | List asset transactions |
 | POST | `/api/asset-transactions` | Create asset transaction |
 | PUT | `/api/asset-transactions/{id}` | Update asset transaction |
 | DELETE | `/api/asset-transactions/{id}` | Delete asset transaction |
 | PATCH | `/api/asset-transactions/batch` | Bulk update: `{ids: [...], patch: {symbol}}` → `{requested, updated, failures}` (best-effort) |
+| GET | `/api/option-transactions` | List option transactions |
+| GET | `/api/option-transactions/{symbol}` | List option transactions by symbol |
+| PUT | `/api/option-transactions/{id}` | Update option transaction |
+| DELETE | `/api/option-transactions/{id}` | Delete option transaction |
+| PATCH | `/api/option-transactions/batch` | Bulk update: `{ids: [...], patch: {symbol}}` → `{requested, updated, failures}` (best-effort) |
 | GET | `/api/portfolio` | Portfolio positions |
 | GET | `/api/conversions` | Currency conversions (timeseries lookups) |
 | GET | `/api/conversions?date=YYYY-MM-DD` | Single conversion, fetched on demand and cached (stale fallback when the provider fails or quota is exhausted) |

--- a/src/MyAccountingApp.Api/DependencyInjection.cs
+++ b/src/MyAccountingApp.Api/DependencyInjection.cs
@@ -164,6 +164,8 @@ public static class DependencyInjection
         builder.Services.AddSingleton<IImportService, ImportService>();
         builder.Services.AddSingleton<ITransactionValidator, TransactionValidator>();
         builder.Services.AddSingleton<IAssetTransactionCommandService, AssetTransactionCommandService>();
+        builder.Services.AddSingleton<IOptionTransactionCommandService, OptionTransactionCommandService>();
+        builder.Services.AddSingleton<ITransactionCommandService, TransactionCommandService>();
         builder.Services.AddSingleton<IPortfolioQuery, PortfolioQuery>();
         builder.Services.AddSingleton<IPositionEngine, PositionEngine>();
         builder.Services.AddSingleton<IValidationQuery, ValidationQuery>();

--- a/src/MyAccountingApp.Api/Endpoints/TransactionsEndpoints.cs
+++ b/src/MyAccountingApp.Api/Endpoints/TransactionsEndpoints.cs
@@ -36,6 +36,22 @@ public static class TransactionsEndpoints
             return Results.Created($"/api/transactions/{transaction.Id}", transaction.ToDto());
         });
 
+        app.MapPatch($"{prefix}/transactions/batch", (BatchTransactionPatchRequest request, ITransactionCommandService service) =>
+        {
+            if (request.Ids is null || request.Ids.Count == 0)
+            {
+                return Results.BadRequest(new { message = "ids are required." });
+            }
+
+            if (request.Patch is null || request.Patch.Category is null)
+            {
+                return Results.BadRequest(new { message = "patch.category is required." });
+            }
+
+            BatchPatchResult result = service.PatchMany(request.Ids, request.Patch);
+            return Results.Ok(result);
+        });
+
         app.MapPut($"{prefix}/transactions/{{id:guid}}", (Guid id, CreateTransactionRequest request, ITransactionRepository repo, ITransactionValidator validator) =>
         {
             Transaction? existing = repo.GetAll().FirstOrDefault(t => t.Id == id);
@@ -192,6 +208,22 @@ public static class TransactionsEndpoints
             return Results.Ok(transactions);
         });
 
+        app.MapPatch($"{prefix}/option-transactions/batch", (BatchOptionTransactionPatchRequest request, IOptionTransactionCommandService service) =>
+        {
+            if (request.Ids is null || request.Ids.Count == 0)
+            {
+                return Results.BadRequest(new { message = "ids are required." });
+            }
+
+            if (request.Patch is null || request.Patch.Symbol is null)
+            {
+                return Results.BadRequest(new { message = "patch.symbol is required." });
+            }
+
+            BatchPatchResult result = service.PatchMany(request.Ids, request.Patch);
+            return Results.Ok(result);
+        });
+
         app.MapPut($"{prefix}/option-transactions/{{id:guid}}", (Guid id, UpdateOptionTransactionRequest request, IOptionTransactionRepository repo) =>
         {
             OptionTransaction? existing = repo.GetAll().FirstOrDefault(t => t.Transaction.Id == id);
@@ -233,3 +265,5 @@ record CreateTransactionRequest(DateTime Date, string Description, decimal Amoun
 record CreateAssetTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category, string Symbol, decimal Quantity, string Type);
 record UpdateOptionTransactionRequest(DateTime Date, string Description, decimal Amount, string Currency, string Category, string Symbol, string Isin, decimal Quantity, string Type);
 record BatchAssetTransactionPatchRequest(List<Guid> Ids, AssetTransactionPatch Patch);
+record BatchOptionTransactionPatchRequest(List<Guid> Ids, OptionTransactionPatch Patch);
+record BatchTransactionPatchRequest(List<Guid> Ids, TransactionPatch Patch);

--- a/src/MyAccountingApp.Application/DTOs/BatchPatchDtos.cs
+++ b/src/MyAccountingApp.Application/DTOs/BatchPatchDtos.cs
@@ -2,6 +2,10 @@ namespace MyAccountingApp.Application.DTOs;
 
 public sealed record AssetTransactionPatch(string? Symbol);
 
+public sealed record OptionTransactionPatch(string? Symbol);
+
+public sealed record TransactionPatch(string? Category);
+
 public sealed record BatchPatchFailure(Guid Id, string Error);
 
 public sealed record BatchPatchResult(

--- a/src/MyAccountingApp.Application/Interfaces/IOptionTransactionCommandService.cs
+++ b/src/MyAccountingApp.Application/Interfaces/IOptionTransactionCommandService.cs
@@ -1,0 +1,8 @@
+using MyAccountingApp.Application.DTOs;
+
+namespace MyAccountingApp.Application.Interfaces;
+
+public interface IOptionTransactionCommandService
+{
+    BatchPatchResult PatchMany(IReadOnlyList<Guid> ids, OptionTransactionPatch patch);
+}

--- a/src/MyAccountingApp.Application/Interfaces/ITransactionCommandService.cs
+++ b/src/MyAccountingApp.Application/Interfaces/ITransactionCommandService.cs
@@ -1,0 +1,8 @@
+using MyAccountingApp.Application.DTOs;
+
+namespace MyAccountingApp.Application.Interfaces;
+
+public interface ITransactionCommandService
+{
+    BatchPatchResult PatchMany(IReadOnlyList<Guid> ids, TransactionPatch patch);
+}

--- a/src/MyAccountingApp.Application/Services/OptionTransactionCommandService.cs
+++ b/src/MyAccountingApp.Application/Services/OptionTransactionCommandService.cs
@@ -1,0 +1,54 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Interfaces;
+
+namespace MyAccountingApp.Application.Services;
+
+public sealed class OptionTransactionCommandService : IOptionTransactionCommandService
+{
+    private readonly IOptionTransactionRepository _repository;
+
+    public OptionTransactionCommandService(IOptionTransactionRepository repository)
+    {
+        this._repository = repository;
+    }
+
+    public BatchPatchResult PatchMany(IReadOnlyList<Guid> ids, OptionTransactionPatch patch)
+    {
+        List<OptionTransaction> all = this._repository.GetAll().ToList();
+        List<BatchPatchFailure> failures = new();
+        int updated = 0;
+
+        foreach (Guid id in ids)
+        {
+            OptionTransaction? target = all.FirstOrDefault(t => t.Transaction.Id == id);
+            if (target is null)
+            {
+                failures.Add(new BatchPatchFailure(id, "Option transaction not found."));
+                continue;
+            }
+
+            try
+            {
+                if (patch.Symbol is not null)
+                {
+                    target.UpdateSymbol(patch.Symbol);
+                }
+
+                updated++;
+            }
+            catch (ArgumentException ex)
+            {
+                failures.Add(new BatchPatchFailure(id, ex.Message));
+            }
+        }
+
+        if (updated > 0)
+        {
+            this._repository.Initialize(all);
+        }
+
+        return new BatchPatchResult(ids.Count, updated, failures);
+    }
+}

--- a/src/MyAccountingApp.Application/Services/TransactionCommandService.cs
+++ b/src/MyAccountingApp.Application/Services/TransactionCommandService.cs
@@ -1,0 +1,61 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+
+namespace MyAccountingApp.Application.Services;
+
+public sealed class TransactionCommandService : ITransactionCommandService
+{
+    private readonly ITransactionRepository _repository;
+
+    public TransactionCommandService(ITransactionRepository repository)
+    {
+        this._repository = repository;
+    }
+
+    public BatchPatchResult PatchMany(IReadOnlyList<Guid> ids, TransactionPatch patch)
+    {
+        List<Transaction> all = this._repository.GetAll().ToList();
+        List<BatchPatchFailure> failures = new();
+        int updated = 0;
+
+        foreach (Guid id in ids)
+        {
+            Transaction? target = all.FirstOrDefault(t => t.Id == id);
+            if (target is null)
+            {
+                failures.Add(new BatchPatchFailure(id, "Transaction not found."));
+                continue;
+            }
+
+            try
+            {
+                if (patch.Category is not null)
+                {
+                    if (!Enum.TryParse<TransactionCategory>(patch.Category, ignoreCase: true, out TransactionCategory category)
+                        || !Enum.IsDefined(category))
+                    {
+                        throw new ArgumentException($"Invalid category '{patch.Category}'.");
+                    }
+
+                    target.UpdateCategory(category);
+                }
+
+                updated++;
+            }
+            catch (ArgumentException ex)
+            {
+                failures.Add(new BatchPatchFailure(id, ex.Message));
+            }
+        }
+
+        if (updated > 0)
+        {
+            this._repository.Initialize(all);
+        }
+
+        return new BatchPatchResult(ids.Count, updated, failures);
+    }
+}

--- a/src/MyAccountingApp.Domain/Entities/OptionTransaction.cs
+++ b/src/MyAccountingApp.Domain/Entities/OptionTransaction.cs
@@ -8,7 +8,7 @@ public class OptionTransaction
 {
     public Transaction Transaction { get; }
 
-    public string Symbol { get; }
+    public string Symbol { get; private set; }
 
     public string Isin { get; }
 
@@ -43,5 +43,15 @@ public class OptionTransaction
         {
             throw new ArgumentException("Quantity must be greater than zero.");
         }
+    }
+
+    public void UpdateSymbol(string symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            throw new ArgumentException("Symbol cannot be null or empty.");
+        }
+
+        this.Symbol = symbol;
     }
 }

--- a/src/MyAccountingApp.Domain/Entities/Transaction.cs
+++ b/src/MyAccountingApp.Domain/Entities/Transaction.cs
@@ -93,6 +93,11 @@ public class Transaction
         }
     }
 
+    public void UpdateCategory(TransactionCategory category)
+    {
+        this.Category = category;
+    }
+
     public TransactionFingerprint GetFingerprint() => new TransactionFingerprint(
         this.Date.Date,
         Math.Abs(this.Money.Amount),

--- a/src/MyAccountingApp.Web/Pages/Options.razor
+++ b/src/MyAccountingApp.Web/Pages/Options.razor
@@ -40,7 +40,22 @@
 }
 else
 {
-    <MudTable Items="@_filteredTransactions" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Outlined="true" Striped="true" SortLabel="Sort by">
+    @if (_selected.Count > 0)
+    {
+        <MudPaper Class="pa-2 mb-2 d-flex align-center" Outlined="true">
+            <MudChip T="int" Color="Color.Primary" Size="Size.Small">@_selected.Count selected</MudChip>
+            <MudText Typo="Typo.body2" Class="ml-2 mud-text-secondary">visible rows selected — bulk actions apply only to these</MudText>
+            <MudSpacer />
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                       OnClick="@OpenBulkSymbolDialog" StartIcon="@Icons.Material.Filled.Edit">
+                Change symbol
+            </MudButton>
+            <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="@ClearSelection" Size="Size.Small" />
+        </MudPaper>
+    }
+
+    <MudTable Items="@_filteredTransactions" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Outlined="true" Striped="true" SortLabel="Sort by"
+              MultiSelection="true" @bind-SelectedItems="_selected">
         <ToolBarContent>
             <MudText Typo="Typo.subtitle1">@_filteredTransactions.Count option transactions</MudText>
             <MudSpacer />
@@ -136,6 +151,25 @@ else
     </DialogActions>
 </MudDialog>
 
+<MudDialog @bind-Visible="_showBulkSymbolDialog">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Change symbol</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText Typo="Typo.body2" Class="mb-4">
+            The new symbol will be applied to <strong>@_selected.Count</strong> selected option transaction(s).
+        </MudText>
+        <MudTextField @bind-Value="_bulkSymbol" Label="New symbol" Variant="Variant.Outlined" FullWidth="true" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseBulkSymbolDialog">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@ConfirmBulkSymbolAsync"
+                   Disabled="@(string.IsNullOrWhiteSpace(_bulkSymbol))">
+            Update @_selected.Count
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
 <MudDialog @bind-Visible="_showDeleteDialog">
     <TitleContent>
         <MudText Typo="Typo.h6">Delete Option Transaction</MudText>
@@ -204,6 +238,10 @@ else
 
     private bool _showDeleteDialog;
     private OptionTransactionDto? _deletingTx;
+
+    private bool _showBulkSymbolDialog;
+    private HashSet<OptionTransactionDto> _selected = new();
+    private string _bulkSymbol = "";
 
     private bool _showDeleteYearDialog;
     private int? _deleteYearCount;
@@ -300,6 +338,64 @@ else
                 string error = await response.Content.ReadAsStringAsync();
                 Snackbar.Add($"Failed to save: {error}", Severity.Error);
             }
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private void ClearSelection()
+    {
+        _selected.Clear();
+    }
+
+    private void OpenBulkSymbolDialog()
+    {
+        _bulkSymbol = "";
+        _showBulkSymbolDialog = true;
+    }
+
+    private void CloseBulkSymbolDialog()
+    {
+        _showBulkSymbolDialog = false;
+    }
+
+    private async Task ConfirmBulkSymbolAsync()
+    {
+        if (_selected.Count == 0 || string.IsNullOrWhiteSpace(_bulkSymbol))
+        {
+            return;
+        }
+
+        var payload = new
+        {
+            ids = _selected.Select(t => t.Transaction.Id).ToList(),
+            patch = new { symbol = _bulkSymbol.Trim() },
+        };
+
+        try
+        {
+            HttpResponseMessage response = await Http.PatchAsJsonAsync("/api/option-transactions/batch", payload);
+            BatchPatchResultDto? result = await response.Content.ReadFromJsonAsync<BatchPatchResultDto>();
+            _showBulkSymbolDialog = false;
+            _selected.Clear();
+
+            if (result is null)
+            {
+                Snackbar.Add("Bulk update failed", Severity.Error);
+            }
+            else if (result.Failures.Count == 0)
+            {
+                Snackbar.Add($"{result.Updated} option transaction(s) updated", Severity.Success);
+            }
+            else
+            {
+                string details = string.Join("; ", result.Failures.Select(f => f.Error));
+                Snackbar.Add($"{result.Updated} updated, {result.Failures.Count} failed: {details}", Severity.Warning);
+            }
+
+            await LoadDataAsync();
         }
         catch (Exception ex)
         {

--- a/src/MyAccountingApp.Web/Pages/Transactions.razor
+++ b/src/MyAccountingApp.Web/Pages/Transactions.razor
@@ -89,7 +89,22 @@ else
         }
     </MudPaper>
 
-    <MudTable Items="@_filteredTransactions" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Outlined="true" Striped="true" SortLabel="Sort by">
+    @if (_selected.Count > 0)
+    {
+        <MudPaper Class="pa-2 mb-2 d-flex align-center" Outlined="true">
+            <MudChip T="int" Color="Color.Primary" Size="Size.Small">@_selected.Count selected</MudChip>
+            <MudText Typo="Typo.body2" Class="ml-2 mud-text-secondary">visible rows selected — bulk actions apply only to these</MudText>
+            <MudSpacer />
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                       OnClick="@OpenBulkCategoryDialog" StartIcon="@Icons.Material.Filled.Edit">
+                Change category
+            </MudButton>
+            <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="@ClearSelection" Size="Size.Small" />
+        </MudPaper>
+    }
+
+    <MudTable Items="@_filteredTransactions" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Outlined="true" Striped="true" SortLabel="Sort by"
+              MultiSelection="true" @bind-SelectedItems="_selected">
         <ToolBarContent>
             <MudText Typo="Typo.subtitle1">@_filteredTransactions.Count transactions</MudText>
             <MudSpacer />
@@ -175,6 +190,30 @@ else
     </DialogActions>
 </MudDialog>
 
+<MudDialog @bind-Visible="_showBulkCategoryDialog">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Change category</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText Typo="Typo.body2" Class="mb-4">
+            The new category will be applied to <strong>@_selected.Count</strong> selected transaction(s).
+        </MudText>
+        <MudSelect @bind-Value="_bulkCategory" Label="New category" Variant="Variant.Outlined">
+            @foreach (var cat in _categories)
+            {
+                <MudSelectItem Value="cat">@cat</MudSelectItem>
+            }
+        </MudSelect>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@CloseBulkCategoryDialog">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@ConfirmBulkCategoryAsync"
+                   Disabled="@(string.IsNullOrWhiteSpace(_bulkCategory))">
+            Update @_selected.Count
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
 <MudDialog @bind-Visible="_showDeleteDialog">
     <TitleContent>
         <MudText Typo="Typo.h6">Delete Transaction</MudText>
@@ -213,8 +252,11 @@ else
 
     private bool _showFormDialog;
     private bool _showDeleteDialog;
+    private bool _showBulkCategoryDialog;
     private Guid? _editingId;
     private TransactionDto? _deletingTx;
+    private HashSet<TransactionDto> _selected = new();
+    private string _bulkCategory = "";
 
     private DateTime? _formDate;
     private string _formDescription = "";
@@ -383,6 +425,64 @@ else
                 string error = await response.Content.ReadAsStringAsync();
                 Snackbar.Add($"Failed to save: {error}", Severity.Error);
             }
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private void ClearSelection()
+    {
+        _selected.Clear();
+    }
+
+    private void OpenBulkCategoryDialog()
+    {
+        _bulkCategory = "";
+        _showBulkCategoryDialog = true;
+    }
+
+    private void CloseBulkCategoryDialog()
+    {
+        _showBulkCategoryDialog = false;
+    }
+
+    private async Task ConfirmBulkCategoryAsync()
+    {
+        if (_selected.Count == 0 || string.IsNullOrWhiteSpace(_bulkCategory))
+        {
+            return;
+        }
+
+        var payload = new
+        {
+            ids = _selected.Select(t => t.Id).ToList(),
+            patch = new { category = _bulkCategory },
+        };
+
+        try
+        {
+            HttpResponseMessage response = await Http.PatchAsJsonAsync("/api/transactions/batch", payload);
+            BatchPatchResultDto? result = await response.Content.ReadFromJsonAsync<BatchPatchResultDto>();
+            _showBulkCategoryDialog = false;
+            _selected.Clear();
+
+            if (result is null)
+            {
+                Snackbar.Add("Bulk update failed", Severity.Error);
+            }
+            else if (result.Failures.Count == 0)
+            {
+                Snackbar.Add($"{result.Updated} transaction(s) updated", Severity.Success);
+            }
+            else
+            {
+                string details = string.Join("; ", result.Failures.Select(f => f.Error));
+                Snackbar.Add($"{result.Updated} updated, {result.Failures.Count} failed: {details}", Severity.Warning);
+            }
+
+            await LoadDataAsync();
         }
         catch (Exception ex)
         {

--- a/tests/MyAccountingApp.Api.Tests/OptionTransactionsEndpointsTests.cs
+++ b/tests/MyAccountingApp.Api.Tests/OptionTransactionsEndpointsTests.cs
@@ -95,4 +95,78 @@ public class OptionTransactionsEndpointsTests
         using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         Assert.Equal(1, document.RootElement.GetProperty("deletedOptions").GetInt32());
     }
+
+    [Fact]
+    public async Task BatchPatch_ShouldUpdateSymbols_ForAllIds()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        Guid first = Guid.NewGuid();
+        Guid second = Guid.NewGuid();
+        Transaction tx1 = new(first, new DateTime(2026, 8, 1), "Seed option", new Money(100m, "EUR"), TransactionCategory.EXPENSE);
+        Transaction tx2 = new(second, new DateTime(2026, 8, 2), "Seed option", new Money(100m, "EUR"), TransactionCategory.EXPENSE);
+        IOptionTransactionRepository repository = factory.Services.GetRequiredService<IOptionTransactionRepository>();
+        repository.Initialize(new[]
+        {
+            new OptionTransaction(tx1, "AAPL", "US0378331005", 2m, AssetTransactionType.Buy),
+            new OptionTransaction(tx2, "AAPL", "US0378331005", 2m, AssetTransactionType.Buy),
+        });
+
+        // Act
+        HttpResponseMessage response = await client.PatchAsJsonAsync(
+            "/api/option-transactions/batch",
+            new { ids = new[] { first, second }, patch = new { symbol = "MSFT 260918C00330000" } });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(2, document.RootElement.GetProperty("requested").GetInt32());
+        Assert.Equal(2, document.RootElement.GetProperty("updated").GetInt32());
+        Assert.Empty(document.RootElement.GetProperty("failures").EnumerateArray());
+
+        HttpResponseMessage all = await client.GetAsync("/api/option-transactions");
+        using JsonDocument allDocument = JsonDocument.Parse(await all.Content.ReadAsStringAsync());
+        Assert.All(allDocument.RootElement.EnumerateArray(), tx => Assert.Equal("MSFT 260918C00330000", tx.GetProperty("symbol").GetString()));
+    }
+
+    [Fact]
+    public async Task BatchPatch_ShouldReportMissingId_AsFailure()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        Guid existing = Guid.NewGuid();
+        Guid missing = Guid.NewGuid();
+        SeedOptionTransaction(factory, existing, new DateTime(2026, 8, 1));
+
+        // Act
+        HttpResponseMessage response = await client.PatchAsJsonAsync(
+            "/api/option-transactions/batch",
+            new { ids = new[] { existing, missing }, patch = new { symbol = "TSLA" } });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(2, document.RootElement.GetProperty("requested").GetInt32());
+        Assert.Equal(1, document.RootElement.GetProperty("updated").GetInt32());
+        JsonElement failure = Assert.Single(document.RootElement.GetProperty("failures").EnumerateArray());
+        Assert.Equal(missing, failure.GetProperty("id").GetGuid());
+    }
+
+    [Fact]
+    public async Task BatchPatch_EmptyIds_ShouldReturnBadRequest()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.PatchAsJsonAsync(
+            "/api/option-transactions/batch",
+            new { ids = Array.Empty<Guid>(), patch = new { symbol = "TSLA" } });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
 }

--- a/tests/MyAccountingApp.Api.Tests/TransactionsEndpointsTests.cs
+++ b/tests/MyAccountingApp.Api.Tests/TransactionsEndpointsTests.cs
@@ -101,4 +101,75 @@ public class TransactionsEndpointsTests
         using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         Assert.Equal(1, document.RootElement.GetProperty("transactions").GetInt32());
     }
+
+    [Fact]
+    public async Task BatchPatch_ShouldUpdateCategories_ForAllIds()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        List<Guid> ids = new();
+        for (int i = 0; i < 3; i++)
+        {
+            HttpResponseMessage created = await client.PostAsJsonAsync("/api/transactions", CreateTransactionBody(new DateTime(2026, 8, 1)));
+            string location = created.Headers.Location!.ToString();
+            ids.Add(Guid.Parse(location.Split('/').Last()));
+        }
+
+        // Act
+        HttpResponseMessage response = await client.PatchAsJsonAsync(
+            "/api/transactions/batch",
+            new { ids, patch = new { category = "TRANSFER" } });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(3, document.RootElement.GetProperty("requested").GetInt32());
+        Assert.Equal(3, document.RootElement.GetProperty("updated").GetInt32());
+        Assert.Empty(document.RootElement.GetProperty("failures").EnumerateArray());
+
+        HttpResponseMessage all = await client.GetAsync("/api/transactions");
+        using JsonDocument allDocument = JsonDocument.Parse(await all.Content.ReadAsStringAsync());
+        Assert.All(allDocument.RootElement.EnumerateArray(), tx => Assert.Equal("TRANSFER", tx.GetProperty("category").GetString()));
+    }
+
+    [Fact]
+    public async Task BatchPatch_ShouldReportInvalidCategory_AsFailure()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        HttpResponseMessage created = await client.PostAsJsonAsync("/api/transactions", CreateTransactionBody(new DateTime(2026, 8, 1)));
+        string location = created.Headers.Location!.ToString();
+        Guid id = Guid.Parse(location.Split('/').Last());
+
+        // Act
+        HttpResponseMessage response = await client.PatchAsJsonAsync(
+            "/api/transactions/batch",
+            new { ids = new[] { id }, patch = new { category = "NOT_A_CATEGORY" } });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(0, document.RootElement.GetProperty("updated").GetInt32());
+        JsonElement failure = Assert.Single(document.RootElement.GetProperty("failures").EnumerateArray());
+        Assert.Equal(id, failure.GetProperty("id").GetGuid());
+        Assert.Contains("Invalid category", failure.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task BatchPatch_EmptyIds_ShouldReturnBadRequest()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+
+        // Act
+        HttpResponseMessage response = await client.PatchAsJsonAsync(
+            "/api/transactions/batch",
+            new { ids = Array.Empty<Guid>(), patch = new { category = "TRANSFER" } });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/OptionTransactionCommandServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/OptionTransactionCommandServiceTests.cs
@@ -1,0 +1,102 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class OptionTransactionCommandServiceTests
+{
+    [Fact]
+    public void PatchMany_ShouldUpdateSymbol_ForAllMatchingIds()
+    {
+        FakeOptionRepo repo = new();
+        OptionTransaction first = CreateOption("AAPL");
+        OptionTransaction second = CreateOption("AAPL");
+        repo.Add(first);
+        repo.Add(second);
+        OptionTransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { first.Transaction.Id, second.Transaction.Id },
+            new OptionTransactionPatch("TSLA"));
+
+        Assert.Equal(2, result.Requested);
+        Assert.Equal(2, result.Updated);
+        Assert.Empty(result.Failures);
+        Assert.Equal("TSLA", repo.GetAll().First(t => t.Transaction.Id == first.Transaction.Id).Symbol);
+        Assert.Equal("TSLA", repo.GetAll().First(t => t.Transaction.Id == second.Transaction.Id).Symbol);
+    }
+
+    [Fact]
+    public void PatchMany_ShouldReportMissingIds_AsFailures()
+    {
+        FakeOptionRepo repo = new();
+        OptionTransaction existing = CreateOption("AAPL");
+        repo.Add(existing);
+        OptionTransactionCommandService service = new(repo);
+        Guid missing = Guid.NewGuid();
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { existing.Transaction.Id, missing },
+            new OptionTransactionPatch("TSLA"));
+
+        Assert.Equal(2, result.Requested);
+        Assert.Equal(1, result.Updated);
+        BatchPatchFailure failure = Assert.Single(result.Failures);
+        Assert.Equal(missing, failure.Id);
+        Assert.Equal("Option transaction not found.", failure.Error);
+    }
+
+    [Fact]
+    public void PatchMany_ShouldReportInvalidSymbol_AsFailure_ForEveryId()
+    {
+        FakeOptionRepo repo = new();
+        OptionTransaction first = CreateOption("AAPL");
+        OptionTransaction second = CreateOption("AAPL");
+        repo.Add(first);
+        repo.Add(second);
+        OptionTransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { first.Transaction.Id, second.Transaction.Id },
+            new OptionTransactionPatch(" "));
+
+        Assert.Equal(0, result.Updated);
+        Assert.Equal(2, result.Failures.Count);
+        Assert.All(result.Failures, failure => Assert.Contains("cannot be null or empty", failure.Error));
+    }
+
+    private static OptionTransaction CreateOption(string symbol)
+    {
+        Transaction transaction = new(
+            Guid.NewGuid(),
+            new DateTime(2026, 8, 1),
+            "Test option",
+            new Money(100, "EUR"),
+            TransactionCategory.EXPENSE);
+        return new OptionTransaction(transaction, symbol, "US0378331005", 2, AssetTransactionType.Buy);
+    }
+
+    private sealed class FakeOptionRepo : IOptionTransactionRepository
+    {
+        private readonly List<OptionTransaction> _transactions = new();
+
+        public void Add(OptionTransaction transaction) => this._transactions.Add(transaction);
+        public IEnumerable<OptionTransaction> GetAll() => this._transactions;
+        public void Initialize(IEnumerable<OptionTransaction> transactions)
+        {
+            this._transactions.Clear();
+            this._transactions.AddRange(transactions);
+        }
+
+        public void Update(OptionTransaction transaction)
+        {
+        }
+
+        public bool Delete(Guid id) => true;
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
+    }
+}

--- a/tests/MyAccountingApp.Application.Tests/Services/TransactionCommandServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/TransactionCommandServiceTests.cs
@@ -1,0 +1,114 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class TransactionCommandServiceTests
+{
+    [Fact]
+    public void PatchMany_ShouldUpdateCategory_ForAllMatchingIds()
+    {
+        FakeTxRepo repo = new();
+        Transaction first = CreateTransaction();
+        Transaction second = CreateTransaction();
+        repo.Add(first);
+        repo.Add(second);
+        TransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { first.Id, second.Id },
+            new TransactionPatch("TRANSFER"));
+
+        Assert.Equal(2, result.Requested);
+        Assert.Equal(2, result.Updated);
+        Assert.Empty(result.Failures);
+        Assert.Equal(TransactionCategory.TRANSFER, repo.GetAll().First(t => t.Id == first.Id).Category);
+        Assert.Equal(TransactionCategory.TRANSFER, repo.GetAll().First(t => t.Id == second.Id).Category);
+    }
+
+    [Fact]
+    public void PatchMany_ShouldAcceptLowercaseCategory()
+    {
+        FakeTxRepo repo = new();
+        Transaction existing = CreateTransaction();
+        repo.Add(existing);
+        TransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { existing.Id },
+            new TransactionPatch("income"));
+
+        Assert.Equal(1, result.Updated);
+        Assert.Equal(TransactionCategory.INCOME, repo.GetAll().Single().Category);
+    }
+
+    [Fact]
+    public void PatchMany_ShouldReportMissingIds_AsFailures()
+    {
+        FakeTxRepo repo = new();
+        Transaction existing = CreateTransaction();
+        repo.Add(existing);
+        TransactionCommandService service = new(repo);
+        Guid missing = Guid.NewGuid();
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { existing.Id, missing },
+            new TransactionPatch("TRANSFER"));
+
+        Assert.Equal(2, result.Requested);
+        Assert.Equal(1, result.Updated);
+        BatchPatchFailure failure = Assert.Single(result.Failures);
+        Assert.Equal(missing, failure.Id);
+        Assert.Equal("Transaction not found.", failure.Error);
+    }
+
+    [Fact]
+    public void PatchMany_ShouldReportInvalidCategory_AsFailure()
+    {
+        FakeTxRepo repo = new();
+        Transaction existing = CreateTransaction();
+        repo.Add(existing);
+        TransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { existing.Id },
+            new TransactionPatch("NOT_A_CATEGORY"));
+
+        Assert.Equal(0, result.Updated);
+        BatchPatchFailure failure = Assert.Single(result.Failures);
+        Assert.Equal(existing.Id, failure.Id);
+        Assert.Contains("Invalid category", failure.Error);
+        Assert.Equal(TransactionCategory.EXPENSE, repo.GetAll().Single().Category);
+    }
+
+    private static Transaction CreateTransaction()
+    {
+        return new Transaction(
+            Guid.NewGuid(),
+            new DateTime(2026, 8, 1),
+            "Test transaction",
+            new Money(100, "EUR"),
+            TransactionCategory.EXPENSE);
+    }
+
+    private sealed class FakeTxRepo : ITransactionRepository
+    {
+        private readonly List<Transaction> _transactions = new();
+
+        public void Add(Transaction transaction) => this._transactions.Add(transaction);
+        public void AddOrUpdate(Transaction transaction) => this._transactions.Add(transaction);
+        public IEnumerable<Transaction> GetAll() => this._transactions;
+        public void Initialize(IEnumerable<Transaction> transactions)
+        {
+            this._transactions.Clear();
+            this._transactions.AddRange(transactions);
+        }
+
+        public bool Delete(Transaction transaction) => this._transactions.Remove(transaction);
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Date.Year == year);
+    }
+}

--- a/tests/MyAccountingApp.Domain.Tests/Entities/OptionTransactionTests.cs
+++ b/tests/MyAccountingApp.Domain.Tests/Entities/OptionTransactionTests.cs
@@ -1,0 +1,32 @@
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Domain.Tests.Entities;
+
+public class OptionTransactionTests
+{
+    [Fact]
+    public void UpdateSymbol_ShouldChangeSymbol_WhenValid()
+    {
+        DateTime date = new(2025, 8, 27);
+        Money money = new(100, "EUR");
+        Transaction transaction = new(date, "Option", money, TransactionCategory.EXPENSE);
+        OptionTransaction option = new(transaction, "AAPL", "US0378331005", 2, AssetTransactionType.Buy);
+
+        option.UpdateSymbol("AAPL 260918C00210000");
+
+        Assert.Equal("AAPL 260918C00210000", option.Symbol);
+    }
+
+    [Fact]
+    public void UpdateSymbol_ShouldThrow_WhenSymbolIsEmpty()
+    {
+        DateTime date = new(2025, 8, 27);
+        Money money = new(100, "EUR");
+        Transaction transaction = new(date, "Option", money, TransactionCategory.EXPENSE);
+        OptionTransaction option = new(transaction, "AAPL", "US0378331005", 2, AssetTransactionType.Buy);
+
+        Assert.Throws<ArgumentException>(() => option.UpdateSymbol(string.Empty));
+    }
+}

--- a/tests/MyAccountingApp.Domain.Tests/Entities/TransationTests.cs
+++ b/tests/MyAccountingApp.Domain.Tests/Entities/TransationTests.cs
@@ -71,4 +71,19 @@ public class TransactionTests
         // Assert - should adjust to positve too
         Assert.True(transaction.Money.Amount > 0);
     }
+
+    [Fact]
+    public void UpdateCategory_ShouldChangeCategory()
+    {
+        // Arrange
+        DateTime date = DateTime.Now;
+        Money money = new Money(amount: 100, currency: Currencies.EUR.ToString());
+        Transaction transaction = new Transaction(date, "Groceries", money, TransactionCategory.EXPENSE);
+
+        // Act
+        transaction.UpdateCategory(TransactionCategory.TRANSFER);
+
+        // Assert
+        Assert.Equal(TransactionCategory.TRANSFER, transaction.Category);
+    }
 }


### PR DESCRIPTION
## PR3 - Patch batch d'Options + category de Transactions

Completa el patró batch a totes les entitats, amb UI paral·lela.

### API
- `PATCH /api/option-transactions/batch` - `{ids, patch: {symbol}}` (best-effort, mateix contracte que #117)
- `PATCH /api/transactions/batch` - `{ids, patch: {category}}` (best-effort; categoria invàlida -> failure per item, case-insensitive)

### Layers
- **Domain**: `OptionTransaction.UpdateSymbol` (`Symbol` ara `private set`), `Transaction.UpdateCategory`
- **Application**: `IOptionTransactionCommandService`/`OptionTransactionCommandService` + `ITransactionCommandService`/`TransactionCommandService` reutilitzant `BatchPatchResult`/`BatchPatchFailure`; DTOs `OptionTransactionPatch`/`TransactionPatch`
- **Api**: endpoints a `TransactionsEndpoints` + registres DI

### UI (patró AssetTransactions de #118)
- **Options**: multi-select + barra "Change symbol" + diàleg
- **Transactions**: multi-select + barra "Change category" + diàleg (MudSelect amb les 4 categories); les seleccions apliquen només a les files filtrades

### Tests (16 nous)
- Domain: 2 (Option UpdateSymbol) + 1 (Transaction UpdateCategory)
- Application: 3 (options) + 4 (transactions: lowercase acceptada, missing ids, invalid category)
- Api: 3 (options: round-trip, missing id, 400) + 3 (transactions: round-trip, invalid category, 400)

Suite: **401 tests verds** (91 App + 40 Domain + 223 Core + 47 Api), build 0/0 `-warnaserror`.