### PR TITLE
feat(api+web): realized gains report by year

### DIFF
--- a/src/MyAccountingApp.Api/DependencyInjection.cs
+++ b/src/MyAccountingApp.Api/DependencyInjection.cs
@@ -168,6 +168,7 @@ public static class DependencyInjection
         builder.Services.AddSingleton<ITransactionCommandService, TransactionCommandService>();
         builder.Services.AddSingleton<IPortfolioQuery, PortfolioQuery>();
         builder.Services.AddSingleton<IPositionEngine, PositionEngine>();
+        builder.Services.AddSingleton<IRealizedGainsReportService, RealizedGainsReportService>();
         builder.Services.AddSingleton<IValidationQuery, ValidationQuery>();
         builder.Services.AddSingleton<IAnnualSummaryService, AnnualSummaryService>();
         builder.Services.AddSingleton<IDashboardQuery, DashboardQuery>();

--- a/src/MyAccountingApp.Api/Endpoints/ApiEndpoints.cs
+++ b/src/MyAccountingApp.Api/Endpoints/ApiEndpoints.cs
@@ -16,5 +16,6 @@ public static class ApiEndpoints
         app.MapConversionEndpoints();
         app.MapBackupEndpoints();
         app.MapDashboardEndpoints();
+        app.MapReportsEndpoints();
     }
 }

--- a/src/MyAccountingApp.Api/Endpoints/ReportsEndpoints.cs
+++ b/src/MyAccountingApp.Api/Endpoints/ReportsEndpoints.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Builder;
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Interfaces;
+
+namespace MyAccountingApp.Api.Endpoints;
+
+public static class ReportsEndpoints
+{
+    public static void MapReportsEndpoints(this WebApplication app)
+    {
+        const string prefix = ApiEndpoints.ApiPrefix;
+
+        app.MapGet($"{prefix}/reports/realized-gains", async (int year, IRealizedGainsReportService reportService) =>
+        {
+            RealizedGainsReportDto report = await reportService.GetRealizedGainsAsync(year);
+            return Results.Ok(report);
+        });
+
+        app.MapGet($"{prefix}/reports/withholding", async (int year, IRealizedGainsReportService reportService) =>
+        {
+            WithholdingReportDto report = await reportService.GetWithholdingAsync(year);
+            return Results.Ok(report);
+        });
+    }
+}

--- a/src/MyAccountingApp.Application/DTOs/RealizedGainsReportDto.cs
+++ b/src/MyAccountingApp.Application/DTOs/RealizedGainsReportDto.cs
@@ -1,0 +1,31 @@
+namespace MyAccountingApp.Application.DTOs;
+
+public record RealizedGainsReportDto(
+    int Year,
+    decimal TotalRealizedGainLoss,
+    List<SymbolRealizedGainsDto> Symbols);
+
+public record SymbolRealizedGainsDto(
+    string Symbol,
+    string Currency,
+    decimal SoldQuantity,
+    decimal Proceeds,
+    decimal CostBasis,
+    decimal RealizedGainLoss,
+    List<RealizedSaleDto> Sales);
+
+public record RealizedSaleDto(
+    DateTime Date,
+    decimal Quantity,
+    decimal Proceeds,
+    decimal CostBasis,
+    decimal RealizedGainLoss);
+
+public record WithholdingReportDto(
+    int Year,
+    List<WithholdingTotalDto> Totals);
+
+public record WithholdingTotalDto(
+    string Currency,
+    decimal Amount,
+    int TransactionCount);

--- a/src/MyAccountingApp.Application/Interfaces/IRealizedGainsReportService.cs
+++ b/src/MyAccountingApp.Application/Interfaces/IRealizedGainsReportService.cs
@@ -1,0 +1,10 @@
+using MyAccountingApp.Application.DTOs;
+
+namespace MyAccountingApp.Application.Interfaces;
+
+public interface IRealizedGainsReportService
+{
+    Task<RealizedGainsReportDto> GetRealizedGainsAsync(int year);
+
+    Task<WithholdingReportDto> GetWithholdingAsync(int year);
+}

--- a/src/MyAccountingApp.Application/Services/FifoCalculator.cs
+++ b/src/MyAccountingApp.Application/Services/FifoCalculator.cs
@@ -1,0 +1,128 @@
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+
+namespace MyAccountingApp.Application.Services;
+
+public sealed class FifoPosition
+{
+    required public IReadOnlyList<FifoLot> OpenLots { get; init; }
+    required public IReadOnlyList<FifoSale> Sales { get; init; }
+    public decimal RealizedGainLoss { get; init; }
+    public decimal NetQuantity { get; init; }
+    public decimal TotalCostBasis { get; init; }
+    public decimal UnmatchedSellQuantity { get; init; }
+    public int TransactionCount { get; init; }
+}
+
+public sealed class FifoLot
+{
+    public DateTime PurchaseDate { get; }
+    public decimal Quantity { get; }
+    public decimal TotalCost { get; }
+    public decimal UnitaryCost => this.TotalCost / this.Quantity;
+    public decimal RemainingQuantity { get; internal set; }
+
+    internal FifoLot(DateTime purchaseDate, decimal quantity, decimal totalCost)
+    {
+        this.PurchaseDate = purchaseDate;
+        this.Quantity = quantity;
+        this.TotalCost = totalCost;
+        this.RemainingQuantity = quantity;
+    }
+}
+
+public sealed class FifoSale
+{
+    public DateTime Date { get; }
+    public decimal Quantity { get; }
+    public decimal Proceeds { get; }
+    public decimal CostBasis { get; }
+    public decimal RealizedGainLoss { get; }
+
+    internal FifoSale(DateTime date, decimal quantity, decimal proceeds, decimal costBasis)
+    {
+        this.Date = date;
+        this.Quantity = quantity;
+        this.Proceeds = proceeds;
+        this.CostBasis = costBasis;
+        this.RealizedGainLoss = proceeds - costBasis;
+    }
+}
+
+public static class FifoCalculator
+{
+    public static FifoPosition Compute(IEnumerable<AssetTransaction> transactions)
+    {
+        List<AssetTransaction> ordered = transactions
+            .OrderBy(t => t.Transaction.Date)
+            .ToList();
+
+        List<FifoLot> lots = new();
+        List<FifoSale> sales = new();
+        decimal realizedGainLoss = 0;
+        decimal totalCost = 0;
+        decimal netQuantity = 0;
+        decimal unmatchedSellQuantity = 0;
+
+        foreach (AssetTransaction tx in ordered)
+        {
+            if (tx.Type == AssetTransactionType.Buy)
+            {
+                FifoLot lot = new(tx.Transaction.Date, tx.Quantity, tx.Transaction.Money.Amount);
+                lots.Add(lot);
+                netQuantity += tx.Quantity;
+                totalCost += tx.Transaction.Money.Amount;
+            }
+            else
+            {
+                decimal sellQty = tx.Quantity;
+                decimal matchedQty = 0;
+                decimal matchedProceeds = 0;
+                decimal matchedCostBasis = 0;
+
+                foreach (FifoLot lot in lots.Where(l => l.RemainingQuantity > 0).OrderBy(l => l.PurchaseDate))
+                {
+                    if (sellQty <= 0)
+                    {
+                        break;
+                    }
+
+                    decimal consumed = Math.Min(sellQty, lot.RemainingQuantity);
+                    decimal costBasis = consumed * lot.UnitaryCost;
+                    decimal proceeds = (consumed / tx.Quantity) * tx.Transaction.Money.Amount;
+
+                    matchedQty += consumed;
+                    matchedProceeds += proceeds;
+                    matchedCostBasis += costBasis;
+                    realizedGainLoss += proceeds - costBasis;
+                    totalCost -= costBasis;
+                    netQuantity -= consumed;
+
+                    lot.RemainingQuantity -= consumed;
+                    sellQty -= consumed;
+                }
+
+                if (matchedQty > 0)
+                {
+                    sales.Add(new FifoSale(tx.Transaction.Date, matchedQty, matchedProceeds, matchedCostBasis));
+                }
+
+                if (sellQty > 0)
+                {
+                    unmatchedSellQuantity += sellQty;
+                }
+            }
+        }
+
+        return new FifoPosition
+        {
+            OpenLots = lots.Where(l => l.RemainingQuantity > 0).ToList(),
+            Sales = sales,
+            RealizedGainLoss = realizedGainLoss,
+            NetQuantity = netQuantity,
+            TotalCostBasis = totalCost,
+            UnmatchedSellQuantity = unmatchedSellQuantity,
+            TransactionCount = ordered.Count,
+        };
+    }
+}

--- a/src/MyAccountingApp.Application/Services/PositionEngine.cs
+++ b/src/MyAccountingApp.Application/Services/PositionEngine.cs
@@ -1,6 +1,5 @@
 using MyAccountingApp.Application.DTOs;
 using MyAccountingApp.Application.Interfaces;
-using MyAccountingApp.Domain.Enums;
 using MyAccountingApp.Domain.Interfaces;
 using MyAccountingApp.Domain.ValueObjects;
 
@@ -19,78 +18,33 @@ public class PositionEngine : IPositionEngine
 
     public async Task<PortfolioPositionDto?> GetPosition(string symbol, bool includePrice = true)
     {
-        var transactions = this._portfolioRepo.GetAssetTransactions(symbol)
-            .OrderBy(t => t.Transaction.Date)
-            .ToList();
+        var transactions = this._portfolioRepo.GetAssetTransactions(symbol).ToList();
 
         if (transactions.Count == 0)
         {
             return null;
         }
 
-        var lots = new List<FifoLot>();
-        decimal realizedGainLoss = 0;
+        FifoPosition position = FifoCalculator.Compute(transactions);
         string currency = transactions[0].Transaction.Money.Currency;
-        decimal totalCost = 0;
-        decimal netQuantity = 0;
-        decimal unmatchedSellQuantity = 0;
 
-        foreach (var tx in transactions)
-        {
-            if (tx.Type == AssetTransactionType.Buy)
-            {
-                var lot = new FifoLot(tx.Transaction.Date, tx.Quantity, tx.Transaction.Money.Amount);
-                lots.Add(lot);
-                netQuantity += tx.Quantity;
-                totalCost += tx.Transaction.Money.Amount;
-            }
-            else
-            {
-                decimal sellQty = tx.Quantity;
+        decimal avgCost = position.NetQuantity > 0 ? Math.Round(position.TotalCostBasis / position.NetQuantity, 4) : 0;
 
-                foreach (var lot in lots.Where(l => l.RemainingQuantity > 0).OrderBy(l => l.PurchaseDate))
-                {
-                    if (sellQty <= 0)
-                    {
-                        break;
-                    }
+        Money? marketPrice = includePrice && position.NetQuantity > 0 ? await this._marketPriceService.GetPriceAsync(symbol) : null;
 
-                    decimal consumed = Math.Min(sellQty, lot.RemainingQuantity);
-                    decimal costBasis = consumed * lot.UnitaryCost;
-                    decimal proceeds = (consumed / tx.Quantity) * tx.Transaction.Money.Amount;
-
-                    realizedGainLoss += proceeds - costBasis;
-                    totalCost -= costBasis;
-                    netQuantity -= consumed;
-
-                    lot.RemainingQuantity -= consumed;
-                    sellQty -= consumed;
-                }
-
-                if (sellQty > 0)
-                {
-                    unmatchedSellQuantity += sellQty;
-                }
-            }
-        }
-
-        decimal avgCost = netQuantity > 0 ? Math.Round(totalCost / netQuantity, 4) : 0;
-
-        Money? marketPrice = includePrice && netQuantity > 0 ? await this._marketPriceService.GetPriceAsync(symbol) : null;
-
-        decimal? unrealizedGainLoss = marketPrice is not null && netQuantity > 0
-            ? Math.Round((marketPrice.Amount - avgCost) * netQuantity, 2)
+        decimal? unrealizedGainLoss = marketPrice is not null && position.NetQuantity > 0
+            ? Math.Round((marketPrice.Amount - avgCost) * position.NetQuantity, 2)
             : null;
 
         return new PortfolioPositionDto(
             symbol,
-            netQuantity,
+            position.NetQuantity,
             avgCost,
-            Math.Round(totalCost, 2),
+            Math.Round(position.TotalCostBasis, 2),
             currency,
-            transactions.Count,
-            Math.Round(realizedGainLoss, 2),
-            lots.Where(l => l.RemainingQuantity > 0)
+            position.TransactionCount,
+            Math.Round(position.RealizedGainLoss, 2),
+            position.OpenLots
                 .Select(l => new TaxLotDto(
                     l.PurchaseDate,
                     l.RemainingQuantity,
@@ -99,24 +53,7 @@ public class PositionEngine : IPositionEngine
                 .ToList(),
             marketPrice?.Amount,
             unrealizedGainLoss,
-            unmatchedSellQuantity > 0,
-            Math.Round(unmatchedSellQuantity, 4));
-    }
-
-    private sealed class FifoLot
-    {
-        public DateTime PurchaseDate { get; }
-        public decimal TotalQuantity { get; }
-        public decimal TotalCost { get; }
-        public decimal UnitaryCost => this.TotalCost / this.TotalQuantity;
-        public decimal RemainingQuantity { get; set; }
-
-        public FifoLot(DateTime purchaseDate, decimal quantity, decimal totalCost)
-        {
-            this.PurchaseDate = purchaseDate;
-            this.TotalQuantity = quantity;
-            this.TotalCost = totalCost;
-            this.RemainingQuantity = quantity;
-        }
+            position.UnmatchedSellQuantity > 0,
+            Math.Round(position.UnmatchedSellQuantity, 4));
     }
 }

--- a/src/MyAccountingApp.Application/Services/RealizedGainsReportService.cs
+++ b/src/MyAccountingApp.Application/Services/RealizedGainsReportService.cs
@@ -1,0 +1,79 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+
+namespace MyAccountingApp.Application.Services;
+
+public class RealizedGainsReportService : IRealizedGainsReportService
+{
+    private readonly IPortfolioRepository _portfolioRepo;
+    private readonly ITransactionRepository _transactionRepo;
+
+    public RealizedGainsReportService(IPortfolioRepository portfolioRepo, ITransactionRepository transactionRepo)
+    {
+        this._portfolioRepo = portfolioRepo;
+        this._transactionRepo = transactionRepo;
+    }
+
+    public Task<RealizedGainsReportDto> GetRealizedGainsAsync(int year)
+    {
+        List<Domain.Entities.AssetTransaction> all = this._portfolioRepo.GetAllTransactions().ToList();
+
+        List<SymbolRealizedGainsDto> symbols = all
+            .GroupBy(t => t.Symbol)
+            .Select(group =>
+            {
+                FifoPosition position = FifoCalculator.Compute(group);
+                List<RealizedSaleDto> yearSales = position.Sales
+                    .Where(s => s.Date.Year == year)
+                    .Select(s => new RealizedSaleDto(
+                        s.Date,
+                        Math.Round(s.Quantity, 4),
+                        Math.Round(s.Proceeds, 2),
+                        Math.Round(s.CostBasis, 2),
+                        Math.Round(s.RealizedGainLoss, 2)))
+                    .ToList();
+
+                if (yearSales.Count == 0)
+                {
+                    return null;
+                }
+
+                string currency = group.First().Transaction.Money.Currency;
+
+                return new SymbolRealizedGainsDto(
+                    group.Key,
+                    currency,
+                    Math.Round(yearSales.Sum(s => s.Quantity), 4),
+                    Math.Round(yearSales.Sum(s => s.Proceeds), 2),
+                    Math.Round(yearSales.Sum(s => s.CostBasis), 2),
+                    Math.Round(yearSales.Sum(s => s.RealizedGainLoss), 2),
+                    yearSales);
+            })
+            .Where(s => s is not null)
+            .Cast<SymbolRealizedGainsDto>()
+            .OrderBy(s => s.Symbol)
+            .ToList();
+
+        return Task.FromResult(new RealizedGainsReportDto(
+            year,
+            Math.Round(symbols.Sum(s => s.RealizedGainLoss), 2),
+            symbols));
+    }
+
+    public Task<WithholdingReportDto> GetWithholdingAsync(int year)
+    {
+        List<WithholdingTotalDto> totals = this._transactionRepo.GetAll()
+            .Where(t => t.Category == TransactionCategory.WITHHOLDING_TAX && t.Date.Year == year)
+            .GroupBy(t => t.Money.Currency)
+            .Select(g => new WithholdingTotalDto(
+                g.Key,
+                Math.Round(g.Sum(t => t.Money.Amount), 2),
+                g.Count()))
+            .OrderBy(t => t.Currency)
+            .ToList();
+
+        return Task.FromResult(new WithholdingReportDto(year, totals));
+    }
+}

--- a/src/MyAccountingApp.Web/Layout/NavMenu.razor
+++ b/src/MyAccountingApp.Web/Layout/NavMenu.razor
@@ -14,6 +14,7 @@
 
     <MudNavGroup Title="Reports" Icon="@Icons.Material.Filled.BarChart">
         <MudNavLink Href="summary" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Summarize">Summary</MudNavLink>
+        <MudNavLink Href="reports" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.ReceiptLong">Tax / Realized</MudNavLink>
     </MudNavGroup>
 
     <MudNavGroup Title="Data" Icon="@Icons.Material.Filled.Storage">

--- a/src/MyAccountingApp.Web/Models/Dtos.cs
+++ b/src/MyAccountingApp.Web/Models/Dtos.cs
@@ -126,3 +126,43 @@ public class DashboardAlertDto
     public string Message { get; set; } = string.Empty;
     public string? Link { get; set; }
 }
+
+public class RealizedGainsReportDto
+{
+    public int Year { get; set; }
+    public decimal TotalRealizedGainLoss { get; set; }
+    public List<SymbolRealizedGainsDto> Symbols { get; set; } = new();
+}
+
+public class SymbolRealizedGainsDto
+{
+    public string Symbol { get; set; } = string.Empty;
+    public string Currency { get; set; } = string.Empty;
+    public decimal SoldQuantity { get; set; }
+    public decimal Proceeds { get; set; }
+    public decimal CostBasis { get; set; }
+    public decimal RealizedGainLoss { get; set; }
+    public List<RealizedSaleDto> Sales { get; set; } = new();
+}
+
+public class RealizedSaleDto
+{
+    public DateTime Date { get; set; }
+    public decimal Quantity { get; set; }
+    public decimal Proceeds { get; set; }
+    public decimal CostBasis { get; set; }
+    public decimal RealizedGainLoss { get; set; }
+}
+
+public class WithholdingReportDto
+{
+    public int Year { get; set; }
+    public List<WithholdingTotalDto> Totals { get; set; } = new();
+}
+
+public class WithholdingTotalDto
+{
+    public string Currency { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public int TransactionCount { get; set; }
+}

--- a/src/MyAccountingApp.Web/Pages/Reports.razor
+++ b/src/MyAccountingApp.Web/Pages/Reports.razor
@@ -1,0 +1,179 @@
+@page "/reports"
+@page "/reports/{Year:int}"
+@inject HttpClient Http
+@inject NavigationManager Navigation
+
+<PageTitle>Reports</PageTitle>
+
+<MudText Typo="Typo.h3" GutterBottom="true">Reports</MudText>
+
+<MudPaper Class="pa-4 mb-6" Outlined="true">
+    <MudGrid>
+        <MudItem xs="12" md="3">
+            <MudSelect T="int" Label="Year" Variant="Variant.Outlined" FullWidth="true"
+                       Value="Year ?? DateTime.Today.Year" ValueChanged="@(y => NavigateToYear(y))">
+                @for (int y = DateTime.Today.Year; y >= DateTime.Today.Year - 10; y--)
+                {
+                    <MudSelectItem T="int" Value="@y">@y</MudSelectItem>
+                }
+            </MudSelect>
+        </MudItem>
+    </MudGrid>
+</MudPaper>
+
+@if (_loading)
+{
+    <MudProgressCircular Indeterminate="true" />
+}
+else
+{
+    <MudText Typo="Typo.subtitle1" Class="mb-2 mud-text-secondary">Realized gains (FIFO)</MudText>
+    <MudTable Items="@(_report?.Symbols ?? new List<SymbolRealizedGainsDto>())" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Outlined="true" Striped="true">
+        <ToolBarContent>
+            <MudText Typo="Typo.subtitle1">@(Year ?? DateTime.Today.Year)</MudText>
+            <MudSpacer />
+            <MudText Typo="Typo.body2">
+                Total realized:
+                <strong class="@(_report?.TotalRealizedGainLoss >= 0 ? "green--text" : "red--text")">
+                    @(_report?.TotalRealizedGainLoss >= 0 ? "+" : "")@_report?.TotalRealizedGainLoss.ToString("N2")
+                </strong>
+            </MudText>
+        </ToolBarContent>
+        <HeaderContent>
+            <MudTh>Symbol</MudTh>
+            <MudTh>Curr.</MudTh>
+            <MudTh>Sold Qty</MudTh>
+            <MudTh>Proceeds</MudTh>
+            <MudTh>Cost Basis</MudTh>
+            <MudTh>Realized P&amp;L</MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Symbol"><MudChip T="string" Size="Size.Small" Color="Color.Primary">@context.Symbol</MudChip></MudTd>
+            <MudTd DataLabel="Curr.">@context.Currency</MudTd>
+            <MudTd DataLabel="Sold Qty">@context.SoldQuantity.ToString("G")</MudTd>
+            <MudTd DataLabel="Proceeds">@context.Proceeds.ToString("N2")</MudTd>
+            <MudTd DataLabel="Cost Basis">@context.CostBasis.ToString("N2")</MudTd>
+            <MudTd DataLabel="Realized P&amp;L">
+                <span class="@(context.RealizedGainLoss >= 0 ? "green--text" : "red--text")">
+                    @(context.RealizedGainLoss >= 0 ? "+" : "")@context.RealizedGainLoss.ToString("N2")
+                </span>
+            </MudTd>
+            <MudTd>
+                <MudIconButton Icon="@(GetExpanded(context) ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
+                               OnClick="@(() => ToggleExpanded(context))" Size="Size.Small" />
+            </MudTd>
+        </RowTemplate>
+        <ChildRowContent>
+            @if (GetExpanded(context))
+            {
+                <MudTd colspan="7">
+                    <MudPaper Class="pa-4 mb-2 mt-2" Outlined="true">
+                        <MudText Typo="Typo.subtitle2" GutterBottom="true">Sales (@context.Sales.Count)</MudText>
+                        <MudSimpleTable>
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Quantity</th>
+                                    <th>Proceeds</th>
+                                    <th>Cost Basis</th>
+                                    <th>Realized P&amp;L</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var sale in context.Sales)
+                                {
+                                    <tr>
+                                        <td>@sale.Date.ToString("yyyy-MM-dd")</td>
+                                        <td>@sale.Quantity.ToString("G")</td>
+                                        <td>@sale.Proceeds.ToString("N2")</td>
+                                        <td>@sale.CostBasis.ToString("N2")</td>
+                                        <td class="@(sale.RealizedGainLoss >= 0 ? "green--text" : "red--text")">@(sale.RealizedGainLoss >= 0 ? "+" : "")@sale.RealizedGainLoss.ToString("N2")</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </MudSimpleTable>
+                    </MudPaper>
+                </MudTd>
+            }
+        </ChildRowContent>
+        <NoRecordsContent>
+            <MudText Class="pa-4">No sales in @(Year ?? DateTime.Today.Year).</MudText>
+        </NoRecordsContent>
+    </MudTable>
+
+    @if (_withholding?.Totals is { Count: > 0 })
+    {
+        <MudText Typo="Typo.subtitle1" Class="mt-8 mb-2 mud-text-secondary">Withholding tax</MudText>
+        <MudTable Items="@_withholding.Totals" Hover="true" Elevation="0" Outlined="true" Striped="true">
+            <HeaderContent>
+                <MudTh>Currency</MudTh>
+                <MudTh>Amount</MudTh>
+                <MudTh>Transactions</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Currency">@context.Currency</MudTd>
+                <MudTd DataLabel="Amount">@context.Amount.ToString("N2")</MudTd>
+                <MudTd DataLabel="Transactions">@context.TransactionCount</MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+}
+
+@code {
+    [Parameter] public int? Year { get; set; }
+
+    private RealizedGainsReportDto? _report;
+    private WithholdingReportDto? _withholding;
+    private bool _loading = true;
+    private readonly HashSet<string> _expanded = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadDataAsync();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!_loading)
+        {
+            await LoadDataAsync();
+        }
+    }
+
+    private int EffectiveYear => Year ?? DateTime.Today.Year;
+
+    private async Task LoadDataAsync()
+    {
+        _loading = true;
+        try
+        {
+            int year = this.EffectiveYear;
+            _report = await Http.GetFromJsonAsync<RealizedGainsReportDto>($"/api/reports/realized-gains?year={year}");
+            _withholding = await Http.GetFromJsonAsync<WithholdingReportDto>($"/api/reports/withholding?year={year}");
+            _expanded.Clear();
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private void NavigateToYear(int year)
+    {
+        if (year != this.EffectiveYear)
+        {
+            Navigation.NavigateTo($"/reports/{year}");
+        }
+    }
+
+    private bool GetExpanded(SymbolRealizedGainsDto symbol) => _expanded.Contains(symbol.Symbol);
+
+    private void ToggleExpanded(SymbolRealizedGainsDto symbol)
+    {
+        if (!_expanded.Remove(symbol.Symbol))
+        {
+            _expanded.Add(symbol.Symbol);
+        }
+    }
+}

--- a/tests/MyAccountingApp.Api.Tests/ReportsEndpointsTests.cs
+++ b/tests/MyAccountingApp.Api.Tests/ReportsEndpointsTests.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace MyAccountingApp.Api.Tests;
+
+public class ReportsEndpointsTests
+{
+    [Fact]
+    public async Task RealizedGains_ShouldReturnYearSalesWithFifoCosts()
+    {
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+
+        await client.PostAsJsonAsync("/api/asset-transactions", new
+        {
+            date = new DateTime(2024, 1, 15),
+            description = "Buy AAPL",
+            amount = 1000m,
+            currency = "EUR",
+            category = "INVESTMENT",
+            symbol = "AAPL",
+            quantity = 10m,
+            type = "Buy",
+        });
+        await client.PostAsJsonAsync("/api/asset-transactions", new
+        {
+            date = new DateTime(2025, 6, 1),
+            description = "Sell AAPL",
+            amount = 1500m,
+            currency = "EUR",
+            category = "INCOME",
+            symbol = "AAPL",
+            quantity = 10m,
+            type = "Sell",
+        });
+
+        HttpResponseMessage response = await client.GetAsync("/api/reports/realized-gains?year=2025");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(2025, document.RootElement.GetProperty("year").GetInt32());
+        Assert.Equal(500m, document.RootElement.GetProperty("totalRealizedGainLoss").GetDecimal());
+        JsonElement symbol = Assert.Single(document.RootElement.GetProperty("symbols").EnumerateArray());
+        Assert.Equal("AAPL", symbol.GetProperty("symbol").GetString());
+        Assert.Equal(10m, symbol.GetProperty("soldQuantity").GetDecimal());
+        Assert.Equal(1500m, symbol.GetProperty("proceeds").GetDecimal());
+        Assert.Equal(1000m, symbol.GetProperty("costBasis").GetDecimal());
+        Assert.Equal(500m, symbol.GetProperty("realizedGainLoss").GetDecimal());
+        JsonElement sale = Assert.Single(symbol.GetProperty("sales").EnumerateArray());
+        Assert.Equal(500m, sale.GetProperty("realizedGainLoss").GetDecimal());
+    }
+
+    [Fact]
+    public async Task RealizedGains_ShouldBeEmpty_WhenNoSalesInYear()
+    {
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+
+        await client.PostAsJsonAsync("/api/asset-transactions", new
+        {
+            date = new DateTime(2024, 1, 15),
+            description = "Buy AAPL",
+            amount = 1000m,
+            currency = "EUR",
+            category = "INVESTMENT",
+            symbol = "AAPL",
+            quantity = 10m,
+            type = "Buy",
+        });
+
+        HttpResponseMessage response = await client.GetAsync("/api/reports/realized-gains?year=2025");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Empty(document.RootElement.GetProperty("symbols").EnumerateArray());
+        Assert.Equal(0m, document.RootElement.GetProperty("totalRealizedGainLoss").GetDecimal());
+    }
+
+    [Fact]
+    public async Task Withholding_ShouldReturnPerCurrencyTotals()
+    {
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+
+        await client.PostAsJsonAsync("/api/transactions", new
+        {
+            date = new DateTime(2025, 3, 1),
+            description = "Withholding",
+            amount = 15m,
+            currency = "USD",
+            category = "WITHHOLDING_TAX",
+        });
+        await client.PostAsJsonAsync("/api/transactions", new
+        {
+            date = new DateTime(2025, 4, 1),
+            description = "Withholding",
+            amount = 20m,
+            currency = "USD",
+            category = "WITHHOLDING_TAX",
+        });
+
+        HttpResponseMessage response = await client.GetAsync("/api/reports/withholding?year=2025");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(2025, document.RootElement.GetProperty("year").GetInt32());
+        JsonElement total = Assert.Single(document.RootElement.GetProperty("totals").EnumerateArray());
+        Assert.Equal("USD", total.GetProperty("currency").GetString());
+        Assert.Equal(35m, total.GetProperty("amount").GetDecimal());
+        Assert.Equal(2, total.GetProperty("transactionCount").GetInt32());
+    }
+}

--- a/tests/MyAccountingApp.Application.Tests/Services/RealizedGainsReportServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/RealizedGainsReportServiceTests.cs
@@ -1,0 +1,128 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Core.Persistence;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+using MyAccountingApp.TestUtilities.Fakes;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class RealizedGainsReportServiceTests
+{
+    private static AssetTransaction Buy(string symbol, decimal price, decimal quantity, DateTime date)
+    {
+        Money money = new(price * quantity, "USD");
+        Transaction tx = new(Guid.NewGuid(), date, $"Buy {symbol}", money, TransactionCategory.INVESTMENT);
+        return new AssetTransaction(tx, symbol, quantity, AssetTransactionType.Buy);
+    }
+
+    private static AssetTransaction Sell(string symbol, decimal price, decimal quantity, DateTime date)
+    {
+        Money money = new(price * quantity, "USD");
+        Transaction tx = new(Guid.NewGuid(), date, $"Sell {symbol}", money, TransactionCategory.INCOME);
+        return new AssetTransaction(tx, symbol, quantity, AssetTransactionType.Sell);
+    }
+
+    [Fact]
+    public async Task GetRealizedGainsAsync_WithCrossYearSell_ReportsOnlyYearSales()
+    {
+        FakePortfolioRepo repo = new();
+        repo.AddOrUpdate(Buy("AAPL", 100, 10, new DateTime(2024, 1, 15)));
+        repo.AddOrUpdate(Sell("AAPL", 150, 10, new DateTime(2025, 6, 1)));
+        RealizedGainsReportService service = new(repo, new InMemoryTransactionRepository());
+
+        RealizedGainsReportDto report = await service.GetRealizedGainsAsync(2025);
+
+        Assert.Equal(2025, report.Year);
+        Assert.Equal(500m, report.TotalRealizedGainLoss);
+        SymbolRealizedGainsDto symbol = Assert.Single(report.Symbols);
+        Assert.Equal("AAPL", symbol.Symbol);
+        Assert.Equal("USD", symbol.Currency);
+        Assert.Equal(10m, symbol.SoldQuantity);
+        Assert.Equal(1500m, symbol.Proceeds);
+        Assert.Equal(1000m, symbol.CostBasis);
+        Assert.Equal(500m, symbol.RealizedGainLoss);
+        RealizedSaleDto sale = Assert.Single(symbol.Sales);
+        Assert.Equal(new DateTime(2025, 6, 1), sale.Date);
+        Assert.Equal(10m, sale.Quantity);
+        Assert.Equal(500m, sale.RealizedGainLoss);
+    }
+
+    [Fact]
+    public async Task GetRealizedGainsAsync_WithPartialFifoSells_UsesLifoCosts()
+    {
+        FakePortfolioRepo repo = new();
+        repo.AddOrUpdate(Buy("AAPL", 100, 10, new DateTime(2025, 1, 15)));
+        repo.AddOrUpdate(Sell("AAPL", 120, 5, new DateTime(2025, 6, 1)));
+        repo.AddOrUpdate(Sell("AAPL", 140, 5, new DateTime(2025, 7, 1)));
+        RealizedGainsReportService service = new(repo, new InMemoryTransactionRepository());
+
+        RealizedGainsReportDto report = await service.GetRealizedGainsAsync(2025);
+
+        Assert.Equal(300m, report.TotalRealizedGainLoss);
+        SymbolRealizedGainsDto symbol = Assert.Single(report.Symbols);
+        Assert.Equal(10m, symbol.SoldQuantity);
+        Assert.Equal(1300m, symbol.Proceeds);
+        Assert.Equal(1000m, symbol.CostBasis);
+        Assert.Equal(2, symbol.Sales.Count);
+    }
+
+    [Fact]
+    public async Task GetRealizedGainsAsync_WithNoYearSales_ReturnsEmptySymbols()
+    {
+        FakePortfolioRepo repo = new();
+        repo.AddOrUpdate(Buy("AAPL", 100, 10, new DateTime(2024, 1, 15)));
+        RealizedGainsReportService service = new(repo, new InMemoryTransactionRepository());
+
+        RealizedGainsReportDto report = await service.GetRealizedGainsAsync(2025);
+
+        Assert.Empty(report.Symbols);
+        Assert.Equal(0m, report.TotalRealizedGainLoss);
+    }
+
+    [Fact]
+    public async Task GetWithholdingAsync_GroupsByCurrencyAndYear()
+    {
+        InMemoryTransactionRepository repo = new();
+        repo.AddOrUpdate(WithholdingTx(new DateTime(2025, 3, 1), 15m, "USD"));
+        repo.AddOrUpdate(WithholdingTx(new DateTime(2025, 4, 1), 20m, "USD"));
+        repo.AddOrUpdate(WithholdingTx(new DateTime(2024, 12, 1), 10m, "EUR"));
+        repo.AddOrUpdate(new Transaction(Guid.NewGuid(), new DateTime(2025, 5, 1), "Dividend", new Money(50m, "USD"), TransactionCategory.DIVIDEND));
+        RealizedGainsReportService service = new(new FakePortfolioRepo(), repo);
+
+        WithholdingReportDto report = await service.GetWithholdingAsync(2025);
+
+        WithholdingTotalDto total = Assert.Single(report.Totals);
+        Assert.Equal("USD", total.Currency);
+        Assert.Equal(35m, total.Amount);
+        Assert.Equal(2, total.TransactionCount);
+    }
+
+    private static Transaction WithholdingTx(DateTime date, decimal amount, string currency) =>
+        new(Guid.NewGuid(), date, "Withholding", new Money(amount, currency), TransactionCategory.WITHHOLDING_TAX);
+
+    private sealed class FakePortfolioRepo : IPortfolioRepository
+    {
+        private readonly List<AssetTransaction> _transactions = new();
+
+        public void AddOrUpdate(AssetTransaction assetTransaction) =>
+            this._transactions.Add(assetTransaction);
+
+        public IEnumerable<AssetTransaction> GetAssetTransactions(string symbol) =>
+            this._transactions.Where(t => t.Symbol == symbol);
+
+        public IEnumerable<AssetTransaction> GetAllTransactions() =>
+            this._transactions;
+
+        public void Initialize(IEnumerable<AssetTransaction> transactions)
+        {
+            this._transactions.Clear();
+            this._transactions.AddRange(transactions);
+        }
+
+        public bool Delete(Guid transactionId) => true;
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
+    }
+}


### PR DESCRIPTION
## D3 — Informe de realized gains per any

Tercer PR de la Fase D (apilat sobre `feat/import-category-mapping`).

### Canvis
- **`FifoCalculator`** (Application): política FIFO compartida — `PositionEngine` ara el consumeix, garantint que l'informe i el portfolio usen **la mateixa política** (criteri d'acceptació del pla)
- **`GET /api/reports/realized-gains?year=2025`**: per símbol — quantitat venuda, proceeds, cost basis, realized + desglossament per venda (data, qty, proceeds, cost, P&L)
- **`GET /api/reports/withholding?year=2025`**: totals de WITHHOLDING_TAX per divisa (sense FX; això és Fase F)
- **UI**: pàgina **Reports** (`/reports/{year}`) sota el grup "Reports" del nav ("Tax / Realized") amb selector d'any, taula expandible per venda i secció de withholding

### Tests (App 109 · Api 57)
- `RealizedGainsReportServiceTests`: venda cross-year (FIFO cost de l'any anterior), sells parcials FIFO, sense vendes → buit, withholding per divisa/any
- `ReportsEndpointsTests`: ends-to-end via API
- `PositionEngineTests` inalterats → confirma que el refactor a `FifoCalculator` preserva el comportament exacte

Mergejar **en ordre**: C1 → C2 → C3 → D1 → D2 → aquest.
