### PR TITLE
refactor(core): extract shared ParseEuropeanDecimal into CsvParsing

### DIFF
--- a/src/MyAccountingApp.Core/Imports/Cobas/CobasImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/Cobas/CobasImportService.cs
@@ -56,8 +56,8 @@ public class CobasImportService : IBrokerImportService
                 }
 
                 DateTime date = ParseDate(fields[2]);
-                decimal amount = ParseEuropeanDecimal(JoinAmountFields(fields));
-                decimal quantity = ParseEuropeanDecimal(fields[^1]);
+                decimal amount = CsvParsing.ParseEuropeanDecimal(JoinAmountFields(fields));
+                decimal quantity = CsvParsing.ParseEuropeanDecimal(fields[^1]);
 
                 if (amount <= 0 || quantity <= 0)
                 {
@@ -119,33 +119,7 @@ public class CobasImportService : IBrokerImportService
     {
         // Importe may be split by an unquoted comma (e.g. "2.560,32 € (Bruto)");
         // Valor liquidativo and Participaciones are always the last two fields.
-        return string.Join(",", fields.Skip(5).Take(fields.Count - 7));
-    }
-
-    private static decimal ParseEuropeanDecimal(string value)
-    {
-        StringBuilder digits = new(value.Length);
-        foreach (char c in value)
-        {
-            if (char.IsDigit(c) || c == '.' || c == ',')
-            {
-                digits.Append(c);
-            }
-        }
-
-        string cleaned = digits.ToString();
-        int lastDot = cleaned.LastIndexOf('.');
-        int lastComma = cleaned.LastIndexOf(',');
-        if (lastComma > lastDot)
-        {
-            cleaned = cleaned.Replace(".", string.Empty).Replace(",", ".");
-        }
-        else if (lastDot > lastComma)
-        {
-            cleaned = cleaned.Replace(",", string.Empty);
-        }
-
-        return decimal.Parse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture);
+return string.Join(",", fields.Skip(5).Take(fields.Count - 7));
     }
 
     private static string BuildSymbol(string producto)

--- a/src/MyAccountingApp.Core/Imports/Common/BankCsvImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/Common/BankCsvImportService.cs
@@ -61,48 +61,6 @@ public class BankCsvImportService : IBrokerImportService
         return fields;
     }
 
-    public static decimal ParseEuropeanDecimal(string value)
-    {
-        string trimmed = value.Trim();
-        bool negative = trimmed.StartsWith('-');
-
-        StringBuilder digits = new StringBuilder(trimmed.Length);
-        foreach (char c in trimmed)
-        {
-            if (char.IsDigit(c) || c == '.' || c == ',')
-            {
-                digits.Append(c);
-            }
-        }
-
-        string cleaned = digits.ToString();
-        int lastDot = cleaned.LastIndexOf('.');
-        int lastComma = cleaned.LastIndexOf(',');
-        if (lastComma > lastDot)
-        {
-            cleaned = cleaned.Replace(".", string.Empty).Replace(",", ".");
-        }
-        else if (lastDot > lastComma)
-        {
-            string trailing = cleaned[(lastDot + 1) ..];
-            if (trailing.Length == 3 && lastDot > 0)
-            {
-                cleaned = cleaned.Replace(".", string.Empty);
-            }
-            else
-            {
-                cleaned = cleaned.Replace(",", string.Empty);
-            }
-        }
-
-        if (negative)
-        {
-            cleaned = "-" + cleaned;
-        }
-
-        return decimal.Parse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture);
-    }
-
     public async Task<(IEnumerable<Transaction> Transactions, IEnumerable<AssetTransaction> AssetTransactions, IEnumerable<OptionTransaction> OptionTransactions)> ParseAllAsync(
         string filePath,
         CancellationToken cancellationToken = default)

--- a/src/MyAccountingApp.Core/Imports/Common/CsvParsing.cs
+++ b/src/MyAccountingApp.Core/Imports/Common/CsvParsing.cs
@@ -1,0 +1,48 @@
+namespace MyAccountingApp.Core.Imports.Common;
+using System.Globalization;
+using System.Text;
+
+public static class CsvParsing
+{
+    public static decimal ParseEuropeanDecimal(string value)
+    {
+        string trimmed = value.Trim();
+        bool negative = trimmed.StartsWith('-');
+
+        StringBuilder digits = new StringBuilder(trimmed.Length);
+        foreach (char c in trimmed)
+        {
+            if (char.IsDigit(c) || c == '.' || c == ',')
+            {
+                digits.Append(c);
+            }
+        }
+
+        string cleaned = digits.ToString();
+        int lastDot = cleaned.LastIndexOf('.');
+        int lastComma = cleaned.LastIndexOf(',');
+        if (lastComma > lastDot)
+        {
+            cleaned = cleaned.Replace(".", string.Empty).Replace(",", ".");
+        }
+        else if (lastDot > lastComma)
+        {
+            string trailing = cleaned[(lastDot + 1) ..];
+            if (trailing.Length == 3 && lastDot > 0)
+            {
+                cleaned = cleaned.Replace(".", string.Empty);
+            }
+            else
+            {
+                cleaned = cleaned.Replace(",", string.Empty);
+            }
+        }
+
+        if (negative)
+        {
+            cleaned = "-" + cleaned;
+        }
+
+        return decimal.Parse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture);
+    }
+}

--- a/src/MyAccountingApp.Core/Imports/Degiro/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/Degiro/DegiroImportService.cs
@@ -42,7 +42,7 @@ public class DegiroImportService : IBrokerImportService
                 DateTime date = ParseDate(fields[0]);
                 string description = fields[5];
                 string currency = NormalizeCurrency(fields[7], fields[9]);
-                decimal amount = ParseEuropeanDecimal(fields[8]);
+                decimal amount = CsvParsing.ParseEuropeanDecimal(fields[8]);
 
                 if (string.IsNullOrWhiteSpace(description) || amount == 0)
                 {
@@ -88,12 +88,6 @@ public class DegiroImportService : IBrokerImportService
         }
 
         return DateTime.Parse(value, CultureInfo.InvariantCulture);
-    }
-
-    private static decimal ParseEuropeanDecimal(string value)
-    {
-        string cleaned = value.Replace(".", string.Empty).Replace(",", ".");
-        return decimal.Parse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture);
     }
 
     private static string NormalizeCurrency(string variationCurrency, string balanceCurrency)

--- a/src/MyAccountingApp.Core/Imports/Degiro/DegiroTransactionImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/Degiro/DegiroTransactionImportService.cs
@@ -45,7 +45,7 @@ public partial class DegiroTransactionImportService : IBrokerImportService
                 string exchange = fields[4];
 
                 int rawQuantity = int.Parse(fields[6], NumberStyles.Any, CultureInfo.InvariantCulture);
-                decimal amount = ParseEuropeanDecimal(fields[9]);
+                decimal amount = CsvParsing.ParseEuropeanDecimal(fields[9]);
                 string currency = NormalizeCurrency(fields[8]);
 
                 if (rawQuantity == 0 || amount == 0)
@@ -101,12 +101,6 @@ public partial class DegiroTransactionImportService : IBrokerImportService
         }
 
         return DateTime.Parse(value, CultureInfo.InvariantCulture);
-    }
-
-    private static decimal ParseEuropeanDecimal(string value)
-    {
-        string cleaned = value.Replace(".", string.Empty).Replace(",", ".");
-        return decimal.Parse(cleaned, NumberStyles.Any, CultureInfo.InvariantCulture);
     }
 
     private static string NormalizeCurrency(string value)

--- a/src/MyAccountingApp.Core/Imports/MyInvestor/MyInvestorAccountImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/MyInvestor/MyInvestorAccountImportService.cs
@@ -45,7 +45,7 @@ public class MyInvestorAccountImportService : IBrokerImportService
 
                 DateTime date = ParseDate(fields[0]);
                 string concepto = fields[2];
-                decimal amount = BankCsvImportService.ParseEuropeanDecimal(fields[3]);
+                decimal amount = CsvParsing.ParseEuropeanDecimal(fields[3]);
                 string currency = fields[4];
 
                 if (amount == 0)

--- a/src/MyAccountingApp.Core/Imports/MyInvestor/MyInvestorFundImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/MyInvestor/MyInvestorFundImportService.cs
@@ -51,7 +51,7 @@ public class MyInvestorFundImportService : IBrokerImportService
 
                 DateTime date = ParseDate(fields[0]);
                 (decimal amount, string currency) = ParseAmount(fields[2]);
-                decimal quantity = BankCsvImportService.ParseEuropeanDecimal(fields[3]);
+                decimal quantity = CsvParsing.ParseEuropeanDecimal(fields[3]);
 
                 if (amount <= 0 || quantity <= 0)
                 {
@@ -92,7 +92,7 @@ public class MyInvestorFundImportService : IBrokerImportService
     {
         string[] parts = value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         string currency = parts.Length > 1 ? parts[^1].ToUpperInvariant() : "EUR";
-        decimal amount = BankCsvImportService.ParseEuropeanDecimal(value);
+        decimal amount = CsvParsing.ParseEuropeanDecimal(value);
         return (amount, currency);
     }
 }

--- a/src/MyAccountingApp.Core/Imports/SelfBank/SelfBankFundImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/SelfBank/SelfBankFundImportService.cs
@@ -59,8 +59,8 @@ public class SelfBankFundImportService : IBrokerImportService
                 }
 
                 DateTime date = ParseDate(fields[0]);
-                decimal quantity = BankCsvImportService.ParseEuropeanDecimal(fields[4]);
-                decimal amount = Math.Abs(BankCsvImportService.ParseEuropeanDecimal(fields[6]));
+                decimal quantity = CsvParsing.ParseEuropeanDecimal(fields[4]);
+                decimal amount = Math.Abs(CsvParsing.ParseEuropeanDecimal(fields[6]));
 
                 if (quantity <= 0 || amount <= 0)
                 {


### PR DESCRIPTION
## Summary

Centralizes the duplicated `ParseEuropeanDecimal` logic into a single shared helper.

### Changes

- Add `CsvParsing.ParseEuropeanDecimal` static helper in `Core/Imports/Common` (robust version: handles negative sign, unquoted comma splits, and thousands/decimal disambiguation with 3-digit trailing rule).
- Remove the public `BankCsvImportService.ParseEuropeanDecimal` and point its callers (SelfBank, MyInvestor fund/account) to `CsvParsing`.
- Delete private copies in `CobasImportService`, `DegiroImportService` and `DegiroTransactionImportService` (the naive dot-strip variant) and point them to the shared helper.

No behavior change for real bank files: Cobas already filters non-digit characters and skips non-positive amounts; Degiro data uses comma decimals which the shared parser handles identically.

### Testing

- Full suite green: 401 tests (App 91, Domain 40, Core 223, Api 47).