### PR TITLE
feat(domain): extend transaction categories for accounting

### DIFF
--- a/src/MyAccountingApp.Application/Services/AnnualSummaryService.cs
+++ b/src/MyAccountingApp.Application/Services/AnnualSummaryService.cs
@@ -70,11 +70,11 @@ public class AnnualSummaryService : IAnnualSummaryService
             .ToList();
 
         decimal expenses = yearTxs
-            .Where(t => t.Category == TransactionCategory.EXPENSE)
+            .Where(t => t.Category.IsCashExpense())
             .Sum(t => t.Money.Amount);
 
         decimal income = yearTxs
-            .Where(t => t.Category == TransactionCategory.INCOME)
+            .Where(t => t.Category.IsCashIncome())
             .Sum(t => t.Money.Amount);
 
         decimal transfers = yearTxs
@@ -135,11 +135,11 @@ public class AnnualSummaryService : IAnnualSummaryService
             }
 
             decimal expenses = monthTxs
-                .Where(t => t.Category == TransactionCategory.EXPENSE)
+                .Where(t => t.Category.IsCashExpense())
                 .Sum(t => t.Money.Amount);
 
             decimal income = monthTxs
-                .Where(t => t.Category == TransactionCategory.INCOME)
+                .Where(t => t.Category.IsCashIncome())
                 .Sum(t => t.Money.Amount);
 
             decimal transfers = monthTxs

--- a/src/MyAccountingApp.Application/Services/DashboardQuery.cs
+++ b/src/MyAccountingApp.Application/Services/DashboardQuery.cs
@@ -42,18 +42,18 @@ public class DashboardQuery : IDashboardQuery
         DateTime yearStart = new DateTime(asOf.Year, 1, 1);
         DateTime monthStart = new DateTime(asOf.Year, asOf.Month, 1);
 
-        decimal SumCategory(List<Transaction> txs, TransactionCategory category) =>
-            txs.Where(t => t.Category == category).Sum(t => t.Money.Amount);
+        decimal SumCategory(List<Transaction> txs, Func<TransactionCategory, bool> predicate) =>
+            txs.Where(t => predicate(t.Category)).Sum(t => t.Money.Amount);
 
         List<Transaction> ytd = allTransactions.Where(t => t.Date >= yearStart && t.Date <= end).ToList();
         List<Transaction> mtd = allTransactions.Where(t => t.Date >= monthStart && t.Date <= end).ToList();
 
-        decimal incomeYtd = SumCategory(ytd, TransactionCategory.INCOME);
-        decimal expenseYtd = SumCategory(ytd, TransactionCategory.EXPENSE);
-        decimal transfersYtd = SumCategory(ytd, TransactionCategory.TRANSFER);
-        decimal depositsYtd = SumCategory(ytd, TransactionCategory.DEPOSIT);
-        decimal incomeMtd = SumCategory(mtd, TransactionCategory.INCOME);
-        decimal expenseMtd = SumCategory(mtd, TransactionCategory.EXPENSE);
+        decimal incomeYtd = SumCategory(ytd, c => c.IsCashIncome());
+        decimal expenseYtd = SumCategory(ytd, c => c.IsCashExpense());
+        decimal transfersYtd = SumCategory(ytd, c => c == TransactionCategory.TRANSFER);
+        decimal depositsYtd = SumCategory(ytd, c => c == TransactionCategory.DEPOSIT);
+        decimal incomeMtd = SumCategory(mtd, c => c.IsCashIncome());
+        decimal expenseMtd = SumCategory(mtd, c => c.IsCashExpense());
 
         return new CashSnapshotDto(
             Math.Round(incomeMtd, 2),

--- a/src/MyAccountingApp.Domain/Enums/TransactionCategory.cs
+++ b/src/MyAccountingApp.Domain/Enums/TransactionCategory.cs
@@ -6,4 +6,9 @@ public enum TransactionCategory
     INCOME = 1,
     TRANSFER = 2,
     DEPOSIT = 3,
+    DIVIDEND = 4,
+    FEE = 5,
+    WITHHOLDING_TAX = 6,
+    INTEREST = 7,
+    INVESTMENT = 8,
 }

--- a/src/MyAccountingApp.Domain/Enums/TransactionCategoryExtensions.cs
+++ b/src/MyAccountingApp.Domain/Enums/TransactionCategoryExtensions.cs
@@ -1,0 +1,10 @@
+namespace MyAccountingApp.Domain.Enums;
+
+public static class TransactionCategoryExtensions
+{
+    public static bool IsCashIncome(this TransactionCategory category) =>
+        category is TransactionCategory.INCOME or TransactionCategory.DIVIDEND or TransactionCategory.INTEREST;
+
+    public static bool IsCashExpense(this TransactionCategory category) =>
+        category is TransactionCategory.EXPENSE or TransactionCategory.FEE or TransactionCategory.WITHHOLDING_TAX;
+}

--- a/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
+++ b/src/MyAccountingApp.Web/Pages/AssetTransactions.razor
@@ -229,7 +229,7 @@ else
 
     private bool IsFormInvalid() => string.IsNullOrWhiteSpace(_formDescription) || string.IsNullOrWhiteSpace(_formSymbol) || _formAmount <= 0 || _formQuantity <= 0;
 
-    private static readonly string[] _categories = { "INCOME", "EXPENSE", "TRANSFER", "DEPOSIT" };
+    private static readonly string[] _categories = { "INCOME", "EXPENSE", "TRANSFER", "DEPOSIT", "DIVIDEND", "FEE", "WITHHOLDING_TAX", "INTEREST", "INVESTMENT" };
     private static readonly string[] _types = { "Buy", "Sell", "CorporateAction" };
 
     private bool _showFormDialog;

--- a/src/MyAccountingApp.Web/Pages/Transactions.razor
+++ b/src/MyAccountingApp.Web/Pages/Transactions.razor
@@ -146,7 +146,7 @@ else
         <RowTemplate>
             <MudTd DataLabel="Date">@context.Date.ToString("yyyy-MM-dd")</MudTd>
             <MudTd DataLabel="Description">@context.Description</MudTd>
-            <MudTd DataLabel="Amount"><span class="@(context.Category == "EXPENSE" || context.Category == "TRANSFER" ? "red--text" : "green--text")">@context.Money.Amount.ToString("N2")</span></MudTd>
+            <MudTd DataLabel="Amount"><span class="@(context.Category == "EXPENSE" || context.Category == "FEE" || context.Category == "WITHHOLDING_TAX" || context.Category == "TRANSFER" ? "red--text" : "green--text")">@context.Money.Amount.ToString("N2")</span></MudTd>
             <MudTd DataLabel="Curr.">@context.Money.Currency</MudTd>
             <MudTd DataLabel="Category">
                 <MudChip T="string" Size="Size.Small" Color="@GetCategoryColor(context.Category)">@context.Category</MudChip>
@@ -256,7 +256,7 @@ else
     private string? _selectedCategory { get; set; }
     private string? _searchText { get; set; }
 
-    private static readonly string[] _categories = { "INCOME", "EXPENSE", "TRANSFER", "DEPOSIT" };
+    private static readonly string[] _categories = { "INCOME", "EXPENSE", "TRANSFER", "DEPOSIT", "DIVIDEND", "FEE", "WITHHOLDING_TAX", "INTEREST", "INVESTMENT" };
     private static readonly string[] _monthNames =
     {
         "January", "February", "March", "April", "May", "June",
@@ -339,8 +339,8 @@ ApplyFilters();
             .OrderBy(g => g.Key)
             .Select(g =>
             {
-                decimal income = g.Where(t => t.Category == "INCOME").Sum(t => t.Money.Amount);
-                decimal expense = g.Where(t => t.Category == "EXPENSE").Sum(t => t.Money.Amount);
+                decimal income = g.Where(t => t.Category is "INCOME" or "DIVIDEND" or "INTEREST").Sum(t => t.Money.Amount);
+                decimal expense = g.Where(t => t.Category is "EXPENSE" or "FEE" or "WITHHOLDING_TAX").Sum(t => t.Money.Amount);
                 decimal transfer = g.Where(t => t.Category == "TRANSFER").Sum(t => t.Money.Amount);
                 decimal deposit = g.Where(t => t.Category == "DEPOSIT").Sum(t => t.Money.Amount);
                 return new FilterCurrencySummary
@@ -372,10 +372,10 @@ ApplyFilters();
 
     private static Color GetCategoryColor(string category) => category switch
     {
-        "INCOME" => Color.Success,
-        "EXPENSE" => Color.Error,
+        "INCOME" or "DIVIDEND" or "INTEREST" => Color.Success,
+        "EXPENSE" or "FEE" or "WITHHOLDING_TAX" => Color.Error,
         "TRANSFER" => Color.Warning,
-        "DEPOSIT" => Color.Info,
+        "DEPOSIT" or "INVESTMENT" => Color.Info,
         _ => Color.Default,
     };
 


### PR DESCRIPTION
## D1 — Noves categories de transacció

Primer PR de la Fase D (apilat sobre `feat/web-portfolio-prices`).

### Canvis
- **`TransactionCategory`** ampliat: `DIVIDEND`, `FEE`, `WITHHOLDING_TAX`, `INTEREST`, `INVESTMENT` (JSON string, no breaking)
- **`TransactionCategoryExtensions`** (Domain): `IsCashIncome()` (INCOME · DIVIDEND · INTEREST) i `IsCashExpense()` (EXPENSE · FEE · WITHHOLDING_TAX)
- **Summary + Dashboard**: income/expense inclouen les noves categories → dividends/interest compten com a ingressos, fees/withholding com a despeses (coherència del net cash flow)
- **UI** (Transactions/AssetTransactions): llistes de categories ampliades (filtre, creació, bulk), colors i resums per divisa

Sense tags (decisió D-lite del pla); el mapping d'imports ve a D2.

Mergejar **en ordre**: C1 → C2 → C3 → aquest.
