### PR TITLE
feat(api): extended validation rules for data quality

### DIFF
--- a/src/MyAccountingApp.Application/Services/ValidationQuery.cs
+++ b/src/MyAccountingApp.Application/Services/ValidationQuery.cs
@@ -1,6 +1,8 @@
 using MyAccountingApp.Application.Interfaces;
 using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
 using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
 
 namespace MyAccountingApp.Application.Services;
 
@@ -9,15 +11,21 @@ public class ValidationQuery : IValidationQuery
     private readonly ITransactionRepository _txRepo;
     private readonly IPortfolioRepository _pfRepo;
     private readonly ITransactionValidator _validator;
+    private readonly IConversionRepository _conversionRepo;
+    private readonly IMarketPriceService _marketPriceService;
 
     public ValidationQuery(
         ITransactionRepository txRepo,
         IPortfolioRepository pfRepo,
-        ITransactionValidator validator)
+        ITransactionValidator validator,
+        IConversionRepository conversionRepo,
+        IMarketPriceService marketPriceService)
     {
         this._txRepo = txRepo;
         this._pfRepo = pfRepo;
         this._validator = validator;
+        this._conversionRepo = conversionRepo;
+        this._marketPriceService = marketPriceService;
     }
 
     public ValidationResult ValidateAll()
@@ -39,9 +47,109 @@ public class ValidationQuery : IValidationQuery
             allWarnings.AddRange(vr.Warnings);
         }
 
+        this.AddFifoShortfallRules(allWarnings);
+        this.AddUnmatchedTransferRules(allWarnings);
+        this.AddDuplicateFingerprintRules(allErrors);
+        this.AddMissingFxRules(allWarnings);
+        this.AddSymbolNoPriceRules(allWarnings);
+
         return new ValidationResult(
             allErrors.Count == 0,
             allErrors,
             allWarnings);
+    }
+
+    private void AddFifoShortfallRules(List<ValidationError> warnings)
+    {
+        foreach (IGrouping<string, AssetTransaction> group in this._pfRepo.GetAllTransactions().GroupBy(t => t.Symbol))
+        {
+            FifoPosition position = FifoCalculator.Compute(group);
+
+            if (position.UnmatchedSellQuantity > 0)
+            {
+                warnings.Add(new ValidationError(
+                    "FIFO_SHORTFALL",
+                    $"Symbol {group.Key} has {Math.Round(position.UnmatchedSellQuantity, 4):G} units sold without an open position",
+                    "warning"));
+            }
+        }
+    }
+
+    private void AddUnmatchedTransferRules(List<ValidationError> warnings)
+    {
+        List<Transaction> transfers = this._txRepo.GetAll()
+            .Where(t => t.Category == TransactionCategory.TRANSFER)
+            .ToList();
+
+        foreach (Transaction transfer in transfers)
+        {
+            bool hasPair = transfers.Any(other =>
+                other.Id != transfer.Id &&
+                other.Money.Amount == transfer.Money.Amount &&
+                other.Money.Currency == transfer.Money.Currency &&
+                Math.Abs((other.Date - transfer.Date).TotalDays) <= 3);
+
+            if (!hasPair)
+            {
+                warnings.Add(new ValidationError(
+                    "UNMATCHED_TRANSFER",
+                    $"Transfer on {transfer.Date:yyyy-MM-dd} ({transfer.Description}) has no matching counterpart within 3 days",
+                    "warning"));
+            }
+        }
+    }
+
+    private void AddDuplicateFingerprintRules(List<ValidationError> errors)
+    {
+        foreach (IGrouping<string, Transaction> group in this._txRepo.GetAll()
+            .GroupBy(t => $"{t.Date:yyyy-MM-dd}|{t.Description}|{t.Money.Amount}|{t.Money.Currency}")
+            .Where(g => g.Count() > 1))
+        {
+            Transaction first = group.First();
+            errors.Add(new ValidationError(
+                "DUPLICATE_FINGERPRINT",
+                $"{group.Count()} transactions share the same date, description and amount ({first.Date:yyyy-MM-dd} {first.Description} {first.Money.Amount} {first.Money.Currency})",
+                "error"));
+        }
+    }
+
+    private void AddMissingFxRules(List<ValidationError> warnings)
+    {
+        IEnumerable<Transaction> nonEur = this._txRepo.GetAll()
+            .Where(t => t.Money.Currency != "EUR");
+
+        foreach (Transaction tx in nonEur)
+        {
+            if (this._conversionRepo.GetByDate(tx.Date) is null)
+            {
+                warnings.Add(new ValidationError(
+                    "MISSING_FX",
+                    $"No EUR conversion available for {tx.Date:yyyy-MM-dd} ({tx.Money.Currency})",
+                    "warning"));
+            }
+        }
+    }
+
+    private void AddSymbolNoPriceRules(List<ValidationError> warnings)
+    {
+        foreach (IGrouping<string, AssetTransaction> group in this._pfRepo.GetAllTransactions().GroupBy(t => t.Symbol))
+        {
+            FifoPosition position = FifoCalculator.Compute(group);
+
+            if (position.NetQuantity <= 0)
+            {
+                continue;
+            }
+
+            Money? cachedPrice = this._marketPriceService.GetCachedPriceAsync(group.Key).GetAwaiter().GetResult();
+
+            if (cachedPrice is null)
+            {
+                warnings.Add(new ValidationError(
+                    "SYMBOL_NO_PRICE",
+                    $"Symbol {group.Key} has an open position but no market price cached",
+                    "info"));
+            }
+        }
     }
 }

--- a/src/MyAccountingApp.Core/Http/Market/YahooMarketPriceService.cs
+++ b/src/MyAccountingApp.Core/Http/Market/YahooMarketPriceService.cs
@@ -11,6 +11,18 @@ public class YahooMarketPriceService : IMarketPriceService
 
     public Task<Money?> RefreshPriceAsync(string symbol) => this.FetchAsync(symbol, useCache: false);
 
+    public Task<Money?> GetCachedPriceAsync(string symbol)
+    {
+        if (!LooksLikeListedEquity(symbol))
+        {
+            return Task.FromResult<Money?>(null);
+        }
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        Money? cached = this._cache.TryGetFresh(symbol, now, out Money? price) ? price : null;
+        return Task.FromResult(cached);
+    }
+
     private async Task<Money?> FetchAsync(string symbol, bool useCache)
     {
         if (!LooksLikeListedEquity(symbol))

--- a/src/MyAccountingApp.Domain/Interfaces/IMarketPriceService.cs
+++ b/src/MyAccountingApp.Domain/Interfaces/IMarketPriceService.cs
@@ -16,4 +16,11 @@ public interface IMarketPriceService
     /// <param name="symbol">Ticker</param>
     /// <returns>Price</returns>
     Task<Money?> RefreshPriceAsync(string symbol);
+
+    /// <summary>
+    /// Return el price of asset from the in-memory cache only, without fetching
+    /// </summary>
+    /// <param name="symbol">Ticker</param>
+    /// <returns>Cached price, or null if not cached</returns>
+    Task<Money?> GetCachedPriceAsync(string symbol);
 }

--- a/tests/MyAccountingApp.Api.Tests/Fakes/CountingMarketPriceService.cs
+++ b/tests/MyAccountingApp.Api.Tests/Fakes/CountingMarketPriceService.cs
@@ -23,4 +23,6 @@ public class CountingMarketPriceService : IMarketPriceService
         Interlocked.Increment(ref _calls);
         return Task.FromResult<Money?>(new Money(100m, "USD"));
     }
+
+    public Task<Money?> GetCachedPriceAsync(string symbol) => Task.FromResult<Money?>(null);
 }

--- a/tests/MyAccountingApp.Application.Tests/Services/PositionEngineTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/PositionEngineTests.cs
@@ -235,6 +235,8 @@ public class PositionEngineTests
         public Task<Money?> GetPriceAsync(string symbol) => throw new InvalidOperationException("Price service should not be called");
 
         public Task<Money?> RefreshPriceAsync(string symbol) => throw new InvalidOperationException("Price service should not be called");
+
+        public Task<Money?> GetCachedPriceAsync(string symbol) => throw new InvalidOperationException("Price service should not be called");
     }
 
     private sealed class FakePortfolioRepo : IPortfolioRepository

--- a/tests/MyAccountingApp.Application.Tests/Services/ValidationQueryTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ValidationQueryTests.cs
@@ -4,6 +4,7 @@ using MyAccountingApp.Domain.Entities;
 using MyAccountingApp.Domain.Enums;
 using MyAccountingApp.Domain.Interfaces;
 using MyAccountingApp.Domain.ValueObjects;
+using MyAccountingApp.TestUtilities.Fakes;
 
 namespace MyAccountingApp.Application.Tests.Services;
 
@@ -15,7 +16,7 @@ public class ValidationQueryTests
         FakeTxRepo txRepo = new();
         FakePfRepo pfRepo = new();
         TransactionValidator validator = new();
-        ValidationQuery query = new(txRepo, pfRepo, validator);
+        ValidationQuery query = new(txRepo, pfRepo, validator, new FakeConversionRepo(), new FakeMarketPriceService());
 
         ValidationResult result = query.ValidateAll();
 
@@ -48,12 +49,130 @@ public class ValidationQueryTests
         pfRepo.AddOrUpdate(assetTx);
 
         TransactionValidator validator = new();
-        ValidationQuery query = new(txRepo, pfRepo, validator);
+        ValidationQuery query = new(txRepo, pfRepo, validator, new FakeConversionRepo(), new FakeMarketPriceService());
 
         ValidationResult result = query.ValidateAll();
 
         Assert.False(result.IsValid);
         Assert.Equal(4, result.Errors.Count);
+    }
+
+    [Fact]
+    public void ValidateAll_FlagsFifoShortfall_AsWarning()
+    {
+        FakeTxRepo txRepo = new();
+        FakePfRepo pfRepo = new();
+        pfRepo.AddOrUpdate(new AssetTransaction(
+            new Transaction(Guid.NewGuid(), new DateTime(2024, 1, 15), "Buy AAPL", new Money(1000m, "USD"), TransactionCategory.INVESTMENT),
+            "AAPL",
+            10,
+            AssetTransactionType.Buy));
+        pfRepo.AddOrUpdate(new AssetTransaction(
+            new Transaction(Guid.NewGuid(), new DateTime(2024, 6, 1), "Sell AAPL", new Money(1500m, "USD"), TransactionCategory.INCOME),
+            "AAPL",
+            15,
+            AssetTransactionType.Sell));
+        ValidationQuery query = new(txRepo, pfRepo, new TransactionValidator(), new FakeConversionRepo(), new FakeMarketPriceService());
+
+        ValidationResult result = query.ValidateAll();
+
+        ValidationError warning = Assert.Single(result.Warnings);
+        Assert.Equal("FIFO_SHORTFALL", warning.Field);
+        Assert.Equal("warning", warning.Severity);
+    }
+
+    [Fact]
+    public void ValidateAll_FlagsUnmatchedTransfer_AsWarning()
+    {
+        FakeTxRepo txRepo = new();
+        txRepo.AddOrUpdate(new Transaction(Guid.NewGuid(), new DateTime(2025, 1, 10), "Transfer to bank", new Money(500m, "EUR"), TransactionCategory.TRANSFER));
+        FakePfRepo pfRepo = new();
+        ValidationQuery query = new(txRepo, pfRepo, new TransactionValidator(), new FakeConversionRepo(), new FakeMarketPriceService());
+
+        ValidationResult result = query.ValidateAll();
+
+        ValidationError warning = Assert.Single(result.Warnings);
+        Assert.Equal("UNMATCHED_TRANSFER", warning.Field);
+    }
+
+    [Fact]
+    public void ValidateAll_DoesNotFlagTransfer_WhenPairExists()
+    {
+        FakeTxRepo txRepo = new();
+        DateTime date = new(2025, 1, 10);
+        txRepo.AddOrUpdate(new Transaction(Guid.NewGuid(), date, "Transfer A", new Money(500m, "EUR"), TransactionCategory.TRANSFER));
+        txRepo.AddOrUpdate(new Transaction(Guid.NewGuid(), date.AddDays(1), "Transfer B", new Money(500m, "EUR"), TransactionCategory.TRANSFER));
+        FakePfRepo pfRepo = new();
+        ValidationQuery query = new(txRepo, pfRepo, new TransactionValidator(), new FakeConversionRepo(), new FakeMarketPriceService());
+
+        ValidationResult result = query.ValidateAll();
+
+        Assert.DoesNotContain(result.Warnings, w => w.Field == "UNMATCHED_TRANSFER");
+    }
+
+    [Fact]
+    public void ValidateAll_FlagsDuplicateFingerprint_AsError()
+    {
+        FakeTxRepo txRepo = new();
+        Transaction tx = new(Guid.NewGuid(), new DateTime(2025, 1, 10), "Salary", new Money(1000m, "EUR"), TransactionCategory.INCOME);
+        txRepo.AddOrUpdate(tx);
+        txRepo.AddOrUpdate(new Transaction(Guid.NewGuid(), tx.Date, tx.Description, tx.Money, tx.Category));
+        FakePfRepo pfRepo = new();
+        ValidationQuery query = new(txRepo, pfRepo, new TransactionValidator(), new FakeConversionRepo(), new FakeMarketPriceService());
+
+        ValidationResult result = query.ValidateAll();
+
+        ValidationError error = Assert.Single(result.Errors);
+        Assert.Equal("DUPLICATE_FINGERPRINT", error.Field);
+        Assert.Equal("error", error.Severity);
+    }
+
+    [Fact]
+    public void ValidateAll_FlagsMissingFx_WhenNoConversionForDate()
+    {
+        FakeTxRepo txRepo = new();
+        txRepo.AddOrUpdate(new Transaction(Guid.NewGuid(), new DateTime(2025, 1, 10), "Buy in USD", new Money(100m, "USD"), TransactionCategory.EXPENSE));
+        FakePfRepo pfRepo = new();
+        ValidationQuery query = new(txRepo, pfRepo, new TransactionValidator(), new FakeConversionRepo(), new FakeMarketPriceService());
+
+        ValidationResult result = query.ValidateAll();
+
+        ValidationError warning = Assert.Single(result.Warnings);
+        Assert.Equal("MISSING_FX", warning.Field);
+    }
+
+    [Fact]
+    public void ValidateAll_DoesNotFlagMissingFx_WhenConversionExists()
+    {
+        FakeTxRepo txRepo = new();
+        DateTime date = new(2025, 1, 10);
+        txRepo.AddOrUpdate(new Transaction(Guid.NewGuid(), date, "Buy in USD", new Money(100m, "USD"), TransactionCategory.EXPENSE));
+        FakePfRepo pfRepo = new();
+        Conversion conversion = new(date, Currencies.EUR, new Dictionary<Currencies, decimal> { { Currencies.USD, 1.08m } });
+        ValidationQuery query = new(txRepo, pfRepo, new TransactionValidator(), new FakeConversionRepo(conversion), new FakeMarketPriceService());
+
+        ValidationResult result = query.ValidateAll();
+
+        Assert.DoesNotContain(result.Warnings, w => w.Field == "MISSING_FX");
+    }
+
+    [Fact]
+    public void ValidateAll_FlagsSymbolWithoutCachedPrice_AsInfo()
+    {
+        FakeTxRepo txRepo = new();
+        FakePfRepo pfRepo = new();
+        pfRepo.AddOrUpdate(new AssetTransaction(
+            new Transaction(Guid.NewGuid(), new DateTime(2025, 1, 15), "Buy UNKN", new Money(100m, "USD"), TransactionCategory.INVESTMENT),
+            "UNKN",
+            5,
+            AssetTransactionType.Buy));
+        ValidationQuery query = new(txRepo, pfRepo, new TransactionValidator(), new FakeConversionRepo(), new FakeMarketPriceService());
+
+        ValidationResult result = query.ValidateAll();
+
+        ValidationError warning = Assert.Single(result.Warnings);
+        Assert.Equal("SYMBOL_NO_PRICE", warning.Field);
+        Assert.Equal("info", warning.Severity);
     }
 
     private sealed class FakeTxRepo : ITransactionRepository
@@ -88,5 +207,29 @@ public class ValidationQueryTests
 
         public bool Delete(Guid transactionId) => true;
         public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
+    }
+
+    private sealed class FakeConversionRepo : IConversionRepository
+    {
+        private readonly Conversion? _conversion;
+
+        public FakeConversionRepo(Conversion? conversion = null)
+        {
+            this._conversion = conversion;
+        }
+
+        public void AddOrUpdate(Conversion conversion)
+        {
+        }
+
+        public Conversion? GetByDate(DateTime date) => this._conversion;
+
+        public Conversion? GetLatestOnOrBefore(DateTime date) => this._conversion;
+
+        public void Initialize(IEnumerable<Conversion> conversions)
+        {
+        }
+
+        public IEnumerable<Conversion> GetAll() => this._conversion is null ? Array.Empty<Conversion>() : new[] { this._conversion };
     }
 }

--- a/tests/MyAccountingApp.TestUtilities/Fakes/FakeMarketPriceService.cs
+++ b/tests/MyAccountingApp.TestUtilities/Fakes/FakeMarketPriceService.cs
@@ -30,5 +30,8 @@ namespace MyAccountingApp.TestUtilities.Fakes
         }
 
         public Task<Money?> RefreshPriceAsync(string symbol) => this.GetPriceAsync(symbol);
+
+        public Task<Money?> GetCachedPriceAsync(string symbol) =>
+            Task.FromResult(_prices.TryGetValue(symbol, out Money? price) ? price : null);
     }
 }


### PR DESCRIPTION
## E1 — Regles de validació ampliades

Primer PR de la Fase E (apilat sobre `feat/realized-gains-report`).

### Noves regles a `GET /api/validate`
| Codi | Severitat | Descripció |
|---|---|---|
| `FIFO_SHORTFALL` | warning | Posició amb vendes sense posició oberta (reusa `FifoCalculator`) |
| `UNMATCHED_TRANSFER` | warning | TRANSFER sense contrapart (mateix import+divisa, ±3 dies) |
| `DUPLICATE_FINGERPRINT` | error | Txs cash amb mateixa data+descripció+import+divisa |
| `MISSING_FX` | warning | Tx no-EUR sense conversion guardada per data |
| `SYMBOL_NO_PRICE` | info | Símbol amb posició oberta sense preu cachejat |

### Altres canvis
- `IMarketPriceService.GetCachedPriceAsync` — només cache, sense xarxa (la regla SYMBOL_NO_PRICE no fa crides)
- `ValidationQuery` ara depèn de `IConversionRepository` + `IMarketPriceService` (DI automàtic)

### Tests (App 116)
- `ValidationQueryTests`: +7 tests (shortfall, transfer sense parella, parella ok, duplicat, MISSING_FX amb/sense conversion, SYMBOL_NO_PRICE)

Mergejar **en ordre**: C1 → C2 → C3 → D1 → D2 → D3 → aquest.
