### PR TITLE
feat(import): map broker lines to richer categories

### DIFF
--- a/src/MyAccountingApp.Core/Imports/Cobas/CobasImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/Cobas/CobasImportService.cs
@@ -66,7 +66,7 @@ public class CobasImportService : IBrokerImportService
 
                 string producto = fields[1];
                 string symbol = BuildSymbol(producto);
-                TransactionCategory category = type == AssetTransactionType.Buy ? TransactionCategory.EXPENSE : TransactionCategory.INCOME;
+                TransactionCategory category = type == AssetTransactionType.Buy ? TransactionCategory.INVESTMENT : TransactionCategory.INCOME;
 
                 Money money = new Money(amount, "EUR");
                 Transaction transaction = new Transaction(date, producto, money, category);

--- a/src/MyAccountingApp.Core/Imports/Degiro/DegiroImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/Degiro/DegiroImportService.cs
@@ -161,27 +161,27 @@ public class DegiroImportService : IBrokerImportService
 
         if (upper.Contains("DIVIDENDO") || upper.Contains("DIVIDEND"))
         {
-            return amount >= 0 ? TransactionCategory.INCOME : TransactionCategory.EXPENSE;
+            return amount >= 0 ? TransactionCategory.DIVIDEND : TransactionCategory.EXPENSE;
         }
 
         if (upper.Contains("RETENCI") || upper.Contains("WITHHOLDING"))
         {
-            return TransactionCategory.EXPENSE;
+            return TransactionCategory.WITHHOLDING_TAX;
         }
 
         if (upper.Contains("COSTES") || upper.Contains("COST") || upper.Contains("COMISI"))
         {
-            return TransactionCategory.EXPENSE;
+            return TransactionCategory.FEE;
         }
 
         if (upper.Contains("TAX") || upper.Contains("IMPUESTO"))
         {
-            return TransactionCategory.EXPENSE;
+            return TransactionCategory.WITHHOLDING_TAX;
         }
 
         if (upper.Contains("INTEREST") || upper.Contains("INTERES"))
         {
-            return amount >= 0 ? TransactionCategory.INCOME : TransactionCategory.EXPENSE;
+            return amount >= 0 ? TransactionCategory.INTEREST : TransactionCategory.EXPENSE;
         }
 
         if (upper.Contains("PRESTAMO") || upper.Contains("PRÉSTAMO") || upper.Contains("LENDING"))
@@ -191,7 +191,7 @@ public class DegiroImportService : IBrokerImportService
 
         if (upper.Contains("PASS-THROUGH") || upper.Contains("PASS THROUGH") || upper.Contains("PASSTHROUGH"))
         {
-            return TransactionCategory.EXPENSE;
+            return TransactionCategory.FEE;
         }
 
         if (upper.Contains("FLATEX") || upper.Contains("DEPOSIT"))

--- a/src/MyAccountingApp.Core/Imports/IBKR/DividendAgent.cs
+++ b/src/MyAccountingApp.Core/Imports/IBKR/DividendAgent.cs
@@ -40,7 +40,7 @@ public class DividendAgent : IIBKRStatementAgent
             }
 
             Money money = new Money(Math.Abs(amount), currency);
-            Transaction transaction = new Transaction(date, description, money, TransactionCategory.INCOME);
+            Transaction transaction = new Transaction(date, description, money, TransactionCategory.DIVIDEND);
             transactions.Add(transaction);
         }
     }

--- a/src/MyAccountingApp.Core/Imports/IBKR/FeeAgent.cs
+++ b/src/MyAccountingApp.Core/Imports/IBKR/FeeAgent.cs
@@ -40,7 +40,7 @@ public class FeeAgent : IIBKRStatementAgent
             }
 
             Money money = new Money(Math.Abs(amount), currency);
-            Transaction transaction = new Transaction(date, description, money, TransactionCategory.EXPENSE);
+            Transaction transaction = new Transaction(date, description, money, TransactionCategory.FEE);
             transactions.Add(transaction);
         }
     }

--- a/src/MyAccountingApp.Core/Imports/IBKR/InteractiveBrokersImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/IBKR/InteractiveBrokersImportService.cs
@@ -368,15 +368,15 @@ public class InteractiveBrokersImportService : IBrokerImportService
         }
         else if (transactionType.Contains("withholding") || transactionType.Contains("tax"))
         {
-            category = TransactionCategory.EXPENSE;
+            category = TransactionCategory.WITHHOLDING_TAX;
         }
         else if (transactionType.Contains("dividend") || descLower.Contains("dividend"))
         {
-            category = TransactionCategory.INCOME;
+            category = TransactionCategory.DIVIDEND;
         }
         else if (transactionType.Contains("credit interest") || descLower.Contains("credit interest"))
         {
-            category = TransactionCategory.INCOME;
+            category = TransactionCategory.INTEREST;
         }
         else if (transactionType.Contains("debit interest") || descLower.Contains("debit interest"))
         {
@@ -384,7 +384,7 @@ public class InteractiveBrokersImportService : IBrokerImportService
         }
         else if (transactionType.Contains("fee") || descLower.Contains("fee"))
         {
-            category = TransactionCategory.EXPENSE;
+            category = TransactionCategory.FEE;
         }
 
         decimal quantity = this.ParseAmount(record.Quantity ?? "0");

--- a/src/MyAccountingApp.Core/Imports/IBKR/InterestAgent.cs
+++ b/src/MyAccountingApp.Core/Imports/IBKR/InterestAgent.cs
@@ -40,7 +40,7 @@ public class InterestAgent : IIBKRStatementAgent
             }
 
             bool isIncome = amount > 0;
-            TransactionCategory category = isIncome ? TransactionCategory.INCOME : TransactionCategory.EXPENSE;
+            TransactionCategory category = isIncome ? TransactionCategory.INTEREST : TransactionCategory.EXPENSE;
             Money money = new Money(Math.Abs(amount), currency);
             Transaction transaction = new Transaction(date, description, money, category);
             transactions.Add(transaction);

--- a/src/MyAccountingApp.Core/Imports/IBKR/WithholdingTaxAgent.cs
+++ b/src/MyAccountingApp.Core/Imports/IBKR/WithholdingTaxAgent.cs
@@ -40,7 +40,7 @@ public class WithholdingTaxAgent : IIBKRStatementAgent
             }
 
             Money money = new Money(Math.Abs(amount), currency);
-            Transaction transaction = new Transaction(date, description, money, TransactionCategory.EXPENSE);
+            Transaction transaction = new Transaction(date, description, money, TransactionCategory.WITHHOLDING_TAX);
             transactions.Add(transaction);
         }
     }

--- a/src/MyAccountingApp.Core/Imports/MyInvestor/MyInvestorFundImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/MyInvestor/MyInvestorFundImportService.cs
@@ -59,7 +59,7 @@ public class MyInvestorFundImportService : IBrokerImportService
                 }
 
                 Money money = new Money(amount, currency);
-                Transaction transaction = new Transaction(date, isin, money, TransactionCategory.EXPENSE);
+                Transaction transaction = new Transaction(date, isin, money, TransactionCategory.INVESTMENT);
                 AssetTransaction assetTx = new AssetTransaction(transaction, isin, quantity, AssetTransactionType.Buy);
                 assetTransactions.Add(assetTx);
             }

--- a/src/MyAccountingApp.Core/Imports/SelfBank/SelfBankFundImportService.cs
+++ b/src/MyAccountingApp.Core/Imports/SelfBank/SelfBankFundImportService.cs
@@ -68,7 +68,7 @@ public class SelfBankFundImportService : IBrokerImportService
                 }
 
                 string symbol = BuildSymbol(fundName);
-                TransactionCategory category = type == AssetTransactionType.Buy ? TransactionCategory.EXPENSE : TransactionCategory.INCOME;
+                TransactionCategory category = type == AssetTransactionType.Buy ? TransactionCategory.INVESTMENT : TransactionCategory.INCOME;
 
                 Money money = new Money(amount, "EUR");
                 Transaction transaction = new Transaction(date, fundName, money, category);

--- a/tests/MyAccountingApp.Core.Tests/Agents/IBKRStatementAgentsTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Agents/IBKRStatementAgentsTests.cs
@@ -170,7 +170,7 @@ public class IBKRStatementAgentsTests
     }
 
     [Theory]
-    [InlineData("10.00", TransactionCategory.INCOME)]
+    [InlineData("10.00", TransactionCategory.INTEREST)]
     [InlineData("-2.00", TransactionCategory.EXPENSE)]
     public void InterestAgent_ClassifiesBySign(string amount, TransactionCategory expected)
     {
@@ -192,7 +192,7 @@ public class IBKRStatementAgentsTests
     }
 
     [Fact]
-    public void WithholdingTaxAgent_AddsExpense()
+    public void WithholdingTaxAgent_AddsWithholdingTax()
     {
         WithholdingTaxAgent agent = new();
         List<Transaction> tx = new();
@@ -208,7 +208,7 @@ public class IBKRStatementAgentsTests
         agent.Parse(rows, tx, assets, options, errors);
 
         Transaction transaction = Assert.Single(tx);
-        Assert.Equal(TransactionCategory.EXPENSE, transaction.Category);
+        Assert.Equal(TransactionCategory.WITHHOLDING_TAX, transaction.Category);
         Assert.Equal(15, transaction.Money.Amount);
     }
 
@@ -229,7 +229,7 @@ public class IBKRStatementAgentsTests
         agent.Parse(rows, tx, assets, options, errors);
 
         Transaction transaction = Assert.Single(tx);
-        Assert.Equal(TransactionCategory.EXPENSE, transaction.Category);
+        Assert.Equal(TransactionCategory.FEE, transaction.Category);
         Assert.Equal("USD", transaction.Money.Currency);
         Assert.Equal(2.5m, transaction.Money.Amount);
     }
@@ -251,7 +251,7 @@ public class IBKRStatementAgentsTests
         agent.Parse(rows, tx, assets, options, errors);
 
         Transaction transaction = Assert.Single(tx);
-        Assert.Equal(TransactionCategory.INCOME, transaction.Category);
+        Assert.Equal(TransactionCategory.DIVIDEND, transaction.Category);
         Assert.Equal(1.5m, transaction.Money.Amount);
     }
 

--- a/tests/MyAccountingApp.Core.Tests/Agents/InteractiveBrokersImportServiceExtraTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Agents/InteractiveBrokersImportServiceExtraTests.cs
@@ -50,7 +50,7 @@ public class InteractiveBrokersImportServiceExtraTests
     }
 
     [Fact]
-    public async Task ParseAllAsync_ClassifiesWithholdingAndFeesAsExpense()
+    public async Task ParseAllAsync_ClassifiesWithholdingAndFeesAsExpenses()
     {
         List<IBKRTransactionRecord> records = new()
         {
@@ -63,7 +63,8 @@ public class InteractiveBrokersImportServiceExtraTests
 
         List<Transaction> list = tx.ToList();
         Assert.Equal(2, list.Count);
-        Assert.All(list, t => Assert.Equal(TransactionCategory.EXPENSE, t.Category));
+        Assert.Equal(TransactionCategory.WITHHOLDING_TAX, list[0].Category);
+        Assert.Equal(TransactionCategory.FEE, list[1].Category);
     }
 
     [Fact]
@@ -80,7 +81,8 @@ public class InteractiveBrokersImportServiceExtraTests
 
         List<Transaction> list = tx.ToList();
         Assert.Equal(2, list.Count);
-        Assert.All(list, t => Assert.Equal(TransactionCategory.INCOME, t.Category));
+        Assert.Equal(TransactionCategory.DIVIDEND, list[0].Category);
+        Assert.Equal(TransactionCategory.INTEREST, list[1].Category);
     }
 
     [Fact]

--- a/tests/MyAccountingApp.Core.Tests/Services/CobasImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/CobasImportServiceTests.cs
@@ -28,7 +28,7 @@ public class CobasImportServiceTests
             Assert.Empty(options);
             AssetTransaction asset = Assert.Single(assets);
             Assert.Equal(AssetTransactionType.Buy, asset.Type);
-            Assert.Equal(TransactionCategory.EXPENSE, asset.Transaction.Category);
+            Assert.Equal(TransactionCategory.INVESTMENT, asset.Transaction.Category);
             Assert.Equal("COBAS_INTERNACIONAL_D", asset.Symbol);
             Assert.Equal(0.502652m, asset.Quantity);
             Assert.Equal(120.00m, asset.Transaction.Money.Amount);

--- a/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/DegiroImportServiceTests.cs
@@ -117,7 +117,7 @@ public class DegiroImportServiceTests
     }
 
     [Fact]
-    public async Task ParseAllAsync_Commission_CreatesExpense()
+    public async Task ParseAllAsync_Commission_CreatesFee()
     {
         string csv = "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden\n" +
             "24-10-2025,17:15,24-10-2025,BTCETC BITCOIN EXCHANGE TRADED,DE000A27Z304,\"Costes de transacción y/o externos de DEGIRO\",,EUR,\"-3,00\",EUR,\"96,06\",16e33fba-6d63-411c-bf21-bb8ef4fe3222";
@@ -131,7 +131,7 @@ public class DegiroImportServiceTests
             Assert.Empty(assets);
             var t = Assert.Single(txs);
             Assert.Equal(3.00m, t.Money.Amount);
-            Assert.Equal(Domain.Enums.TransactionCategory.EXPENSE, t.Category);
+            Assert.Equal(Domain.Enums.TransactionCategory.FEE, t.Category);
         }
         finally
         {

--- a/tests/MyAccountingApp.Core.Tests/Services/MyInvestorFundImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/MyInvestorFundImportServiceTests.cs
@@ -28,7 +28,7 @@ public class MyInvestorFundImportServiceTests
             Assert.Empty(options);
             AssetTransaction asset = Assert.Single(assets);
             Assert.Equal(AssetTransactionType.Buy, asset.Type);
-            Assert.Equal(TransactionCategory.EXPENSE, asset.Transaction.Category);
+            Assert.Equal(TransactionCategory.INVESTMENT, asset.Transaction.Category);
             Assert.Equal("ES0165243017", asset.Symbol);
             Assert.Equal(234.913m, asset.Quantity);
             Assert.Equal(250.00m, asset.Transaction.Money.Amount);

--- a/tests/MyAccountingApp.Core.Tests/Services/SelfBankFundImportServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Services/SelfBankFundImportServiceTests.cs
@@ -30,7 +30,7 @@ public class SelfBankFundImportServiceTests
             Assert.Empty(options);
             AssetTransaction asset = Assert.Single(assets);
             Assert.Equal(AssetTransactionType.Buy, asset.Type);
-            Assert.Equal(TransactionCategory.EXPENSE, asset.Transaction.Category);
+            Assert.Equal(TransactionCategory.INVESTMENT, asset.Transaction.Category);
             Assert.Equal("SIGMA_INTERNACIONAL_A", asset.Symbol);
             Assert.Equal(6.63081400m, asset.Quantity);
             Assert.Equal(120.00m, asset.Transaction.Money.Amount);


### PR DESCRIPTION
## D2 — Mapping d'imports a les noves categories

Segon PR de la Fase D (apilat sobre `feat/transaction-categories`).

### Canvis (només imports nous; no es reescriu històric)
- **IBKR agents**: Dividends → `DIVIDEND`, Fees → `FEE`, Withholding Tax → `WITHHOLDING_TAX`, Interest positiu → `INTEREST` (negatiu manté `EXPENSE`)
- **IBKR Flex (MapToTransaction)**: withholding/tax → `WITHHOLDING_TAX`, dividend → `DIVIDEND`, credit interest → `INTEREST`, fee → `FEE`
- **Degiro cash classifier**: DIVIDENDO → `DIVIDEND`, RETENCI/WITHHOLDING i TAX/IMPUESTO → `WITHHOLDING_TAX`, COSTES/COST/COMISI i PASS-THROUGH → `FEE`, INTERES → `INTEREST`
- **Compres de fons → `INVESTMENT`**: MyInvestor, SelfBank, Cobas (vendes mantenen `INCOME`)
- Els buys de valors cotitzats (Degiro transactions, TradeAgent, CSV genèric) mantenen `EXPENSE`

### Tests actualitzats (Core 234)
- `IBKRStatementAgentsTests`: DIVIDEND/FEE/WITHHOLDING_TAX/INTEREST
- `InteractiveBrokersImportServiceExtraTests`: asserts per element
- `DegiroImportServiceTests`, `MyInvestorFundImportServiceTests`, `SelfBankFundImportServiceTests`, `CobasImportServiceTests`

Mergejar **en ordre**: C1 → C2 → C3 → D1 → aquest.
