### PR TITLE
feat(web): group navigation and add empty states to movement pages

### DIFF
--- a/src/MyAccountingApp.Web/Layout/NavMenu.razor
+++ b/src/MyAccountingApp.Web/Layout/NavMenu.razor
@@ -1,11 +1,23 @@
 ﻿<MudNavMenu>
     <MudText Typo="Typo.h6" Class="px-4 py-4">Navigation</MudText>
     <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
-    <MudNavLink Href="summary" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.BarChart">Summary</MudNavLink>
-    <MudNavLink Href="transactions" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Receipt">Transactions</MudNavLink>
-    <MudNavLink Href="asset-transactions" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.TrendingUp">Asset Transactions</MudNavLink>
-    <MudNavLink Href="options" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.ShowChart">Options</MudNavLink>
-    <MudNavLink Href="portfolio" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.AccountBalance">Portfolio</MudNavLink>
-    <MudNavLink Href="import" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.FileUpload">Import</MudNavLink>
-    <MudNavLink Href="settings" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Settings">Settings</MudNavLink>
+
+    <MudNavGroup Title="Movements" Icon="@Icons.Material.Filled.SwapVert" Expanded="true">
+        <MudNavLink Href="transactions" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Receipt">Transactions</MudNavLink>
+        <MudNavLink Href="asset-transactions" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.TrendingUp">Asset Transactions</MudNavLink>
+        <MudNavLink Href="options" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.ShowChart">Options</MudNavLink>
+    </MudNavGroup>
+
+    <MudNavGroup Title="Investments" Icon="@Icons.Material.Filled.AccountBalance">
+        <MudNavLink Href="portfolio" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.PieChart">Portfolio</MudNavLink>
+    </MudNavGroup>
+
+    <MudNavGroup Title="Reports" Icon="@Icons.Material.Filled.BarChart">
+        <MudNavLink Href="summary" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Summarize">Summary</MudNavLink>
+    </MudNavGroup>
+
+    <MudNavGroup Title="Data" Icon="@Icons.Material.Filled.Storage">
+        <MudNavLink Href="import" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.FileUpload">Import</MudNavLink>
+        <MudNavLink Href="settings" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Settings">Settings</MudNavLink>
+    </MudNavGroup>
 </MudNavMenu>

--- a/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
+++ b/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
@@ -1,46 +1,59 @@
 @page "/asset-transactions"
 @inject HttpClient Http
 @inject ISnackbar Snackbar
+@inject NavigationManager Navigation
 
 <PageTitle>Asset Transactions</PageTitle>
 
 <MudText Typo="Typo.h3" GutterBottom="true">Asset Transactions</MudText>
 
-<MudPaper Class="pa-4 mb-4" Outlined="true">
-    <MudGrid>
-        <MudItem xs="12" sm="4">
-            <MudSelect T="int?" @bind-Value="_selectedYear" @bind-Value:after="ApplyFilters" Label="Year" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
-                @foreach (var year in _availableYears)
-                {
-                    <MudSelectItem T="int?" Value="@((int?)year)">@year</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
-        <MudItem xs="12" sm="4">
-            <MudSelect @bind-Value="_selectedSymbol" @bind-Value:after="ApplyFilters" Label="Symbol" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
-                @foreach (var symbol in _availableSymbols)
-                {
-                    <MudSelectItem Value="symbol">@symbol</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
-        <MudItem xs="12" sm="4">
-            <MudSelect @bind-Value="_selectedType" @bind-Value:after="ApplyFilters" Label="Type" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
-                @foreach (var type in _types)
-                {
-                    <MudSelectItem Value="type">@type</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
-    </MudGrid>
-</MudPaper>
-
 @if (_loading)
 {
     <MudProgressCircular Indeterminate="true" />
 }
+else if (_allTransactions.Count == 0)
+{
+    <MudPaper Class="pa-8 text-center" Outlined="true">
+        <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Size="Size.Large" Class="mud-text-secondary" />
+        <MudText Typo="Typo.h5" Class="mt-4">No asset transactions yet</MudText>
+        <MudText Typo="Typo.body2" Class="mb-4 mud-text-secondary">Import your first CSV or create an asset transaction manually.</MudText>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.FileUpload"
+                   OnClick="@(() => Navigation.NavigateTo("import"))">
+            Go to Import
+        </MudButton>
+    </MudPaper>
+}
 else
 {
+    <MudPaper Class="pa-4 mb-4" Outlined="true">
+        <MudGrid>
+            <MudItem xs="12" sm="4">
+                <MudSelect T="int?" @bind-Value="_selectedYear" @bind-Value:after="ApplyFilters" Label="Year" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
+                    @foreach (var year in _availableYears)
+                    {
+                        <MudSelectItem T="int?" Value="@((int?)year)">@year</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
+            <MudItem xs="12" sm="4">
+                <MudSelect @bind-Value="_selectedSymbol" @bind-Value:after="ApplyFilters" Label="Symbol" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
+                    @foreach (var symbol in _availableSymbols)
+                    {
+                        <MudSelectItem Value="symbol">@symbol</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
+            <MudItem xs="12" sm="4">
+                <MudSelect @bind-Value="_selectedType" @bind-Value:after="ApplyFilters" Label="Type" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
+                    @foreach (var type in _types)
+                    {
+                        <MudSelectItem Value="type">@type</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
+        </MudGrid>
+    </MudPaper>
+
     @if (_selected.Count > 0)
     {
         <MudPaper Class="pa-2 mb-2 d-flex align-center" Outlined="true">

--- a/src/MyAccountingApp.Web/Pages/Options.razor
+++ b/src/MyAccountingApp.Web/Pages/Options.razor
@@ -2,44 +2,57 @@
 @using System.Text.Json
 @inject HttpClient Http
 @inject ISnackbar Snackbar
+@inject NavigationManager Navigation
 
 <PageTitle>Options</PageTitle>
 
 <MudText Typo="Typo.h3" GutterBottom="true">Options</MudText>
 
-<MudPaper Class="pa-4 mb-4" Outlined="true">
-    <MudGrid>
-        <MudItem xs="12" sm="4">
-            <MudSelect T="int?" @bind-Value="_selectedYear" @bind-Value:after="ApplyFilters" Label="Year" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
-                @foreach (var year in _availableYears)
-                {
-                    <MudSelectItem T="int?" Value="@((int?)year)">@year</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
-        <MudItem xs="12" sm="4">
-            <MudSelect @bind-Value="_selectedSymbol" @bind-Value:after="ApplyFilters" Label="Symbol" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
-                @foreach (var symbol in _availableSymbols)
-                {
-                    <MudSelectItem Value="symbol">@symbol</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
-        <MudItem xs="12" sm="4">
-            <MudButton Variant="Variant.Filled" Color="Color.Error" StartIcon="@Icons.Material.Filled.DeleteSweep"
-                       OnClick="@OpenDeleteYearDialog" Disabled="@(!_selectedYear.HasValue)">
-                Delete Year
-            </MudButton>
-        </MudItem>
-    </MudGrid>
-</MudPaper>
-
 @if (_loading)
 {
     <MudProgressCircular Indeterminate="true" />
 }
+else if (_allTransactions.Count == 0)
+{
+    <MudPaper Class="pa-8 text-center" Outlined="true">
+        <MudIcon Icon="@Icons.Material.Filled.ShowChart" Size="Size.Large" Class="mud-text-secondary" />
+        <MudText Typo="Typo.h5" Class="mt-4">No option transactions yet</MudText>
+        <MudText Typo="Typo.body2" Class="mb-4 mud-text-secondary">Import your first CSV or create an option transaction manually.</MudText>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.FileUpload"
+                   OnClick="@(() => Navigation.NavigateTo("import"))">
+            Go to Import
+        </MudButton>
+    </MudPaper>
+}
 else
 {
+    <MudPaper Class="pa-4 mb-4" Outlined="true">
+        <MudGrid>
+            <MudItem xs="12" sm="4">
+                <MudSelect T="int?" @bind-Value="_selectedYear" @bind-Value:after="ApplyFilters" Label="Year" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
+                    @foreach (var year in _availableYears)
+                    {
+                        <MudSelectItem T="int?" Value="@((int?)year)">@year</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
+            <MudItem xs="12" sm="4">
+                <MudSelect @bind-Value="_selectedSymbol" @bind-Value:after="ApplyFilters" Label="Symbol" Variant="Variant.Outlined" FullWidth="true" Clearable="true">
+                    @foreach (var symbol in _availableSymbols)
+                    {
+                        <MudSelectItem Value="symbol">@symbol</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
+            <MudItem xs="12" sm="4">
+                <MudButton Variant="Variant.Filled" Color="Color.Error" StartIcon="@Icons.Material.Filled.DeleteSweep"
+                           OnClick="@OpenDeleteYearDialog" Disabled="@(!_selectedYear.HasValue)">
+                    Delete Year
+                </MudButton>
+            </MudItem>
+        </MudGrid>
+    </MudPaper>
+
     @if (_selected.Count > 0)
     {
         <MudPaper Class="pa-2 mb-2 d-flex align-center" Outlined="true">

--- a/src/MyAccountingApp.Web/Pages/Transactions.razor
+++ b/src/MyAccountingApp.Web/Pages/Transactions.razor
@@ -1,6 +1,7 @@
 @page "/transactions"
 @inject HttpClient Http
 @inject ISnackbar Snackbar
+@inject NavigationManager Navigation
 
 <PageTitle>Transactions</PageTitle>
 
@@ -43,6 +44,18 @@
 @if (_loading)
 {
     <MudProgressCircular Indeterminate="true" />
+}
+else if (_allTransactions.Count == 0)
+{
+    <MudPaper Class="pa-8 text-center" Outlined="true">
+        <MudIcon Icon="@Icons.Material.Filled.Receipt" Size="Size.Large" Class="mud-text-secondary" />
+        <MudText Typo="Typo.h5" Class="mt-4">No transactions yet</MudText>
+        <MudText Typo="Typo.body2" Class="mb-4 mud-text-secondary">Import your first CSV or create a transaction manually.</MudText>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.FileUpload"
+                   OnClick="@(() => Navigation.NavigateTo("import"))">
+            Go to Import
+        </MudButton>
+    </MudPaper>
 }
 else
 {


### PR DESCRIPTION
## PR4 - Shell comptable: navegació agrupada + empty states

Primera onada W2 del pla (UI més "app de comptabilitat").

### W2.1 - Nav lateral agrupada (NavMenu.razor)
- **Movements**: Transactions, Asset Transactions, Options (expandit per defecte)
- **Investments**: Portfolio
- **Reports**: Summary
- **Data**: Import, Settings
- Icons per grup (MudNavGroup); Home es manté al capdamunt

### W2.4 - Empty states amb CTA (3 pàgines)
- Transactions, Asset Transactions i Options ara mostren un estat buit amb icona, text i botó **"Go to Import"** quan no hi ha dades
- Els filtres només es mostren quan hi ha dades (abans sortien sempre)

Lògica de pàgina intacta (filtres, multi-select bulk, edició). Suite: **401 tests verds**, build 0/0 `-warnaserror`.