### PR TITLE
fix(summary): separate cash ledger from investment flows

### DIFF
--- a/src/MyAccountingApp.Application/DTOs/AnnualSummaryDto.cs
+++ b/src/MyAccountingApp.Application/DTOs/AnnualSummaryDto.cs
@@ -23,4 +23,5 @@ public record AnnualSummaryDto(
     int AssetTransactionCount,
     List<MonthlySummaryDto> Months,
     decimal Transfers,
-    decimal Deposits);
+    decimal Deposits,
+    bool IncludesAssetCashFlows);

--- a/src/MyAccountingApp.Application/Services/AnnualSummaryService.cs
+++ b/src/MyAccountingApp.Application/Services/AnnualSummaryService.cs
@@ -93,7 +93,7 @@ public class AnnualSummaryService : IAnnualSummaryService
             .Where(a => a.Type == AssetTransactionType.Sell)
             .Sum(a => a.Transaction.Money.Amount);
 
-        decimal netCashFlow = income + investmentSales - expenses - investmentPurchases;
+            decimal netCashFlow = income - expenses;
 
         List<MonthlySummaryDto> months = this.BuildMonthlySummaries(year, yearTxs, yearAssetTxs);
 
@@ -108,7 +108,8 @@ public class AnnualSummaryService : IAnnualSummaryService
             yearAssetTxs.Count,
             months,
             Math.Round(transfers, 2),
-            Math.Round(deposits, 2));
+            Math.Round(deposits, 2),
+            IncludesAssetCashFlows: false);
     }
 
     private List<MonthlySummaryDto> BuildMonthlySummaries(
@@ -157,7 +158,7 @@ public class AnnualSummaryService : IAnnualSummaryService
                 .Where(a => a.Type == AssetTransactionType.Sell)
                 .Sum(a => a.Transaction.Money.Amount);
 
-            decimal netCashFlow = income + investmentSales - expenses - investmentPurchases;
+        decimal netCashFlow = income - expenses;
 
             result.Add(new MonthlySummaryDto(
                 month,

--- a/tests/MyAccountingApp.Application.Tests/Services/AnnualSummaryServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/AnnualSummaryServiceTests.cs
@@ -56,11 +56,12 @@ public class AnnualSummaryServiceTests
         Assert.Equal(1000m, result.Income);
         Assert.Equal(300m, result.InvestmentPurchases);
         Assert.Equal(150m, result.InvestmentSales);
-        Assert.Equal(350m, result.NetCashFlow);
+        Assert.Equal(500m, result.NetCashFlow);
         Assert.Equal(2, result.TransactionCount);
         Assert.Equal(2, result.AssetTransactionCount);
         Assert.Equal(0, result.Transfers);
         Assert.Equal(0, result.Deposits);
+        Assert.False(result.IncludesAssetCashFlows);
         Assert.NotEmpty(result.Months);
         MonthlySummaryDto month = Assert.Single(result.Months);
         Assert.Equal(6, month.Month);
@@ -68,7 +69,7 @@ public class AnnualSummaryServiceTests
         Assert.Equal(1000m, month.Income);
         Assert.Equal(300m, month.InvestmentPurchases);
         Assert.Equal(150m, month.InvestmentSales);
-        Assert.Equal(350m, month.NetCashFlow);
+        Assert.Equal(500m, month.NetCashFlow);
         Assert.Equal(0, month.Transfers);
         Assert.Equal(0, month.Deposits);
     }
@@ -133,7 +134,31 @@ public class AnnualSummaryServiceTests
         AnnualSummaryDto? result = svc.GetByYear(2024);
 
         Assert.NotNull(result);
-        Assert.Equal(2800m, result.NetCashFlow);
+        Assert.Equal(3000m, result.NetCashFlow);
+        Assert.Equal(1000m, result.InvestmentPurchases);
+        Assert.Equal(800m, result.InvestmentSales);
+    }
+
+    [Fact]
+    public void NetCashFlow_DoesNotDoubleCountInvestmentOutflows()
+    {
+        Transaction[] txs = new Transaction[]
+        {
+            Tx(2024, 3000, TransactionCategory.INCOME),
+            Tx(2024, 1000, TransactionCategory.EXPENSE),
+        };
+        AssetTransaction[] assets = new AssetTransaction[]
+        {
+            AssetTx(2024, 1000, AssetTransactionType.Buy),
+        };
+        var svc = CreateService(txs, assets);
+
+        AnnualSummaryDto? result = svc.GetByYear(2024);
+
+        Assert.NotNull(result);
+        Assert.Equal(2000m, result.NetCashFlow);
+        Assert.Equal(1000m, result.InvestmentPurchases);
+        Assert.Equal(1000m, result.Expenses);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fase B1 del `pla_visibilitat_comptabilitat_MyAccountingApp.md` — comptabilitat sana: caixa ≠ inversió.

### Model (documentat al SUMMARY)

```text
TRESORERIA (cash ledger)   ← només ITransactionRepository (INCOME/EXPENSE/TRANSFER/DEPOSIT)
CARTERA (investments)      ← AssetTransaction: purchases/sales com a KPIs separats
```

### Changes

- `AnnualSummaryService`: `NetCashFlow` ara és **cash-only** (`income − expenses`). Abans era `income + investmentSales − expenses − investmentPurchases`, que barrejava (i podia duplicar) sortides d'inversió amb despesa de consum — e.g. SelfBank: sortida de caixa al compte **i** buy del fons com a AssetTransaction.
- Els fluxos d'inversió segueixen com a KPIs propis (`InvestmentPurchases` / `InvestmentSales`), fora del net cash flow.
- Nou flag `IncludesAssetCashFlows: false` a `AnnualSummaryDto` (transparència; `DashboardQuery` ja era cash-only).
- `DashboardQuery` ja aplicava la mateixa regla (no canviat).

### Test plan

- `NetCashFlow_IsCorrect` actualitzat: income 5000, expense 2000, buy 1000, sell 800 → net **3000** (abans 2800 barrejat).
- Nou `NetCashFlow_DoesNotDoubleCountInvestmentOutflows`: bank expense 1000 + asset buy 1000 → net 2000, expenses 1000, purchases 1000 (sense doble comptatge).
- `IncludesAssetCashFlows` false verificat.
- Suite verda: 413 (App 101, Domain 40, Core 223, Api 49).

### Fora d'abast

- B2 (UI seccions Cash/Investments), B3 (imports amb category INVESTMENT) — pròxims PRs.