### PR TITLE
feat(web): open asset movements from portfolio symbol

### DIFF
--- a/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
+++ b/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
@@ -251,7 +251,21 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        string? symbol = GetQueryParam("symbol");
+        if (!string.IsNullOrWhiteSpace(symbol))
+        {
+            _selectedSymbol = symbol;
+        }
+
         await LoadDataAsync();
+    }
+
+    private string? GetQueryParam(string key)
+    {
+        string query = Navigation.ToAbsoluteUri(Navigation.Uri).Query;
+        string prefix = key + "=";
+        int index = query.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
+        return index < 0 ? null : Uri.UnescapeDataString(query[(index + prefix.Length)..]);
     }
 
     private async Task LoadDataAsync()

--- a/src/MyAccountingApp.Web/Pages/Portfolio.razor
+++ b/src/MyAccountingApp.Web/Pages/Portfolio.razor
@@ -1,5 +1,6 @@
 @page "/portfolio"
 @inject HttpClient Http
+@inject NavigationManager Navigation
 
 <PageTitle>Portfolio</PageTitle>
 
@@ -50,6 +51,8 @@ else
         <RowTemplate>
             <MudTd DataLabel="Symbol">
                 <MudChip T="string" Size="Size.Small" Color="Color.Primary">@context.Symbol</MudChip>
+                <MudIconButton Icon="@Icons.Material.Filled.ListAlt" Size="Size.Small" aria-label="View movements"
+                               OnClick="@(() => NavigateToMovements(context.Symbol))" />
             </MudTd>
             <MudTd DataLabel="Net Qty">@context.NetQuantity.ToString("G")</MudTd>
             <MudTd DataLabel="Avg Cost">@context.AverageUnitaryCost.ToString("N4")</MudTd>
@@ -147,5 +150,10 @@ else
     {
         if (!_expanded.Remove(pos.Symbol))
             _expanded.Add(pos.Symbol);
+    }
+
+    private void NavigateToMovements(string symbol)
+    {
+        Navigation.NavigateTo($"/asset-transactions?symbol={Uri.EscapeDataString(symbol)}");
     }
 }


### PR DESCRIPTION
## PR5 - Deep links Portfolio -> moviments filtrats per símbol

W3.1 del pla.

- **Portfolio.razor**: cada posició té ara un botó d'icona ("View movements") que navega a `/asset-transactions?symbol=X` (symbol escaped)
- **AssetTransactions.razor**: llegeix el query parameter `symbol` a `OnInitializedAsync` i pre-aplica el filtre de símbol (el selector "Symbol" ja reflecteix el valor actiu)
- Parseig manual del query string (no cal `WebUtilities`, que no està disponible en Blazor WASM)

El filtre existent de la pàgina fa la resta — zero canvis d'API. Suite: **401 tests verds**, build 0/0 `-warnaserror`.