### PR TITLE
feat(web): show cash vs investments sections

### DIFF
--- a/src/MyAccountingApp.Web/Models/AnnualSummaryDto.cs
+++ b/src/MyAccountingApp.Web/Models/AnnualSummaryDto.cs
@@ -34,4 +34,5 @@ public class AnnualSummaryDto
     public List<MonthlySummaryDto>? Months { get; set; }
     public decimal Transfers { get; set; }
     public decimal Deposits { get; set; }
+    public bool IncludesAssetCashFlows { get; set; }
 }

--- a/src/MyAccountingApp.Web/Pages/Home.razor
+++ b/src/MyAccountingApp.Web/Pages/Home.razor
@@ -17,11 +17,12 @@ else
         <MudIconButton Icon="@Icons.Material.Filled.Refresh" OnClick="@LoadAsync" Size="Size.Small" aria-label="Refresh" />
     </MudText>
 
+    <MudText Typo="Typo.subtitle1" Class="mb-2 mud-text-secondary">Cash</MudText>
     <MudGrid>
         <MudItem xs="12" sm="6" md="3">
             <MudCard Class="pa-4" Outlined="true">
                 <MudCardContent>
-                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">Cash — month to date</MudText>
+                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">Month to date</MudText>
                     <MudText Typo="Typo.h4" Class="green--text">+@_dashboard.Cash.IncomeMtd.ToString("N2")</MudText>
                     <MudText Typo="Typo.h4" Class="red--text">-@_dashboard.Cash.ExpenseMtd.ToString("N2")</MudText>
                     <MudText Typo="Typo.h5" Class="@NetClass(_dashboard.Cash.NetCashFlowMtd)">Net @_dashboard.Cash.NetCashFlowMtd.ToString("N2")</MudText>
@@ -31,7 +32,7 @@ else
         <MudItem xs="12" sm="6" md="3">
             <MudCard Class="pa-4" Outlined="true">
                 <MudCardContent>
-                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">Cash — year to date</MudText>
+                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">Year to date</MudText>
                     <MudText Typo="Typo.h4" Class="green--text">+@_dashboard.Cash.IncomeYtd.ToString("N2")</MudText>
                     <MudText Typo="Typo.h4" Class="red--text">-@_dashboard.Cash.ExpenseYtd.ToString("N2")</MudText>
                     <MudText Typo="Typo.h5" Class="@NetClass(_dashboard.Cash.NetCashFlowYtd)">Net @_dashboard.Cash.NetCashFlowYtd.ToString("N2")</MudText>
@@ -41,19 +42,52 @@ else
         <MudItem xs="12" sm="6" md="3">
             <MudCard Class="pa-4" Outlined="true">
                 <MudCardContent>
-                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">Investments — year to date</MudText>
-                    <MudText Typo="Typo.h4">@_dashboard.Portfolio.TotalCostBasisEur.ToString("N2") EUR</MudText>
-                    <MudText Typo="Typo.body2" Class="mud-text-secondary">cost basis of open positions</MudText>
-                    <MudText Typo="Typo.h6" Class="@GainClass(_dashboard.Portfolio.RealizedGainLossYtdEur)">Realized @_dashboard.Portfolio.RealizedGainLossYtdEur.ToString("N2") EUR</MudText>
+                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">Transfers YTD</MudText>
+                    <MudText Typo="Typo.h5">@_dashboard.Cash.TransfersYtd.ToString("N2")</MudText>
                 </MudCardContent>
             </MudCard>
         </MudItem>
         <MudItem xs="12" sm="6" md="3">
             <MudCard Class="pa-4" Outlined="true">
                 <MudCardContent>
-                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">Portfolio</MudText>
-                    <MudText Typo="Typo.h4">@_dashboard.Portfolio.OpenPositionCount open positions</MudText>
-                    <MudText Typo="Typo.body2" Class="mud-text-secondary">@_dashboard.Portfolio.SymbolCount symbol(s) tracked</MudText>
+                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">Deposits YTD</MudText>
+                    <MudText Typo="Typo.h5" Class="green--text">@_dashboard.Cash.DepositsYtd.ToString("N2")</MudText>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+    </MudGrid>
+
+    <MudText Typo="Typo.subtitle1" Class="mt-6 mb-2 mud-text-secondary">Investments</MudText>
+    <MudGrid>
+        <MudItem xs="12" sm="6" md="3">
+            <MudCard Class="pa-4" Outlined="true">
+                <MudCardContent>
+                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">Cost basis (open)</MudText>
+                    <MudText Typo="Typo.h4">@_dashboard.Portfolio.TotalCostBasisEur.ToString("N2") EUR</MudText>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="3">
+            <MudCard Class="pa-4" Outlined="true">
+                <MudCardContent>
+                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">Realized YTD</MudText>
+                    <MudText Typo="Typo.h5" Class="@GainClass(_dashboard.Portfolio.RealizedGainLossYtdEur)">@_dashboard.Portfolio.RealizedGainLossYtdEur.ToString("N2") EUR</MudText>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="3">
+            <MudCard Class="pa-4" Outlined="true">
+                <MudCardContent>
+                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">Open positions</MudText>
+                    <MudText Typo="Typo.h4">@_dashboard.Portfolio.OpenPositionCount</MudText>
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="3">
+            <MudCard Class="pa-4" Outlined="true">
+                <MudCardContent>
+                    <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">Symbols tracked</MudText>
+                    <MudText Typo="Typo.h5">@_dashboard.Portfolio.SymbolCount</MudText>
                 </MudCardContent>
             </MudCard>
         </MudItem>

--- a/src/MyAccountingApp.Web/Pages/Summary.razor
+++ b/src/MyAccountingApp.Web/Pages/Summary.razor
@@ -21,22 +21,39 @@ else if (_error != null)
 else if (Year.HasValue)
 {
     <MudButton Variant="Variant.Text" Color="Color.Primary" StartIcon="@Icons.Material.Filled.ArrowBack" Href="summary" Class="mb-4">Back to all years</MudButton>
+    <MudText Typo="Typo.h4" GutterBottom="true">@Year.Value</MudText>
+
+    <MudText Typo="Typo.subtitle1" Class="mb-2 mud-text-secondary">Cash</MudText>
     <MudCard Class="pa-6" Outlined="true">
         <MudCardContent>
-            <MudText Typo="Typo.h4" GutterBottom="true">@Year.Value</MudText>
             <MudGrid>
                 <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Income</MudText><MudText Typo="Typo.h5" Color="Color.Success">@_summary?.Income.ToString("N2") €</MudText></MudItem>
                 <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Expenses</MudText><MudText Typo="Typo.h5" Color="Color.Error">@_summary?.Expenses.ToString("N2") €</MudText></MudItem>
                 <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Transfers</MudText><MudText Typo="Typo.h5">@_summary?.Transfers.ToString("N2") €</MudText></MudItem>
                 <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Deposits</MudText><MudText Typo="Typo.h5" Color="Color.Success">@_summary?.Deposits.ToString("N2") €</MudText></MudItem>
                 <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Net Cash Flow</MudText><MudText Typo="Typo.h5" Color="@NetCashFlowColor">@_summary?.NetCashFlow.ToString("N2") €</MudText></MudItem>
-                <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Transactions</MudText><MudText Typo="Typo.h5">@_summary?.TransactionCount</MudText></MudItem>
-                <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Investment Purchases</MudText><MudText Typo="Typo.h5">@_summary?.InvestmentPurchases.ToString("N2") €</MudText></MudItem>
-                <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Investment Sales</MudText><MudText Typo="Typo.h5">@_summary?.InvestmentSales.ToString("N2") €</MudText></MudItem>
+                <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Bank Transactions</MudText><MudText Typo="Typo.h5">@_summary?.TransactionCount</MudText></MudItem>
+            </MudGrid>
+        </MudCardContent>
+    </MudCard>
+
+    <MudText Typo="Typo.subtitle1" Class="mt-6 mb-2 mud-text-secondary">Investments</MudText>
+    <MudCard Class="pa-6" Outlined="true">
+        <MudCardContent>
+            <MudGrid>
+                <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Purchases</MudText><MudText Typo="Typo.h5">@_summary?.InvestmentPurchases.ToString("N2") €</MudText></MudItem>
+                <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Sales</MudText><MudText Typo="Typo.h5">@_summary?.InvestmentSales.ToString("N2") €</MudText></MudItem>
                 <MudItem xs="6" md="3"><MudText Typo="Typo.subtitle2">Asset Transactions</MudText><MudText Typo="Typo.h5">@_summary?.AssetTransactionCount</MudText></MudItem>
             </MudGrid>
         </MudCardContent>
     </MudCard>
+
+    @if (_summary is { IncludesAssetCashFlows: false })
+    {
+        <MudAlert Severity="Severity.Info" Class="mt-4">
+            Cash and investment flows are reported separately: net cash flow only counts the cash ledger, and investment purchases/sales are shown above without being folded into cash expenses.
+        </MudAlert>
+    }
 
     @if (_summary?.Months is { Count: > 0 })
     {


### PR DESCRIPTION
## Summary

Fase B2 del `pla_visibilitat_comptabilitat_MyAccountingApp.md` — UI amb seccions **Cash** i **Investments** separades (backend B1 ja aplicat).

### Changes

- **Summary.razor** (vista anual): les KPIs ara estan agrupades en dos blocs visuals:
  - **Cash**: Income, Expenses, Transfers, Deposits, Net Cash Flow, Bank Transactions.
  - **Investments**: Purchases, Sales, Asset Transactions.
  - Nota d'informació quan `IncludesAssetCashFlows: false` explicant que el net cash flow només compta el ledger de caixa.
- **Home.razor**: seccions explícites "Cash" (MTD, YTD, Transfers YTD, Deposits YTD) i "Investments" (cost basis, realized YTD, posicions obertes, símbols).
- `AnnualSummaryDto` (Web) exposa `IncludesAssetCashFlows`.

### Test plan

- Build 0 warnings / 0 errors.
- Suite verda: 413 (App 101, Domain 40, Core 223, Api 49).
- Smoke manual: `/summary/2026` mostra dos blocs; `/` mostra seccions Cash/Investments.

### Fora d'abast

- B3 (opcional): imports amb category `INVESTMENT`/`TRANSFER` per a buys de fons. Proper: C1 (FIFO shortfall) o B3, com prefereixis.