### PR TITLE
fix(web): harden symbol query param and bulk-edit UX

### DIFF
--- a/src/MyAccountingApp.Application/Services/AssetTransactionCommandService.cs
+++ b/src/MyAccountingApp.Application/Services/AssetTransactionCommandService.cs
@@ -16,11 +16,12 @@ public sealed class AssetTransactionCommandService : IAssetTransactionCommandSer
 
     public BatchPatchResult PatchMany(IReadOnlyList<Guid> ids, AssetTransactionPatch patch)
     {
+        List<Guid> distinctIds = ids.Distinct().ToList();
         List<AssetTransaction> all = this._repository.GetAllTransactions().ToList();
         List<BatchPatchFailure> failures = new();
         int updated = 0;
 
-        foreach (Guid id in ids)
+        foreach (Guid id in distinctIds)
         {
             AssetTransaction? target = all.FirstOrDefault(t => t.Transaction.Id == id);
             if (target is null)
@@ -33,10 +34,13 @@ public sealed class AssetTransactionCommandService : IAssetTransactionCommandSer
             {
                 if (patch.Symbol is not null)
                 {
+                    string before = target.Symbol;
                     target.UpdateSymbol(patch.Symbol);
+                    if (!string.Equals(before, target.Symbol, StringComparison.Ordinal))
+                    {
+                        updated++;
+                    }
                 }
-
-                updated++;
             }
             catch (ArgumentException ex)
             {
@@ -49,6 +53,6 @@ public sealed class AssetTransactionCommandService : IAssetTransactionCommandSer
             this._repository.Initialize(all);
         }
 
-        return new BatchPatchResult(ids.Count, updated, failures);
+        return new BatchPatchResult(distinctIds.Count, updated, failures);
     }
 }

--- a/src/MyAccountingApp.Application/Services/OptionTransactionCommandService.cs
+++ b/src/MyAccountingApp.Application/Services/OptionTransactionCommandService.cs
@@ -16,11 +16,12 @@ public sealed class OptionTransactionCommandService : IOptionTransactionCommandS
 
     public BatchPatchResult PatchMany(IReadOnlyList<Guid> ids, OptionTransactionPatch patch)
     {
+        List<Guid> distinctIds = ids.Distinct().ToList();
         List<OptionTransaction> all = this._repository.GetAll().ToList();
         List<BatchPatchFailure> failures = new();
         int updated = 0;
 
-        foreach (Guid id in ids)
+        foreach (Guid id in distinctIds)
         {
             OptionTransaction? target = all.FirstOrDefault(t => t.Transaction.Id == id);
             if (target is null)
@@ -33,10 +34,13 @@ public sealed class OptionTransactionCommandService : IOptionTransactionCommandS
             {
                 if (patch.Symbol is not null)
                 {
+                    string before = target.Symbol;
                     target.UpdateSymbol(patch.Symbol);
+                    if (!string.Equals(before, target.Symbol, StringComparison.Ordinal))
+                    {
+                        updated++;
+                    }
                 }
-
-                updated++;
             }
             catch (ArgumentException ex)
             {
@@ -49,6 +53,6 @@ public sealed class OptionTransactionCommandService : IOptionTransactionCommandS
             this._repository.Initialize(all);
         }
 
-        return new BatchPatchResult(ids.Count, updated, failures);
+        return new BatchPatchResult(distinctIds.Count, updated, failures);
     }
 }

--- a/src/MyAccountingApp.Application/Services/TransactionCommandService.cs
+++ b/src/MyAccountingApp.Application/Services/TransactionCommandService.cs
@@ -17,11 +17,12 @@ public sealed class TransactionCommandService : ITransactionCommandService
 
     public BatchPatchResult PatchMany(IReadOnlyList<Guid> ids, TransactionPatch patch)
     {
+        List<Guid> distinctIds = ids.Distinct().ToList();
         List<Transaction> all = this._repository.GetAll().ToList();
         List<BatchPatchFailure> failures = new();
         int updated = 0;
 
-        foreach (Guid id in ids)
+        foreach (Guid id in distinctIds)
         {
             Transaction? target = all.FirstOrDefault(t => t.Id == id);
             if (target is null)
@@ -40,10 +41,13 @@ public sealed class TransactionCommandService : ITransactionCommandService
                         throw new ArgumentException($"Invalid category '{patch.Category}'.");
                     }
 
+                    TransactionCategory before = target.Category;
                     target.UpdateCategory(category);
+                    if (before != target.Category)
+                    {
+                        updated++;
+                    }
                 }
-
-                updated++;
             }
             catch (ArgumentException ex)
             {
@@ -56,6 +60,6 @@ public sealed class TransactionCommandService : ITransactionCommandService
             this._repository.Initialize(all);
         }
 
-        return new BatchPatchResult(ids.Count, updated, failures);
+        return new BatchPatchResult(distinctIds.Count, updated, failures);
     }
 }

--- a/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
+++ b/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
@@ -249,23 +249,17 @@ else
     private string _formCategory = "EXPENSE";
     private string _formType = "Buy";
 
+    [SupplyParameterFromQuery(Name = "symbol")]
+    public string? SymbolFromQuery { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
-        string? symbol = GetQueryParam("symbol");
-        if (!string.IsNullOrWhiteSpace(symbol))
+        if (!string.IsNullOrWhiteSpace(SymbolFromQuery))
         {
-            _selectedSymbol = symbol;
+            _selectedSymbol = SymbolFromQuery;
         }
 
         await LoadDataAsync();
-    }
-
-    private string? GetQueryParam(string key)
-    {
-        string query = Navigation.ToAbsoluteUri(Navigation.Uri).Query;
-        string prefix = key + "=";
-        int index = query.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
-        return index < 0 ? null : Uri.UnescapeDataString(query[(index + prefix.Length)..]);
     }
 
     private async Task LoadDataAsync()
@@ -285,6 +279,7 @@ else
                 .OrderBy(s => s)
                 .ToList();
             ApplyFilters();
+            _selected.Clear();
         }
         finally
         {
@@ -306,6 +301,7 @@ else
             query = query.Where(t => t.Type == _selectedType);
 
         _filteredTransactions = query.OrderByDescending(t => t.Transaction.Date).ToList();
+        _selected.RemoveWhere(item => !_filteredTransactions.Contains(item));
     }
 
     private void OpenCreateDialog()
@@ -390,6 +386,16 @@ else
         _selected.Clear();
     }
 
+    private static string Trim(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "no details";
+        }
+
+        return value.Length <= 200 ? value : value[..200] + "...";
+    }
+
     private void OpenBulkSymbolDialog()
     {
         _bulkSymbol = "";
@@ -408,15 +414,29 @@ else
             return;
         }
 
+        List<AssetTransactionDto> targets = _selected.Where(s => _filteredTransactions.Contains(s)).ToList();
+        if (targets.Count == 0)
+        {
+            Snackbar.Add("No visible rows selected", Severity.Warning);
+            return;
+        }
+
         var payload = new
         {
-            ids = _selected.Select(t => t.Transaction.Id).ToList(),
+            ids = targets.Select(t => t.Transaction.Id).ToList(),
             patch = new { symbol = _bulkSymbol.Trim() },
         };
 
         try
         {
             HttpResponseMessage response = await Http.PatchAsJsonAsync("/api/asset-transactions/batch", payload);
+            if (!response.IsSuccessStatusCode)
+            {
+                string body = await response.Content.ReadAsStringAsync();
+                Snackbar.Add($"Bulk update failed ({(int)response.StatusCode}): {Trim(body)}", Severity.Error);
+                return;
+            }
+
             BatchPatchResultDto? result = await response.Content.ReadFromJsonAsync<BatchPatchResultDto>();
             _showBulkSymbolDialog = false;
             _selected.Clear();

--- a/src/MyAccountingApp.Web/Pages/Options.razor
+++ b/src/MyAccountingApp.Web/Pages/Options.razor
@@ -283,6 +283,7 @@ else
                 .OrderBy(s => s)
                 .ToList();
             ApplyFilters();
+            _selected.Clear();
         }
         finally
         {
@@ -301,6 +302,7 @@ else
             query = query.Where(t => t.Symbol == _selectedSymbol);
 
         _filteredTransactions = query.OrderByDescending(t => t.Transaction.Date).ToList();
+        _selected.RemoveWhere(item => !_filteredTransactions.Contains(item));
     }
 
     private void OpenEditDialog(OptionTransactionDto tx)
@@ -363,6 +365,16 @@ else
         _selected.Clear();
     }
 
+    private static string Trim(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "no details";
+        }
+
+        return value.Length <= 200 ? value : value[..200] + "...";
+    }
+
     private void OpenBulkSymbolDialog()
     {
         _bulkSymbol = "";
@@ -381,15 +393,29 @@ else
             return;
         }
 
+        List<OptionTransactionDto> targets = _selected.Where(s => _filteredTransactions.Contains(s)).ToList();
+        if (targets.Count == 0)
+        {
+            Snackbar.Add("No visible rows selected", Severity.Warning);
+            return;
+        }
+
         var payload = new
         {
-            ids = _selected.Select(t => t.Transaction.Id).ToList(),
+            ids = targets.Select(t => t.Transaction.Id).ToList(),
             patch = new { symbol = _bulkSymbol.Trim() },
         };
 
         try
         {
             HttpResponseMessage response = await Http.PatchAsJsonAsync("/api/option-transactions/batch", payload);
+            if (!response.IsSuccessStatusCode)
+            {
+                string body = await response.Content.ReadAsStringAsync();
+                Snackbar.Add($"Bulk update failed ({(int)response.StatusCode}): {Trim(body)}", Severity.Error);
+                return;
+            }
+
             BatchPatchResultDto? result = await response.Content.ReadFromJsonAsync<BatchPatchResultDto>();
             _showBulkSymbolDialog = false;
             _selected.Clear();

--- a/src/MyAccountingApp.Web/Pages/Transactions.razor
+++ b/src/MyAccountingApp.Web/Pages/Transactions.razor
@@ -293,7 +293,8 @@ else
                 .Distinct()
                 .OrderByDescending(y => y)
                 .ToList();
-            ApplyFilters();
+ApplyFilters();
+            _selected.Clear();
         }
         finally
         {
@@ -328,6 +329,7 @@ else
 
         _filteredTransactions = query.OrderByDescending(t => t.Date).ToList();
         RebuildFilterSummaries();
+        _selected.RemoveWhere(item => !_filteredTransactions.Contains(item));
     }
 
     private void RebuildFilterSummaries()
@@ -450,6 +452,16 @@ else
         _selected.Clear();
     }
 
+    private static string Trim(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "no details";
+        }
+
+        return value.Length <= 200 ? value : value[..200] + "...";
+    }
+
     private void OpenBulkCategoryDialog()
     {
         _bulkCategory = "";
@@ -468,15 +480,29 @@ else
             return;
         }
 
+        List<TransactionDto> targets = _selected.Where(s => _filteredTransactions.Contains(s)).ToList();
+        if (targets.Count == 0)
+        {
+            Snackbar.Add("No visible rows selected", Severity.Warning);
+            return;
+        }
+
         var payload = new
         {
-            ids = _selected.Select(t => t.Id).ToList(),
+            ids = targets.Select(t => t.Id).ToList(),
             patch = new { category = _bulkCategory },
         };
 
         try
         {
             HttpResponseMessage response = await Http.PatchAsJsonAsync("/api/transactions/batch", payload);
+            if (!response.IsSuccessStatusCode)
+            {
+                string body = await response.Content.ReadAsStringAsync();
+                Snackbar.Add($"Bulk update failed ({(int)response.StatusCode}): {Trim(body)}", Severity.Error);
+                return;
+            }
+
             BatchPatchResultDto? result = await response.Content.ReadFromJsonAsync<BatchPatchResultDto>();
             _showBulkCategoryDialog = false;
             _selected.Clear();

--- a/tests/MyAccountingApp.Application.Tests/Services/AssetTransactionCommandServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/AssetTransactionCommandServiceTests.cs
@@ -72,6 +72,42 @@ public class AssetTransactionCommandServiceTests
     }
 
     [Fact]
+    public void PatchMany_ShouldNotCountUnchangedSymbol_AsUpdated()
+    {
+        FakePfRepo repo = new();
+        AssetTransaction existing = CreateAsset("AAPL");
+        repo.AddOrUpdate(existing);
+        AssetTransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { existing.Transaction.Id },
+            new AssetTransactionPatch("AAPL"));
+
+        Assert.Equal(1, result.Requested);
+        Assert.Equal(0, result.Updated);
+        Assert.Empty(result.Failures);
+        Assert.Equal("AAPL", repo.GetAllTransactions().Single().Symbol);
+    }
+
+    [Fact]
+    public void PatchMany_ShouldCountDuplicateIdsOnce()
+    {
+        FakePfRepo repo = new();
+        AssetTransaction existing = CreateAsset("AAPL");
+        repo.AddOrUpdate(existing);
+        AssetTransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { existing.Transaction.Id, existing.Transaction.Id },
+            new AssetTransactionPatch("TSLA"));
+
+        Assert.Equal(1, result.Requested);
+        Assert.Equal(1, result.Updated);
+        Assert.Empty(result.Failures);
+        Assert.Equal("TSLA", repo.GetAllTransactions().Single().Symbol);
+    }
+
+    [Fact]
     public void PatchMany_ShouldReportAllMissingIds_WhenNoneExist()
     {
         FakePfRepo repo = new();

--- a/tests/MyAccountingApp.Application.Tests/Services/OptionTransactionCommandServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/OptionTransactionCommandServiceTests.cs
@@ -69,6 +69,42 @@ public class OptionTransactionCommandServiceTests
         Assert.All(result.Failures, failure => Assert.Contains("cannot be null or empty", failure.Error));
     }
 
+    [Fact]
+    public void PatchMany_ShouldNotCountUnchangedSymbol_AsUpdated()
+    {
+        FakeOptionRepo repo = new();
+        OptionTransaction existing = CreateOption("AAPL");
+        repo.Add(existing);
+        OptionTransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { existing.Transaction.Id },
+            new OptionTransactionPatch("AAPL"));
+
+        Assert.Equal(1, result.Requested);
+        Assert.Equal(0, result.Updated);
+        Assert.Empty(result.Failures);
+        Assert.Equal("AAPL", repo.GetAll().Single().Symbol);
+    }
+
+    [Fact]
+    public void PatchMany_ShouldCountDuplicateIdsOnce()
+    {
+        FakeOptionRepo repo = new();
+        OptionTransaction existing = CreateOption("AAPL");
+        repo.Add(existing);
+        OptionTransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { existing.Transaction.Id, existing.Transaction.Id },
+            new OptionTransactionPatch("TSLA"));
+
+        Assert.Equal(1, result.Requested);
+        Assert.Equal(1, result.Updated);
+        Assert.Empty(result.Failures);
+        Assert.Equal("TSLA", repo.GetAll().Single().Symbol);
+    }
+
     private static OptionTransaction CreateOption(string symbol)
     {
         Transaction transaction = new(

--- a/tests/MyAccountingApp.Application.Tests/Services/TransactionCommandServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/TransactionCommandServiceTests.cs
@@ -85,6 +85,42 @@ public class TransactionCommandServiceTests
         Assert.Equal(TransactionCategory.EXPENSE, repo.GetAll().Single().Category);
     }
 
+    [Fact]
+    public void PatchMany_ShouldNotCountUnchangedCategory_AsUpdated()
+    {
+        FakeTxRepo repo = new();
+        Transaction existing = CreateTransaction();
+        repo.Add(existing);
+        TransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { existing.Id },
+            new TransactionPatch("EXPENSE"));
+
+        Assert.Equal(1, result.Requested);
+        Assert.Equal(0, result.Updated);
+        Assert.Empty(result.Failures);
+        Assert.Equal(TransactionCategory.EXPENSE, repo.GetAll().Single().Category);
+    }
+
+    [Fact]
+    public void PatchMany_ShouldCountDuplicateIdsOnce()
+    {
+        FakeTxRepo repo = new();
+        Transaction existing = CreateTransaction();
+        repo.Add(existing);
+        TransactionCommandService service = new(repo);
+
+        BatchPatchResult result = service.PatchMany(
+            new[] { existing.Id, existing.Id },
+            new TransactionPatch("TRANSFER"));
+
+        Assert.Equal(1, result.Requested);
+        Assert.Equal(1, result.Updated);
+        Assert.Empty(result.Failures);
+        Assert.Equal(TransactionCategory.TRANSFER, repo.GetAll().Single().Category);
+    }
+
     private static Transaction CreateTransaction()
     {
         return new Transaction(


### PR DESCRIPTION
## Summary

Fixes from the post-#117–#122 code review (`pla_fix_post_bulk_ui_MyAccountingApp.md`): F1, F2 and optional F3.

- **F1 — query symbol:** replace the manual `GetQueryParam` string parser in `AssetTransactions.razor` with the framework `[SupplyParameterFromQuery(Name = "symbol")]`. `/asset-transactions?symbol=FOO&x=1` now filters as `FOO` only (the old parser swallowed `&x=1` into the value).
- **F2 — bulk UX:**
  - HTTP status is checked before deserializing the batch result on all 3 pages (`AssetTransactions`, `Options`, `Transactions`); failures show `Bulk update failed (status): <detail trimmed to 200 chars>` and keep the dialog open.
  - Selection is scoped to visible rows: filters prune non-visible items from `_selected` and reloads clear the selection (DTO instances are replaced).
  - Defensive `targets` computed before PATCH only from rows still in `_filteredTransactions`; empty → warning snackbar "No visible rows selected" and no request.
- **F3 — accurate feedback:** the three `PatchMany` command services dedupe ids (`Requested` = distinct count) and count rows only when the patched field actually changes (same symbol/category → `Updated: 0`).

## Acceptance checklist

- [x] `/asset-transactions?symbol=X&y=1` filters as `X` only (F1)
- [x] Portfolio → movements icon navigation unaffected (F1 — no markup change)
- [x] Bulk symbol/category success path (F2 — same payload shape)
- [x] Bulk failure shows status error without unhandled client exception (F2)
- [x] Changing filters drops non-visible selection; reload clears selection (F2)
- [x] Same-value patch → `Updated: 0`; duplicate ids → counted once (F3, 6 new unit tests)
- [x] `dotnet build` 0 warnings / 0 errors (`-warnaserror`)
- [x] Full test suite green: 407 (App 97, Domain 40, Core 223, Api 47)