### PR TITLE
feat(api): dashboard query and endpoint

### DIFF
--- a/src/MyAccountingApp.Api/DependencyInjection.cs
+++ b/src/MyAccountingApp.Api/DependencyInjection.cs
@@ -170,6 +170,7 @@ public static class DependencyInjection
         builder.Services.AddSingleton<IPositionEngine, PositionEngine>();
         builder.Services.AddSingleton<IValidationQuery, ValidationQuery>();
         builder.Services.AddSingleton<IAnnualSummaryService, AnnualSummaryService>();
+        builder.Services.AddSingleton<IDashboardQuery, DashboardQuery>();
         builder.Services.AddSingleton(currencyOptions);
         builder.Services.AddHostedService<CurrencyStartupSync>();
 

--- a/src/MyAccountingApp.Api/Endpoints/ApiEndpoints.cs
+++ b/src/MyAccountingApp.Api/Endpoints/ApiEndpoints.cs
@@ -15,5 +15,6 @@ public static class ApiEndpoints
         app.MapPortfolioEndpoints();
         app.MapConversionEndpoints();
         app.MapBackupEndpoints();
+        app.MapDashboardEndpoints();
     }
 }

--- a/src/MyAccountingApp.Api/Endpoints/DashboardEndpoints.cs
+++ b/src/MyAccountingApp.Api/Endpoints/DashboardEndpoints.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Builder;
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Interfaces;
+
+namespace MyAccountingApp.Api.Endpoints;
+
+public static class DashboardEndpoints
+{
+    public static void MapDashboardEndpoints(this WebApplication app)
+    {
+        const string prefix = ApiEndpoints.ApiPrefix;
+
+        app.MapGet($"{prefix}/dashboard", async (DateOnly? asOf, IDashboardQuery dashboardQuery) =>
+        {
+            DateOnly date = asOf ?? DateOnly.FromDateTime(DateTime.Today);
+            DashboardDto dashboard = await dashboardQuery.GetAsync(date);
+            return Results.Ok(dashboard);
+        });
+    }
+}

--- a/src/MyAccountingApp.Application/DTOs/DashboardDto.cs
+++ b/src/MyAccountingApp.Application/DTOs/DashboardDto.cs
@@ -1,0 +1,32 @@
+namespace MyAccountingApp.Application.DTOs;
+
+public sealed record DashboardDto(
+    DateOnly AsOf,
+    CashSnapshotDto Cash,
+    PortfolioSnapshotDto Portfolio,
+    IReadOnlyList<DashboardAlertDto> Alerts);
+
+public sealed record CashSnapshotDto(
+    decimal IncomeMtd,
+    decimal ExpenseMtd,
+    decimal NetCashFlowMtd,
+    decimal IncomeYtd,
+    decimal ExpenseYtd,
+    decimal NetCashFlowYtd,
+    decimal TransfersYtd,
+    decimal DepositsYtd);
+
+public sealed record PortfolioSnapshotDto(
+    decimal TotalCostBasisEur,
+    decimal? TotalMarketValueEur,
+    decimal? TotalUnrealizedEur,
+    decimal RealizedGainLossYtdEur,
+    int OpenPositionCount,
+    int SymbolCount,
+    int SymbolsWithoutPrice);
+
+public sealed record DashboardAlertDto(
+    string Severity,
+    string Code,
+    string Message,
+    string? Link);

--- a/src/MyAccountingApp.Application/Interfaces/IDashboardQuery.cs
+++ b/src/MyAccountingApp.Application/Interfaces/IDashboardQuery.cs
@@ -1,0 +1,8 @@
+using MyAccountingApp.Application.DTOs;
+
+namespace MyAccountingApp.Application.Interfaces;
+
+public interface IDashboardQuery
+{
+    Task<DashboardDto> GetAsync(DateOnly asOf);
+}

--- a/src/MyAccountingApp.Application/Services/DashboardQuery.cs
+++ b/src/MyAccountingApp.Application/Services/DashboardQuery.cs
@@ -1,0 +1,170 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+
+namespace MyAccountingApp.Application.Services;
+
+public class DashboardQuery : IDashboardQuery
+{
+    private const string Eur = "EUR";
+
+    private readonly ITransactionRepository _transactionRepo;
+    private readonly IPortfolioRepository _portfolioRepo;
+    private readonly IValidationQuery _validationQuery;
+
+    public DashboardQuery(
+        ITransactionRepository transactionRepo,
+        IPortfolioRepository portfolioRepo,
+        IValidationQuery validationQuery)
+    {
+        this._transactionRepo = transactionRepo;
+        this._portfolioRepo = portfolioRepo;
+        this._validationQuery = validationQuery;
+    }
+
+    public Task<DashboardDto> GetAsync(DateOnly asOf)
+    {
+        List<Transaction> allTransactions = this._transactionRepo.GetAll().ToList();
+        List<AssetTransaction> allAssetTransactions = this._portfolioRepo.GetAllTransactions().ToList();
+
+        CashSnapshotDto cash = BuildCashSnapshot(allTransactions, asOf);
+        PortfolioSnapshotDto portfolio = BuildPortfolioSnapshot(allAssetTransactions, asOf.Year);
+        List<DashboardAlertDto> alerts = BuildAlerts(allTransactions, allAssetTransactions);
+
+        return Task.FromResult(new DashboardDto(asOf, cash, portfolio, alerts));
+    }
+
+    private static CashSnapshotDto BuildCashSnapshot(List<Transaction> allTransactions, DateOnly asOf)
+    {
+        DateTime end = asOf.ToDateTime(new TimeOnly(23, 59, 59));
+        DateTime yearStart = new DateTime(asOf.Year, 1, 1);
+        DateTime monthStart = new DateTime(asOf.Year, asOf.Month, 1);
+
+        decimal SumCategory(List<Transaction> txs, TransactionCategory category) =>
+            txs.Where(t => t.Category == category).Sum(t => t.Money.Amount);
+
+        List<Transaction> ytd = allTransactions.Where(t => t.Date >= yearStart && t.Date <= end).ToList();
+        List<Transaction> mtd = allTransactions.Where(t => t.Date >= monthStart && t.Date <= end).ToList();
+
+        decimal incomeYtd = SumCategory(ytd, TransactionCategory.INCOME);
+        decimal expenseYtd = SumCategory(ytd, TransactionCategory.EXPENSE);
+        decimal transfersYtd = SumCategory(ytd, TransactionCategory.TRANSFER);
+        decimal depositsYtd = SumCategory(ytd, TransactionCategory.DEPOSIT);
+        decimal incomeMtd = SumCategory(mtd, TransactionCategory.INCOME);
+        decimal expenseMtd = SumCategory(mtd, TransactionCategory.EXPENSE);
+
+        return new CashSnapshotDto(
+            Math.Round(incomeMtd, 2),
+            Math.Round(expenseMtd, 2),
+            Math.Round(incomeMtd - expenseMtd, 2),
+            Math.Round(incomeYtd, 2),
+            Math.Round(expenseYtd, 2),
+            Math.Round(incomeYtd - expenseYtd, 2),
+            Math.Round(transfersYtd, 2),
+            Math.Round(depositsYtd, 2));
+    }
+
+    private static PortfolioSnapshotDto BuildPortfolioSnapshot(List<AssetTransaction> allAssetTransactions, int year)
+    {
+        decimal totalCostBasis = 0;
+        decimal realizedYtd = 0;
+        int openPositionCount = 0;
+        int symbolCount = 0;
+
+        foreach (IGrouping<string, AssetTransaction> symbolGroup in allAssetTransactions.GroupBy(t => t.Symbol))
+        {
+            symbolCount++;
+
+            List<AssetTransaction> ordered = symbolGroup.OrderBy(t => t.Transaction.Date).ToList();
+            (decimal costBasis, decimal realized) = ComputeFifo(ordered, year);
+            totalCostBasis += costBasis;
+            realizedYtd += realized;
+
+            if (ordered.Sum(t => t.Type == AssetTransactionType.Buy ? t.Quantity : -t.Quantity) > 0)
+            {
+                openPositionCount++;
+            }
+        }
+
+        return new PortfolioSnapshotDto(
+            Math.Round(totalCostBasis, 2),
+            null,
+            null,
+            Math.Round(realizedYtd, 2),
+            openPositionCount,
+            symbolCount,
+            0);
+    }
+
+    private static (decimal CostBasis, decimal Realized) ComputeFifo(List<AssetTransaction> ordered, int year)
+    {
+        List<FifoLot> lots = new();
+        decimal realized = 0;
+
+        foreach (AssetTransaction tx in ordered)
+        {
+            if (tx.Type == AssetTransactionType.Buy)
+            {
+                lots.Add(new FifoLot(tx.Quantity, tx.Transaction.Money.Amount));
+            }
+            else
+            {
+                decimal sellQty = tx.Quantity;
+                decimal matchedCostBasis = 0;
+
+                foreach (FifoLot lot in lots.Where(l => l.RemainingQuantity > 0))
+                {
+                    if (sellQty <= 0)
+                    {
+                        break;
+                    }
+
+                    decimal consumed = Math.Min(sellQty, lot.RemainingQuantity);
+                    matchedCostBasis += consumed * lot.UnitaryCost;
+                    decimal proceeds = (consumed / tx.Quantity) * tx.Transaction.Money.Amount;
+                    realized += tx.Transaction.Date.Year == year
+                        ? (proceeds - (consumed * lot.UnitaryCost))
+                        : 0;
+                    lot.RemainingQuantity -= consumed;
+                    sellQty -= consumed;
+                }
+            }
+        }
+
+        decimal costBasis = lots.Where(l => l.RemainingQuantity > 0).Sum(l => l.RemainingQuantity * l.UnitaryCost);
+        return (costBasis, realized);
+    }
+
+    private static List<DashboardAlertDto> BuildAlerts(List<Transaction> allTransactions, List<AssetTransaction> allAssetTransactions)
+    {
+        List<DashboardAlertDto> alerts = new();
+
+        if (allTransactions.Any(t => t.Money.Currency != Eur) || allAssetTransactions.Any(t => t.Transaction.Money.Currency != Eur))
+        {
+            alerts.Add(new DashboardAlertDto(
+                "warning",
+                "UNCONVERTED_CURRENCY",
+                "Some movements are not in EUR and are excluded from the totals above.",
+                "/conversions"));
+        }
+
+        return alerts;
+    }
+
+    private sealed class FifoLot
+    {
+        public decimal TotalQuantity { get; }
+        public decimal TotalCost { get; }
+        public decimal UnitaryCost => this.TotalCost / this.TotalQuantity;
+        public decimal RemainingQuantity { get; set; }
+
+        public FifoLot(decimal quantity, decimal totalCost)
+        {
+            this.TotalQuantity = quantity;
+            this.TotalCost = totalCost;
+            this.RemainingQuantity = quantity;
+        }
+    }
+}

--- a/tests/MyAccountingApp.Api.Tests/DashboardEndpointsTests.cs
+++ b/tests/MyAccountingApp.Api.Tests/DashboardEndpointsTests.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace MyAccountingApp.Api.Tests;
+
+public class DashboardEndpointsTests
+{
+    [Fact]
+    public async Task Dashboard_ShouldReturnCashAndPortfolioSnapshot()
+    {
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+
+        await client.PostAsJsonAsync("/api/transactions", new
+        {
+            date = new DateTime(2026, 1, 10),
+            description = "Salary",
+            amount = 1000m,
+            currency = "EUR",
+            category = "INCOME",
+        });
+        await client.PostAsJsonAsync("/api/transactions", new
+        {
+            date = new DateTime(2026, 8, 1),
+            description = "Groceries",
+            amount = 100m,
+            currency = "EUR",
+            category = "EXPENSE",
+        });
+        await client.PostAsJsonAsync("/api/asset-transactions", new
+        {
+            date = new DateTime(2026, 1, 5),
+            description = "Buy AAPL",
+            amount = 200m,
+            currency = "EUR",
+            category = "EXPENSE",
+            symbol = "AAPL",
+            quantity = 2m,
+            type = "Buy",
+        });
+
+        HttpResponseMessage response = await client.GetAsync("/api/dashboard?asOf=2026-08-11");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement root = document.RootElement;
+
+        Assert.Equal("2026-08-11", root.GetProperty("asOf").GetString());
+        JsonElement cash = root.GetProperty("cash");
+        Assert.Equal(1000, cash.GetProperty("incomeYtd").GetDecimal());
+        Assert.Equal(100, cash.GetProperty("expenseYtd").GetDecimal());
+        Assert.Equal(900, cash.GetProperty("netCashFlowYtd").GetDecimal());
+
+        JsonElement portfolio = root.GetProperty("portfolio");
+        Assert.Equal(200, portfolio.GetProperty("totalCostBasisEur").GetDecimal());
+        Assert.Equal(0, portfolio.GetProperty("realizedGainLossYtdEur").GetDecimal());
+        Assert.Equal(1, portfolio.GetProperty("openPositionCount").GetInt32());
+
+        Assert.Empty(root.GetProperty("alerts").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task Dashboard_ShouldDefaultToToday_AndReturnOk()
+    {
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/dashboard");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.NotNull(document.RootElement.GetProperty("asOf").GetString());
+        Assert.Equal(0, document.RootElement.GetProperty("cash").GetProperty("incomeYtd").GetDecimal());
+    }
+}

--- a/tests/MyAccountingApp.Application.Tests/Services/DashboardQueryTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/DashboardQueryTests.cs
@@ -1,0 +1,106 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class DashboardQueryTests
+{
+    private static readonly DateOnly AsOf = new(2026, 8, 11);
+
+    [Fact]
+    public async Task GetAsync_ShouldComputeCashYtdAndMtd()
+    {
+        FakeTxRepo txRepo = new();
+        txRepo.Add(new Transaction(new DateTime(2026, 1, 10), "Salary", new Money(1000, "EUR"), TransactionCategory.INCOME));
+        txRepo.Add(new Transaction(new DateTime(2026, 1, 15), "Rent", new Money(400, "EUR"), TransactionCategory.EXPENSE));
+        txRepo.Add(new Transaction(new DateTime(2026, 1, 20), "Transfer", new Money(200, "EUR"), TransactionCategory.TRANSFER));
+        txRepo.Add(new Transaction(new DateTime(2026, 8, 1), "Bonus", new Money(500, "EUR"), TransactionCategory.INCOME));
+        txRepo.Add(new Transaction(new DateTime(2026, 8, 5), "Groceries", new Money(100, "EUR"), TransactionCategory.EXPENSE));
+        txRepo.Add(new Transaction(new DateTime(2025, 12, 30), "Old", new Money(999, "EUR"), TransactionCategory.INCOME));
+        DashboardQuery query = new(txRepo, new FakePfRepo(), new FakeValidationQuery());
+
+        DashboardDto dashboard = await query.GetAsync(AsOf);
+
+        Assert.Equal(1500, dashboard.Cash.IncomeYtd);
+        Assert.Equal(500, dashboard.Cash.ExpenseYtd);
+        Assert.Equal(1000, dashboard.Cash.NetCashFlowYtd);
+        Assert.Equal(200, dashboard.Cash.TransfersYtd);
+        Assert.Equal(0, dashboard.Cash.DepositsYtd);
+        Assert.Equal(500, dashboard.Cash.IncomeMtd);
+        Assert.Equal(100, dashboard.Cash.ExpenseMtd);
+        Assert.Equal(400, dashboard.Cash.NetCashFlowMtd);
+    }
+
+    [Fact]
+    public async Task GetAsync_ShouldComputeFifoPortfolioTotals()
+    {
+        FakePfRepo pfRepo = new();
+        pfRepo.Add(CreateAsset("AAPL", new DateTime(2026, 1, 5), 10, 1000, AssetTransactionType.Buy));
+        pfRepo.Add(CreateAsset("AAPL", new DateTime(2026, 8, 3), 2, 300, AssetTransactionType.Sell));
+        DashboardQuery query = new(new FakeTxRepo(), pfRepo, new FakeValidationQuery());
+
+        DashboardDto dashboard = await query.GetAsync(AsOf);
+
+        Assert.Equal(800, dashboard.Portfolio.TotalCostBasisEur);
+        Assert.Equal(100, dashboard.Portfolio.RealizedGainLossYtdEur);
+        Assert.Equal(1, dashboard.Portfolio.OpenPositionCount);
+        Assert.Equal(1, dashboard.Portfolio.SymbolCount);
+        Assert.Null(dashboard.Portfolio.TotalMarketValueEur);
+    }
+
+    [Fact]
+    public async Task GetAsync_ShouldAlert_WhenNonEurMovementsExist()
+    {
+        FakeTxRepo txRepo = new();
+        txRepo.Add(new Transaction(new DateTime(2026, 1, 10), "USD income", new Money(100, "USD"), TransactionCategory.INCOME));
+        DashboardQuery query = new(txRepo, new FakePfRepo(), new FakeValidationQuery());
+
+        DashboardDto dashboard = await query.GetAsync(AsOf);
+
+        DashboardAlertDto alert = Assert.Single(dashboard.Alerts);
+        Assert.Equal("UNCONVERTED_CURRENCY", alert.Code);
+        Assert.Equal("/conversions", alert.Link);
+    }
+
+    private static AssetTransaction CreateAsset(string symbol, DateTime date, decimal quantity, decimal amount, AssetTransactionType type)
+    {
+        Transaction transaction = new(date, "Test " + symbol, new Money(amount, "EUR"), TransactionCategory.EXPENSE);
+        return new AssetTransaction(transaction, symbol, quantity, type);
+    }
+
+    private sealed class FakeTxRepo : ITransactionRepository
+    {
+        private readonly List<Transaction> _transactions = new();
+
+        public void Add(Transaction transaction) => this._transactions.Add(transaction);
+        public void Initialize(IEnumerable<Transaction> transactions) => this._transactions.Clear();
+        public void AddOrUpdate(Transaction transaction) => this._transactions.Add(transaction);
+        public IEnumerable<Transaction> GetAll() => this._transactions;
+        public bool Delete(Transaction transaction) => this._transactions.Remove(transaction);
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Date.Year == year);
+    }
+
+    private sealed class FakePfRepo : IPortfolioRepository
+    {
+        private readonly List<AssetTransaction> _transactions = new();
+
+        public void Add(AssetTransaction transaction) => this._transactions.Add(transaction);
+        public void AddOrUpdate(AssetTransaction assetTransaction) => this._transactions.Add(assetTransaction);
+        public IEnumerable<AssetTransaction> GetAssetTransactions(string symbol) =>
+            this._transactions.Where(t => t.Symbol == symbol);
+        public IEnumerable<AssetTransaction> GetAllTransactions() => this._transactions;
+        public bool Delete(Guid transactionId) => this._transactions.RemoveAll(t => t.Transaction.Id == transactionId) > 0;
+        public void Initialize(IEnumerable<AssetTransaction> transactions) => this._transactions.Clear();
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
+    }
+
+    private sealed class FakeValidationQuery : IValidationQuery
+    {
+        public ValidationResult ValidateAll() => new ValidationResult(true, new List<ValidationError>(), new List<ValidationError>());
+    }
+}


### PR DESCRIPTION
## Summary

Fase A1 del `pla_visibilitat_comptabilitat_MyAccountingApp.md` — backend del dashboard.

### Changes

- New `DashboardDto` / `CashSnapshotDto` / `PortfolioSnapshotDto` / `DashboardAlertDto` (Application/DTOs).
- New `IDashboardQuery` / `DashboardQuery` service:
  - Cash MTD/YTD: INCOME/EXPENSE/TTRANSFER/DEPOSIT from `ITransactionRepository`, net = income − expense (transfers/deposits reported separately; fase B will formalize the cash vs investments split).
  - Portfolio snapshot **without any market price call** (0 Yahoo): FIFO cost basis of open lots + realized gain/loss YTD per symbol, open position count. `TotalMarketValueEur`/`TotalUnrealizedEur` are `null` in this phase.
  - EUR-only aggregation; non-EUR movements produce a `UNCONVERTED_CURRENCY` alert (warning, link `/conversions`).
- New `GET /api/dashboard?asOf=yyyy-MM-dd` endpoint (defaults to today), registered in DI + ApiEndpoints.

### Test plan

- `DashboardQueryTests`: cash YTD/MTD math, FIFO cost/realized, non-EUR alert (3 unit tests).
- `DashboardEndpointsTests`: roundtrip via API with seeded transactions + asset buy; default `asOf` (2 tests).
- Full suite green: 412 (App 100, Domain 40, Core 223, Api 49).

### Fora d'abast (fases posteriors)

- A2 home UI, A3 summary charts/CSV.
- Market prices (fase C), cash vs investments split (fase B).