### PR TITLE
fix(portfolio): handle FIFO sell shortfall explicitly

### DIFF
--- a/src/MyAccountingApp.Application/DTOs/PortfolioPositionDto.cs
+++ b/src/MyAccountingApp.Application/DTOs/PortfolioPositionDto.cs
@@ -10,4 +10,6 @@ public record PortfolioPositionDto(
     decimal RealizedGainLoss,
     List<TaxLotDto> OpenLots,
     decimal? MarketPrice,
-    decimal? UnrealizedGainLoss);
+    decimal? UnrealizedGainLoss,
+    bool HasShortfall,
+    decimal UnmatchedSellQuantity);

--- a/src/MyAccountingApp.Application/Services/PortfolioQuery.cs
+++ b/src/MyAccountingApp.Application/Services/PortfolioQuery.cs
@@ -53,6 +53,8 @@ public class PortfolioQuery : IPortfolioQuery
             0,
             new List<TaxLotDto>(),
             null,
-            null);
+            null,
+            false,
+            0);
     }
 }

--- a/src/MyAccountingApp.Application/Services/PositionEngine.cs
+++ b/src/MyAccountingApp.Application/Services/PositionEngine.cs
@@ -33,6 +33,7 @@ public class PositionEngine : IPositionEngine
         string currency = transactions[0].Transaction.Money.Currency;
         decimal totalCost = 0;
         decimal netQuantity = 0;
+        decimal unmatchedSellQuantity = 0;
 
         foreach (var tx in transactions)
         {
@@ -46,7 +47,6 @@ public class PositionEngine : IPositionEngine
             else
             {
                 decimal sellQty = tx.Quantity;
-                netQuantity -= sellQty;
 
                 foreach (var lot in lots.Where(l => l.RemainingQuantity > 0).OrderBy(l => l.PurchaseDate))
                 {
@@ -61,9 +61,15 @@ public class PositionEngine : IPositionEngine
 
                     realizedGainLoss += proceeds - costBasis;
                     totalCost -= costBasis;
+                    netQuantity -= consumed;
 
                     lot.RemainingQuantity -= consumed;
                     sellQty -= consumed;
+                }
+
+                if (sellQty > 0)
+                {
+                    unmatchedSellQuantity += sellQty;
                 }
             }
         }
@@ -92,7 +98,9 @@ public class PositionEngine : IPositionEngine
                     Math.Round(l.RemainingQuantity * l.UnitaryCost, 2)))
                 .ToList(),
             marketPrice?.Amount,
-            unrealizedGainLoss);
+            unrealizedGainLoss,
+            unmatchedSellQuantity > 0,
+            Math.Round(unmatchedSellQuantity, 4));
     }
 
     private sealed class FifoLot

--- a/tests/MyAccountingApp.Application.Tests/Services/PositionEngineTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/PositionEngineTests.cs
@@ -152,6 +152,68 @@ public class PositionEngineTests
         Assert.Null(result.UnrealizedGainLoss);
     }
 
+    [Fact]
+    public async Task GetPosition_WithSellExceedingPosition_FlagsShortfall()
+    {
+        DateTime buyDate = new(2024, 1, 15);
+        DateTime sellDate = new(2024, 6, 1);
+        FakePortfolioRepo repo = new();
+        repo.AddOrUpdate(Buy("AAPL", 100, 10, buyDate));
+        repo.AddOrUpdate(Sell("AAPL", 150, 15, sellDate));
+        FakeMarketPriceService priceService = new();
+        PositionEngine engine = new(repo, priceService);
+
+        var result = await engine.GetPosition("AAPL");
+
+        Assert.NotNull(result);
+        Assert.True(result.HasShortfall);
+        Assert.Equal(5, result.UnmatchedSellQuantity);
+        Assert.Equal(0, result.NetQuantity);
+        Assert.Equal(0, result.TotalCostBasis);
+        Assert.Equal(500m, result.RealizedGainLoss);
+        Assert.Empty(result.OpenLots);
+        Assert.Null(result.MarketPrice);
+        Assert.Null(result.UnrealizedGainLoss);
+    }
+
+    [Fact]
+    public async Task GetPosition_WithFullSell_DoesNotFlagShortfall()
+    {
+        DateTime buyDate = new(2024, 1, 15);
+        DateTime sellDate = new(2024, 6, 1);
+        FakePortfolioRepo repo = new();
+        repo.AddOrUpdate(Buy("AAPL", 100, 10, buyDate));
+        repo.AddOrUpdate(Sell("AAPL", 150, 10, sellDate));
+        FakeMarketPriceService priceService = new();
+        PositionEngine engine = new(repo, priceService);
+
+        var result = await engine.GetPosition("AAPL");
+
+        Assert.NotNull(result);
+        Assert.False(result.HasShortfall);
+        Assert.Equal(0, result.UnmatchedSellQuantity);
+        Assert.Equal(0, result.NetQuantity);
+    }
+
+    [Fact]
+    public async Task GetPosition_WithMultipleShortfallSells_AccumulatesUnmatchedQuantity()
+    {
+        DateTime buyDate = new(2024, 1, 15);
+        FakePortfolioRepo repo = new();
+        repo.AddOrUpdate(Buy("AAPL", 100, 10, buyDate));
+        repo.AddOrUpdate(Sell("AAPL", 150, 7, new DateTime(2024, 6, 1)));
+        repo.AddOrUpdate(Sell("AAPL", 150, 5, new DateTime(2024, 7, 1)));
+        FakeMarketPriceService priceService = new();
+        PositionEngine engine = new(repo, priceService);
+
+        var result = await engine.GetPosition("AAPL");
+
+        Assert.NotNull(result);
+        Assert.True(result.HasShortfall);
+        Assert.Equal(2, result.UnmatchedSellQuantity);
+        Assert.Equal(0, result.NetQuantity);
+    }
+
     private sealed class FakePortfolioRepo : IPortfolioRepository
     {
         private readonly List<AssetTransaction> _transactions = new();


### PR DESCRIPTION
## C1 — FIFO sell shortfall

Primer PR de la Fase C del pla `pla_visibilitat_comptabilitat_MyAccountingApp.md`.

### Canvis
- `PositionEngine`: quan un Sell supera les posicions obertes (shortfall), la quantitat venuda es **clampa** a la disponible:
  - `NetQuantity` mai baixa de 0
  - `RealizedGainLoss` només compta les quantitats realment matxades amb lots FIFO
  - La quantitat no matxada s'acumula i es reporta explícitament
- `PortfolioPositionDto`: nous camps `HasShortfall` i `UnmatchedSellQuantity`

### Tests (App: 101 → 104)
- `GetPosition_WithSellExceedingPosition_FlagsShortfall` — buy 10 / sell 15 → shortfall 5, net 0, realized només del matched
- `GetPosition_WithFullSell_DoesNotFlagShortfall` — sell exacte no alerta
- `GetPosition_WithMultipleShortfallSells_AccumulatesUnmatchedQuantity` — acumulació entre vendes

Aquesta és la branca **base** de la cadena C2/C3.
