### PR TITLE
perf(api): lazy and cached market prices for portfolio

### DIFF
--- a/src/MyAccountingApp.Api/Endpoints/PortfolioEndpoints.cs
+++ b/src/MyAccountingApp.Api/Endpoints/PortfolioEndpoints.cs
@@ -11,17 +11,25 @@ public static class PortfolioEndpoints
     {
         const string prefix = ApiEndpoints.ApiPrefix;
 
-        app.MapGet($"{prefix}/portfolio", async (IPortfolioRepository repo, IPositionEngine positionEngine) =>
+        app.MapGet($"{prefix}/portfolio", async (IPortfolioRepository repo, IPositionEngine positionEngine, bool includePrices = false) =>
         {
             string[] symbols = repo.GetAllTransactions().Select(t => t.Symbol).Distinct().ToArray();
-            PortfolioPositionDto?[] positions = await Task.WhenAll(symbols.Select(s => positionEngine.GetPosition(s)));
+            PortfolioPositionDto?[] positions = await Task.WhenAll(symbols.Select(s => positionEngine.GetPosition(s, includePrices)));
             return Results.Ok(positions.Where(p => p is not null).ToList());
         });
 
-        app.MapGet($"{prefix}/portfolio/{{symbol}}", async (string symbol, IPositionEngine positionEngine) =>
+        app.MapGet($"{prefix}/portfolio/{{symbol}}", async (string symbol, IPositionEngine positionEngine, bool includePrices = true) =>
         {
-            PortfolioPositionDto? position = await positionEngine.GetPosition(symbol);
+            PortfolioPositionDto? position = await positionEngine.GetPosition(symbol, includePrices);
             return position is not null ? Results.Ok(position) : Results.NotFound(new { symbol, message = "No transactions found for this symbol" });
+        });
+
+        app.MapPost($"{prefix}/portfolio/refresh-prices", async (IPortfolioRepository repo, IPositionEngine positionEngine, IMarketPriceService priceService) =>
+        {
+            string[] symbols = repo.GetAllTransactions().Select(t => t.Symbol).Distinct().ToArray();
+            await Task.WhenAll(symbols.Select(s => priceService.RefreshPriceAsync(s)));
+            PortfolioPositionDto?[] positions = await Task.WhenAll(symbols.Select(s => positionEngine.GetPosition(s, true)));
+            return Results.Ok(positions.Where(p => p is not null).ToList());
         });
 
         app.MapGet($"{prefix}/validate", (IValidationQuery validationQuery) =>

--- a/src/MyAccountingApp.Application/Interfaces/IPositionEngine.cs
+++ b/src/MyAccountingApp.Application/Interfaces/IPositionEngine.cs
@@ -4,5 +4,5 @@ namespace MyAccountingApp.Application.Interfaces;
 
 public interface IPositionEngine
 {
-    Task<PortfolioPositionDto?> GetPosition(string symbol);
+    Task<PortfolioPositionDto?> GetPosition(string symbol, bool includePrice = true);
 }

--- a/src/MyAccountingApp.Application/Services/PositionEngine.cs
+++ b/src/MyAccountingApp.Application/Services/PositionEngine.cs
@@ -17,7 +17,7 @@ public class PositionEngine : IPositionEngine
         this._marketPriceService = marketPriceService;
     }
 
-    public async Task<PortfolioPositionDto?> GetPosition(string symbol)
+    public async Task<PortfolioPositionDto?> GetPosition(string symbol, bool includePrice = true)
     {
         var transactions = this._portfolioRepo.GetAssetTransactions(symbol)
             .OrderBy(t => t.Transaction.Date)
@@ -76,7 +76,7 @@ public class PositionEngine : IPositionEngine
 
         decimal avgCost = netQuantity > 0 ? Math.Round(totalCost / netQuantity, 4) : 0;
 
-        Money? marketPrice = netQuantity > 0 ? await this._marketPriceService.GetPriceAsync(symbol) : null;
+        Money? marketPrice = includePrice && netQuantity > 0 ? await this._marketPriceService.GetPriceAsync(symbol) : null;
 
         decimal? unrealizedGainLoss = marketPrice is not null && netQuantity > 0
             ? Math.Round((marketPrice.Amount - avgCost) * netQuantity, 2)

--- a/src/MyAccountingApp.Core/Http/Market/MarketPriceCache.cs
+++ b/src/MyAccountingApp.Core/Http/Market/MarketPriceCache.cs
@@ -1,0 +1,42 @@
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Core.Http.Market;
+
+public class MarketPriceCache
+{
+    public static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(30);
+
+    private readonly TimeSpan _ttl;
+    private readonly Dictionary<string, CacheEntry> _entries = new();
+    private readonly object _lock = new();
+
+    public MarketPriceCache(TimeSpan? ttl = null)
+    {
+        this._ttl = ttl ?? DefaultTtl;
+    }
+
+    public bool TryGetFresh(string symbol, DateTimeOffset now, out Money price)
+    {
+        lock (this._lock)
+        {
+            if (this._entries.TryGetValue(symbol, out CacheEntry? entry) && now - entry.FetchedAt < this._ttl)
+            {
+                price = entry.Price;
+                return true;
+            }
+        }
+
+        price = default!;
+        return false;
+    }
+
+    public void Set(string symbol, Money price, DateTimeOffset now)
+    {
+        lock (this._lock)
+        {
+            this._entries[symbol] = new CacheEntry(price, now);
+        }
+    }
+
+    private sealed record CacheEntry(Money Price, DateTimeOffset FetchedAt);
+}

--- a/src/MyAccountingApp.Core/Http/Market/YahooMarketPriceService.cs
+++ b/src/MyAccountingApp.Core/Http/Market/YahooMarketPriceService.cs
@@ -5,7 +5,43 @@ using YahooFinanceApi;
 namespace MyAccountingApp.Core.Http.Market;
 public class YahooMarketPriceService : IMarketPriceService
 {
-    public async Task<Money?> GetPriceAsync(string symbol)
+    private readonly MarketPriceCache _cache = new();
+
+    public Task<Money?> GetPriceAsync(string symbol) => this.FetchAsync(symbol, useCache: true);
+
+    public Task<Money?> RefreshPriceAsync(string symbol) => this.FetchAsync(symbol, useCache: false);
+
+    private async Task<Money?> FetchAsync(string symbol, bool useCache)
+    {
+        if (!LooksLikeListedEquity(symbol))
+        {
+            return null;
+        }
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        if (useCache && this._cache.TryGetFresh(symbol, now, out Money? cachedPrice))
+        {
+            return cachedPrice;
+        }
+
+        Money? price = await FetchFromYahooAsync(symbol);
+
+        if (price is not null)
+        {
+            this._cache.Set(symbol, price, now);
+        }
+
+        return price;
+    }
+
+    /// <summary>
+    /// Heuristic to detect fund symbols (e.g. COBAS_*, SIGMA_*) that are not listed on Yahoo.
+    /// </summary>
+    public static bool LooksLikeListedEquity(string? symbol) =>
+        !string.IsNullOrWhiteSpace(symbol) && !symbol.Contains('_');
+
+    private static async Task<Money?> FetchFromYahooAsync(string symbol)
     {
         try
         {

--- a/src/MyAccountingApp.Domain/Interfaces/IMarketPriceService.cs
+++ b/src/MyAccountingApp.Domain/Interfaces/IMarketPriceService.cs
@@ -9,4 +9,11 @@ public interface IMarketPriceService
     /// <param name="symbol">Ticker</param>
     /// <returns>Price</returns>
     Task<Money?> GetPriceAsync(string symbol);
+
+    /// <summary>
+    /// Return el price of asset based on its ticker, bypassing the in-memory cache
+    /// </summary>
+    /// <param name="symbol">Ticker</param>
+    /// <returns>Price</returns>
+    Task<Money?> RefreshPriceAsync(string symbol);
 }

--- a/tests/MyAccountingApp.Api.Tests/ApiWebApplicationFactory.cs
+++ b/tests/MyAccountingApp.Api.Tests/ApiWebApplicationFactory.cs
@@ -30,6 +30,8 @@ public class ApiWebApplicationFactory : WebApplicationFactory<Program>
             services.AddSingleton<IOptionTransactionRepository>(new JsonOptionTransactionRepository(Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.json")));
             services.RemoveAll<IPendingConversionQueue>();
             services.AddSingleton<IPendingConversionQueue>(new FakePendingConversionQueue());
+            services.RemoveAll<IMarketPriceService>();
+            services.AddSingleton<IMarketPriceService>(new CountingMarketPriceService());
         });
     }
 }

--- a/tests/MyAccountingApp.Api.Tests/Fakes/CountingMarketPriceService.cs
+++ b/tests/MyAccountingApp.Api.Tests/Fakes/CountingMarketPriceService.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Api.Tests.Fakes;
+
+public class CountingMarketPriceService : IMarketPriceService
+{
+    private static int _calls;
+
+    public static int Calls => Volatile.Read(ref _calls);
+
+    public static void Reset() => Interlocked.Exchange(ref _calls, 0);
+
+    public Task<Money?> GetPriceAsync(string symbol)
+    {
+        Interlocked.Increment(ref _calls);
+        return Task.FromResult<Money?>(new Money(100m, "USD"));
+    }
+
+    public Task<Money?> RefreshPriceAsync(string symbol)
+    {
+        Interlocked.Increment(ref _calls);
+        return Task.FromResult<Money?>(new Money(100m, "USD"));
+    }
+}

--- a/tests/MyAccountingApp.Api.Tests/PortfolioEndpointsTests.cs
+++ b/tests/MyAccountingApp.Api.Tests/PortfolioEndpointsTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using MyAccountingApp.Api.Tests.Fakes;
 
 namespace MyAccountingApp.Api.Tests;
 
@@ -80,5 +81,121 @@ public class PortfolioEndpointsTests
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Portfolio_ByDefault_DoesNotFetchMarketPrices()
+    {
+        // Arrange
+        CountingMarketPriceService.Reset();
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        await SeedBuyAsync(client);
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/api/portfolio");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(0, CountingMarketPriceService.Calls);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement position = Assert.Single(document.RootElement.EnumerateArray());
+        Assert.Equal(JsonValueKind.Null, position.GetProperty("marketPrice").ValueKind);
+        Assert.Equal(JsonValueKind.Null, position.GetProperty("unrealizedGainLoss").ValueKind);
+    }
+
+    [Fact]
+    public async Task Portfolio_WithIncludePrices_FetchesMarketPrices()
+    {
+        // Arrange
+        CountingMarketPriceService.Reset();
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        await SeedBuyAsync(client);
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/api/portfolio?includePrices=true");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, CountingMarketPriceService.Calls);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement position = Assert.Single(document.RootElement.EnumerateArray());
+        Assert.Equal(100m, position.GetProperty("marketPrice").GetDecimal());
+        Assert.Equal(50m, position.GetProperty("unrealizedGainLoss").GetDecimal());
+    }
+
+    [Fact]
+    public async Task Portfolio_SingleSymbol_FetchesMarketPriceByDefault()
+    {
+        // Arrange
+        CountingMarketPriceService.Reset();
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        await SeedBuyAsync(client);
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/api/portfolio/AAPL");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, CountingMarketPriceService.Calls);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(100m, document.RootElement.GetProperty("marketPrice").GetDecimal());
+    }
+
+    [Fact]
+    public async Task Portfolio_SingleSymbol_WithoutPrices_DoesNotFetch()
+    {
+        // Arrange
+        CountingMarketPriceService.Reset();
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        await SeedBuyAsync(client);
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/api/portfolio/AAPL?includePrices=false");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(0, CountingMarketPriceService.Calls);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(JsonValueKind.Null, document.RootElement.GetProperty("marketPrice").ValueKind);
+    }
+
+    [Fact]
+    public async Task RefreshPrices_ShouldWarmPricesAndReturnPositions()
+    {
+        // Arrange
+        CountingMarketPriceService.Reset();
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        await SeedBuyAsync(client);
+
+        // Act
+        HttpResponseMessage response = await client.PostAsync("/api/portfolio/refresh-prices", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(2, CountingMarketPriceService.Calls);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement position = Assert.Single(document.RootElement.EnumerateArray());
+        Assert.Equal(100m, position.GetProperty("marketPrice").GetDecimal());
+    }
+
+    private static async Task SeedBuyAsync(HttpClient client)
+    {
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/asset-transactions", new
+        {
+            date = new DateTime(2026, 1, 5),
+            description = "Buy AAPL",
+            amount = 150m,
+            currency = "EUR",
+            category = "EXPENSE",
+            symbol = "AAPL",
+            quantity = 2m,
+            type = "Buy",
+        });
+        response.EnsureSuccessStatusCode();
     }
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/PositionEngineTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/PositionEngineTests.cs
@@ -214,6 +214,29 @@ public class PositionEngineTests
         Assert.Equal(0, result.NetQuantity);
     }
 
+    [Fact]
+    public async Task GetPosition_WithoutPrice_SkipsPriceService()
+    {
+        FakePortfolioRepo repo = new();
+        repo.AddOrUpdate(Buy("AAPL", 150, 10, new DateTime(2024, 1, 15)));
+        ThrowingMarketPriceService priceService = new();
+        PositionEngine engine = new(repo, priceService);
+
+        var result = await engine.GetPosition("AAPL", includePrice: false);
+
+        Assert.NotNull(result);
+        Assert.Null(result.MarketPrice);
+        Assert.Null(result.UnrealizedGainLoss);
+        Assert.Equal(10, result.NetQuantity);
+    }
+
+    private sealed class ThrowingMarketPriceService : IMarketPriceService
+    {
+        public Task<Money?> GetPriceAsync(string symbol) => throw new InvalidOperationException("Price service should not be called");
+
+        public Task<Money?> RefreshPriceAsync(string symbol) => throw new InvalidOperationException("Price service should not be called");
+    }
+
     private sealed class FakePortfolioRepo : IPortfolioRepository
     {
         private readonly List<AssetTransaction> _transactions = new();

--- a/tests/MyAccountingApp.Core.Tests/Services/YahooMarketPriceServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/YahooMarketPriceServiceTests.cs
@@ -1,0 +1,62 @@
+using System;
+using MyAccountingApp.Core.Http.Market;
+using MyAccountingApp.Domain.ValueObjects;
+using Xunit;
+
+namespace MyAccountingApp.Core.Tests.Services;
+
+public class YahooMarketPriceServiceTests
+{
+    [Theory]
+    [InlineData("AAPL", true)]
+    [InlineData("BMW.DE", true)]
+    [InlineData("VWRA.L", true)]
+    [InlineData("COBAS_INTERNACIONAL_D", false)]
+    [InlineData("SIGMA_INTERNACIONAL_A", false)]
+    [InlineData("", false)]
+    [InlineData("  ", false)]
+    public void LooksLikeListedEquity_ReturnsExpectedResult(string symbol, bool expected)
+    {
+        Assert.Equal(expected, YahooMarketPriceService.LooksLikeListedEquity(symbol));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    public void LooksLikeListedEquity_WithNull_ReturnsFalse(string? symbol)
+    {
+        Assert.False(YahooMarketPriceService.LooksLikeListedEquity(symbol));
+    }
+
+    [Fact]
+    public void MarketPriceCache_ReturnsPrice_WithinTtl()
+    {
+        MarketPriceCache cache = new();
+        Money price = new(150.25m, "USD");
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        cache.Set("AAPL", price, now);
+
+        Assert.True(cache.TryGetFresh("AAPL", now.AddMinutes(29), out Money? cached));
+        Assert.Equal(150.25m, cached.Amount);
+        Assert.Equal("USD", cached.Currency);
+    }
+
+    [Fact]
+    public void MarketPriceCache_ReturnsStale_AfterTtl()
+    {
+        MarketPriceCache cache = new();
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        cache.Set("AAPL", new Money(150.25m, "USD"), now);
+
+        Assert.False(cache.TryGetFresh("AAPL", now.AddMinutes(31), out _));
+    }
+
+    [Fact]
+    public void MarketPriceCache_ReturnsStale_WhenNeverSet()
+    {
+        MarketPriceCache cache = new();
+
+        Assert.False(cache.TryGetFresh("AAPL", DateTimeOffset.UtcNow, out _));
+    }
+}

--- a/tests/MyAccountingApp.TestUtilities/Fakes/FakeMarketPriceService.cs
+++ b/tests/MyAccountingApp.TestUtilities/Fakes/FakeMarketPriceService.cs
@@ -28,5 +28,7 @@ namespace MyAccountingApp.TestUtilities.Fakes
 
             return null;
         }
+
+        public Task<Money?> RefreshPriceAsync(string symbol) => this.GetPriceAsync(symbol);
     }
 }


### PR DESCRIPTION
## C2 — Preus de mercat lazy i cachejats

Segon PR de la Fase C (branca apilada sobre `fix/portfolio-fifo-shortfall`).

### Canvis
- **Endpoints**:
  - `GET /api/portfolio?includePrices=false` (default) — **0 crides de preus**, càlcul FIFO complet (cost, realized, shortfall)
  - `GET /api/portfolio/{symbol}?includePrices=true` (default true)
  - `POST /api/portfolio/refresh-prices` — refreda preus (bypass del cache) i retorna posicions cotitzades
- **`IMarketPriceService`**: nou `RefreshPriceAsync` (bypass cache) + `GetPriceAsync` ara amb **cache en memòria TTL 30 min** (`MarketPriceCache`)
- **Heurística `LooksLikeListedEquity`**: símbols de fons (`COBAS_*`, `SIGMA_*`) no criden mai Yahoo
- `IPositionEngine.GetPosition(symbol, includePrice = true)` — opció per saltar el preu

### Tests (App 105 · Core 234 · Api 54)
- Api: `GET /api/portfolio` default → **0 crides** (CountingMarketPriceService); `includePrices=true` → 1 crida + `marketPrice`; símbol individual default → 1 crida; `refresh-prices` → refreda i retorna preus
- Core: heurística fons (AAPL/BMW.DE/VWRA.L true; COBAS_*/SIGMA_* false) + TTL del cache (fresc dins 30 min, stale després)
- App: `GetPosition(includePrice: false)` no crida el servei de preus (verifiable amb throwing fake)

Mergejar **en ordre**: C1 (#129) primer, després aquest.
