### PR TITLE
feat(web): data quality page with dashboard alert link

### DIFF
--- a/src/MyAccountingApp.Application/Services/DashboardQuery.cs
+++ b/src/MyAccountingApp.Application/Services/DashboardQuery.cs
@@ -32,6 +32,7 @@ public class DashboardQuery : IDashboardQuery
         CashSnapshotDto cash = BuildCashSnapshot(allTransactions, asOf);
         PortfolioSnapshotDto portfolio = BuildPortfolioSnapshot(allAssetTransactions, asOf.Year);
         List<DashboardAlertDto> alerts = BuildAlerts(allTransactions, allAssetTransactions);
+        this.AddDataQualityAlert(alerts);
 
         return Task.FromResult(new DashboardDto(asOf, cash, portfolio, alerts));
     }
@@ -151,6 +152,28 @@ public class DashboardQuery : IDashboardQuery
         }
 
         return alerts;
+    }
+
+    private void AddDataQualityAlert(List<DashboardAlertDto> alerts)
+    {
+        ValidationResult validation = this._validationQuery.ValidateAll();
+
+        if (validation.Errors.Count > 0)
+        {
+            alerts.Add(new DashboardAlertDto(
+                "error",
+                "DATA_QUALITY",
+                $"{validation.Errors.Count} data quality error(s) found",
+                "/data-quality"));
+        }
+        else if (validation.Warnings.Count > 0)
+        {
+            alerts.Add(new DashboardAlertDto(
+                "warning",
+                "DATA_QUALITY",
+                $"{validation.Warnings.Count} data quality warning(s) found",
+                "/data-quality"));
+        }
     }
 
     private sealed class FifoLot

--- a/src/MyAccountingApp.Web/Layout/NavMenu.razor
+++ b/src/MyAccountingApp.Web/Layout/NavMenu.razor
@@ -19,6 +19,7 @@
 
     <MudNavGroup Title="Data" Icon="@Icons.Material.Filled.Storage">
         <MudNavLink Href="import" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.FileUpload">Import</MudNavLink>
+        <MudNavLink Href="data-quality" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Checklist">Data quality</MudNavLink>
         <MudNavLink Href="settings" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Settings">Settings</MudNavLink>
     </MudNavGroup>
 </MudNavMenu>

--- a/src/MyAccountingApp.Web/Models/Dtos.cs
+++ b/src/MyAccountingApp.Web/Models/Dtos.cs
@@ -75,6 +75,15 @@ public class ValidationError
     public string Severity { get; set; } = string.Empty;
 }
 
+public class ValidationResponseDto
+{
+    public bool IsValid { get; set; }
+    public int ErrorCount { get; set; }
+    public int WarningCount { get; set; }
+    public List<ValidationError> Errors { get; set; } = new();
+    public List<ValidationError> Warnings { get; set; } = new();
+}
+
 public class BatchPatchFailureDto
 {
     public Guid Id { get; set; }

--- a/src/MyAccountingApp.Web/Pages/DataQuality.razor
+++ b/src/MyAccountingApp.Web/Pages/DataQuality.razor
@@ -1,0 +1,104 @@
+@page "/data-quality"
+@inject HttpClient Http
+
+<PageTitle>Data quality</PageTitle>
+
+<MudText Typo="Typo.h3" GutterBottom="true">Data quality</MudText>
+
+<MudButton Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Refresh"
+           OnClick="@LoadDataAsync" Disabled="@_loading" Class="mb-4">
+    Re-check
+</MudButton>
+
+@if (_loading)
+{
+    <MudProgressCircular Indeterminate="true" />
+}
+else
+{
+    @if (_result is { IsValid: true } && _result.Warnings.Count == 0)
+    {
+        <MudAlert Severity="Severity.Success" Class="mb-4">No data quality issues found.</MudAlert>
+    }
+    else
+    {
+        <MudPaper Class="pa-4 mb-4" Outlined="true">
+            <MudGrid>
+                <MudItem xs="4" md="3">
+                    <MudChip T="string" Color="Color.Error" Size="Size.Medium">
+                        @_result?.ErrorCount errors
+                    </MudChip>
+                </MudItem>
+                <MudItem xs="4" md="3">
+                    <MudChip T="string" Color="Color.Warning" Size="Size.Medium">
+                        @WarningCount warnings
+                    </MudChip>
+                </MudItem>
+                <MudItem xs="4" md="3">
+                    <MudChip T="string" Color="Color.Info" Size="Size.Medium">
+                        @InfoCount info
+                    </MudChip>
+                </MudItem>
+            </MudGrid>
+        </MudPaper>
+
+        <MudTable Items="@_issues" Hover="true" Breakpoint="Breakpoint.Sm" Elevation="0" Outlined="true" Striped="true">
+            <HeaderContent>
+                <MudTh>Severity</MudTh>
+                <MudTh>Code</MudTh>
+                <MudTh>Message</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Severity">
+                    <MudChip T="string" Size="Size.Small" Color="@MapSeverityColor(context.Severity)">@context.Severity</MudChip>
+                </MudTd>
+                <MudTd DataLabel="Code"><MudText Typo="Typo.body2" Style="font-family: monospace">@context.Field</MudText></MudTd>
+                <MudTd DataLabel="Message">@context.Message</MudTd>
+            </RowTemplate>
+            <NoRecordsContent>
+                <MudText Class="pa-4">No issues.</MudText>
+            </NoRecordsContent>
+        </MudTable>
+    }
+}
+
+@code {
+    private ValidationResponseDto? _result;
+    private List<ValidationError> _issues = new();
+    private bool _loading = true;
+
+    private int WarningCount => _result?.Warnings.Count(w => w.Severity != "info") ?? 0;
+    private int InfoCount => _result?.Warnings.Count(w => w.Severity == "info") ?? 0;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadDataAsync();
+    }
+
+    private async Task LoadDataAsync()
+    {
+        _loading = true;
+        try
+        {
+            _result = await Http.GetFromJsonAsync<ValidationResponseDto>("/api/validate");
+            _issues = new List<ValidationError>();
+            if (_result is not null)
+            {
+                _issues.AddRange(_result.Errors);
+                _issues.AddRange(_result.Warnings);
+            }
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private static Color MapSeverityColor(string severity) => severity switch
+    {
+        "error" => Color.Error,
+        "warning" => Color.Warning,
+        "info" => Color.Info,
+        _ => Color.Default,
+    };
+}

--- a/tests/MyAccountingApp.Api.Tests/DashboardEndpointsTests.cs
+++ b/tests/MyAccountingApp.Api.Tests/DashboardEndpointsTests.cs
@@ -57,7 +57,11 @@ public class DashboardEndpointsTests
         Assert.Equal(0, portfolio.GetProperty("realizedGainLossYtdEur").GetDecimal());
         Assert.Equal(1, portfolio.GetProperty("openPositionCount").GetInt32());
 
-        Assert.Empty(root.GetProperty("alerts").EnumerateArray());
+        JsonElement alerts = root.GetProperty("alerts");
+        Assert.Contains(alerts.EnumerateArray(), a =>
+            a.GetProperty("code").GetString() == "DATA_QUALITY"
+            && a.GetProperty("severity").GetString() == "warning"
+            && a.GetProperty("link").GetString() == "/data-quality");
     }
 
     [Fact]

--- a/tests/MyAccountingApp.Application.Tests/Services/DashboardQueryTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/DashboardQueryTests.cs
@@ -99,8 +99,64 @@ public class DashboardQueryTests
         public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
     }
 
+    [Fact]
+    public async Task GetAsync_ShouldAddDataQualityAlert_WhenValidationHasErrors()
+    {
+        FakeTxRepo txRepo = new();
+        FakeValidationQuery validation = new(1, 0);
+
+        DashboardQuery query = new(txRepo, new FakePfRepo(), validation);
+
+        DashboardDto dashboard = await query.GetAsync(AsOf);
+
+        DashboardAlertDto alert = Assert.Single(dashboard.Alerts);
+        Assert.Equal("error", alert.Severity);
+        Assert.Equal("DATA_QUALITY", alert.Code);
+        Assert.Equal("/data-quality", alert.Link);
+    }
+
+    [Fact]
+    public async Task GetAsync_ShouldAddDataQualityAlert_WhenValidationHasWarnings()
+    {
+        FakeTxRepo txRepo = new();
+        FakeValidationQuery validation = new(0, 2);
+
+        DashboardQuery query = new(txRepo, new FakePfRepo(), validation);
+
+        DashboardDto dashboard = await query.GetAsync(AsOf);
+
+        DashboardAlertDto alert = Assert.Single(dashboard.Alerts);
+        Assert.Equal("warning", alert.Severity);
+        Assert.Equal("DATA_QUALITY", alert.Code);
+    }
+
+    [Fact]
+    public async Task GetAsync_ShouldNotAddDataQualityAlert_WhenValidationClean()
+    {
+        FakeTxRepo txRepo = new();
+        FakeValidationQuery validation = new(0, 0);
+
+        DashboardQuery query = new(txRepo, new FakePfRepo(), validation);
+
+        DashboardDto dashboard = await query.GetAsync(AsOf);
+
+        Assert.DoesNotContain(dashboard.Alerts, a => a.Code == "DATA_QUALITY");
+    }
+
     private sealed class FakeValidationQuery : IValidationQuery
     {
-        public ValidationResult ValidateAll() => new ValidationResult(true, new List<ValidationError>(), new List<ValidationError>());
+        private readonly int _errorCount;
+        private readonly int _warningCount;
+
+        public FakeValidationQuery(int errorCount = 0, int warningCount = 0)
+        {
+            this._errorCount = errorCount;
+            this._warningCount = warningCount;
+        }
+
+        public ValidationResult ValidateAll() => new ValidationResult(
+            this._errorCount == 0,
+            Enumerable.Range(0, this._errorCount).Select(_ => new ValidationError("FIELD", "error", "error")).ToList(),
+            Enumerable.Range(0, this._warningCount).Select(_ => new ValidationError("FIELD", "warning", "warning")).ToList());
     }
 }


### PR DESCRIPTION
## E2 — Pàgina Data quality + alerta al dashboard

Segon PR de la Fase E (apilat sobre `feat/extended-validation-rules`).

### Canvis
- **Pàgina `/data-quality`** (grup nav "Data"): crida `GET /api/validate`, resum per severitat (errors/warnings/info), taula d'incidències amb chip de severitat, botó Re-check
- **Alerta al dashboard** (enllaç des d'alertes, com demana el pla): si hi ha errors → `DATA_QUALITY` error; si només warnings → warning; sempre amb link a `/data-quality`
- `DashboardQuery` per fi usa el `IValidationQuery` que tenia injectat però mort

### Tests
- `DashboardQueryTests`: +3 (alerta error / alerta warning / sense alerta quan tot net)
- `DashboardEndpointsTests`: actualitzat — el dashboard ara retorna l'alerta DATA_QUALITY (el seed crea una posició AAPL sense preu cachejat)

Mergejar **en ordre**: C1 → C2 → C3 → D1 → D2 → D3 → E1 → aquest.
