### PR TITLE
feat(app): ToEur helper and EUR valuations on portfolio view

### DIFF
--- a/src/MyAccountingApp.Api/DependencyInjection.cs
+++ b/src/MyAccountingApp.Api/DependencyInjection.cs
@@ -168,6 +168,8 @@ public static class DependencyInjection
         builder.Services.AddSingleton<ITransactionCommandService, TransactionCommandService>();
         builder.Services.AddSingleton<IPortfolioQuery, PortfolioQuery>();
         builder.Services.AddSingleton<IPositionEngine, PositionEngine>();
+        builder.Services.AddSingleton<IToEurConverter, ToEurConverter>();
+        builder.Services.AddSingleton<IPositionValuationService, PositionValuationService>();
         builder.Services.AddSingleton<IRealizedGainsReportService, RealizedGainsReportService>();
         builder.Services.AddSingleton<IValidationQuery, ValidationQuery>();
         builder.Services.AddSingleton<IAnnualSummaryService, AnnualSummaryService>();

--- a/src/MyAccountingApp.Api/Endpoints/PortfolioEndpoints.cs
+++ b/src/MyAccountingApp.Api/Endpoints/PortfolioEndpoints.cs
@@ -32,6 +32,13 @@ public static class PortfolioEndpoints
             return Results.Ok(positions.Where(p => p is not null).ToList());
         });
 
+        app.MapGet($"{prefix}/portfolio/valuation", async (IPositionValuationService valuationService, DateTime? asOf) =>
+        {
+            DateOnly valuationDate = DateOnly.FromDateTime((asOf ?? DateTime.UtcNow).Date);
+            IReadOnlyList<PositionValuationDto> valuations = await valuationService.GetValuationsAsync(valuationDate);
+            return Results.Ok(new { asOf = valuationDate, positions = valuations });
+        });
+
         app.MapGet($"{prefix}/validate", (IValidationQuery validationQuery) =>
         {
             ValidationResult result = validationQuery.ValidateAll();

--- a/src/MyAccountingApp.Application/DTOs/EurConversionDto.cs
+++ b/src/MyAccountingApp.Application/DTOs/EurConversionDto.cs
@@ -1,0 +1,11 @@
+namespace MyAccountingApp.Application.DTOs;
+
+/// <summary>
+/// Represents a currency amount converted to EUR with full FX traceability.
+/// </summary>
+public sealed record EurConversionDto(
+    decimal AmountEur,
+    decimal Rate,
+    DateOnly RateDate,
+    bool IsStale,
+    string Provider);

--- a/src/MyAccountingApp.Application/DTOs/PositionValuationDto.cs
+++ b/src/MyAccountingApp.Application/DTOs/PositionValuationDto.cs
@@ -1,0 +1,17 @@
+namespace MyAccountingApp.Application.DTOs;
+
+/// <summary>
+/// Represents the EUR valuation of an open position, including the FX rate applied and its rate date.
+/// </summary>
+public sealed record PositionValuationDto(
+    string Symbol,
+    string Currency,
+    decimal NetQuantity,
+    decimal? MarketPrice,
+    decimal? UnrealizedGainLoss,
+    decimal? ValueEur,
+    decimal? UnrealizedGainLossEur,
+    decimal? Rate,
+    DateOnly? RateDate,
+    bool IsStale,
+    string? Provider);

--- a/src/MyAccountingApp.Application/Interfaces/IPositionValuationService.cs
+++ b/src/MyAccountingApp.Application/Interfaces/IPositionValuationService.cs
@@ -1,0 +1,17 @@
+using MyAccountingApp.Application.DTOs;
+
+namespace MyAccountingApp.Application.Interfaces;
+
+/// <summary>
+/// Computes EUR valuations for all open positions with FX traceability.
+/// </summary>
+public interface IPositionValuationService
+{
+    /// <summary>
+    /// Computes the EUR valuation of every open position as of the given date.
+    /// </summary>
+    /// <param name="asOf">The date for which rates are requested.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The valuations, one per symbol with transactions.</returns>
+    Task<IReadOnlyList<PositionValuationDto>> GetValuationsAsync(DateOnly asOf, CancellationToken cancellationToken = default);
+}

--- a/src/MyAccountingApp.Application/Interfaces/IToEurConverter.cs
+++ b/src/MyAccountingApp.Application/Interfaces/IToEurConverter.cs
@@ -1,0 +1,20 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Application.Interfaces;
+
+/// <summary>
+/// Converts a monetary amount to EUR using the currency rate service, keeping the
+/// applied rate date traceable when the quote is stale.
+/// </summary>
+public interface IToEurConverter
+{
+    /// <summary>
+    /// Converts the given money to EUR using the rate for the specified date.
+    /// </summary>
+    /// <param name="money">The amount to convert. EUR amounts are returned unchanged.</param>
+    /// <param name="date">The date for which the rate is requested.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The EUR amount with the applied rate and its actual rate date.</returns>
+    Task<EurConversionDto> ToEurAsync(Money money, DateOnly date, CancellationToken cancellationToken = default);
+}

--- a/src/MyAccountingApp.Application/Services/PositionValuationService.cs
+++ b/src/MyAccountingApp.Application/Services/PositionValuationService.cs
@@ -1,0 +1,93 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Domain.Exceptions;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Application.Services;
+
+/// <inheritdoc/>
+public class PositionValuationService : IPositionValuationService
+{
+    private readonly IPortfolioRepository _portfolioRepo;
+    private readonly IPositionEngine _positionEngine;
+    private readonly IToEurConverter _toEurConverter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PositionValuationService"/> class.
+    /// </summary>
+    /// <param name="portfolioRepo">Repository holding the asset transactions.</param>
+    /// <param name="positionEngine">Engine computing positions and market prices.</param>
+    /// <param name="toEurConverter">Converter used for the EUR valuation.</param>
+    public PositionValuationService(
+        IPortfolioRepository portfolioRepo,
+        IPositionEngine positionEngine,
+        IToEurConverter toEurConverter)
+    {
+        this._portfolioRepo = portfolioRepo;
+        this._positionEngine = positionEngine;
+        this._toEurConverter = toEurConverter;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<PositionValuationDto>> GetValuationsAsync(DateOnly asOf, CancellationToken cancellationToken = default)
+    {
+        string[] symbols = this._portfolioRepo.GetAllTransactions().Select(t => t.Symbol).Distinct().ToArray();
+        List<PositionValuationDto> result = new();
+
+        foreach (string symbol in symbols)
+        {
+            PortfolioPositionDto? position = await this._positionEngine.GetPosition(symbol, includePrice: true);
+
+            if (position is null || position.NetQuantity <= 0)
+            {
+                continue;
+            }
+
+            decimal? valueEur = null;
+            decimal? unrealizedEur = null;
+            decimal? rate = null;
+            DateOnly? rateDate = null;
+            bool isStale = false;
+            string? provider = null;
+
+            if (position.MarketPrice is not null)
+            {
+                try
+                {
+                    Money marketValue = new(position.MarketPrice.Value * position.NetQuantity, position.Currency);
+                    EurConversionDto converted = await this._toEurConverter.ToEurAsync(marketValue, asOf, cancellationToken);
+                    valueEur = converted.AmountEur;
+                    rate = converted.Rate;
+                    rateDate = converted.RateDate;
+                    isStale = converted.IsStale;
+                    provider = converted.Provider;
+
+                    if (position.UnrealizedGainLoss is not null)
+                    {
+                        Money unrealized = new(position.UnrealizedGainLoss.Value, position.Currency);
+                        unrealizedEur = (await this._toEurConverter.ToEurAsync(unrealized, asOf, cancellationToken)).AmountEur;
+                    }
+                }
+                catch (ConversionNotAvailableException)
+                {
+                }
+            }
+
+            result.Add(new PositionValuationDto(
+                symbol,
+                position.Currency,
+                position.NetQuantity,
+                position.MarketPrice,
+                position.UnrealizedGainLoss,
+                valueEur,
+                unrealizedEur,
+                rate,
+                rateDate,
+                isStale,
+                provider));
+        }
+
+        return result;
+    }
+}

--- a/src/MyAccountingApp.Application/Services/ToEurConverter.cs
+++ b/src/MyAccountingApp.Application/Services/ToEurConverter.cs
@@ -1,0 +1,45 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Interfaces;
+using MyAccountingApp.Domain.Exceptions;
+using MyAccountingApp.Domain.ValueObjects;
+
+namespace MyAccountingApp.Application.Services;
+
+/// <inheritdoc/>
+public class ToEurConverter : IToEurConverter
+{
+    private readonly ICurrencyRateService _rateService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToEurConverter"/> class.
+    /// </summary>
+    /// <param name="rateService">The currency rate service used to resolve quotes.</param>
+    public ToEurConverter(ICurrencyRateService rateService)
+    {
+        this._rateService = rateService;
+    }
+
+    /// <inheritdoc/>
+    public async Task<EurConversionDto> ToEurAsync(Money money, DateOnly date, CancellationToken cancellationToken = default)
+    {
+        if (money.Currency == "EUR")
+        {
+            return new EurConversionDto(money.Amount, 1m, date, false, "base");
+        }
+
+        IReadOnlyList<FxQuoteDto> quotes = await this._rateService.GetFxQuotesAsync(date.ToDateTime(TimeOnly.MinValue), cancellationToken);
+        FxQuoteDto? quote = quotes.FirstOrDefault(q => string.Equals(q.Quote, money.Currency, StringComparison.OrdinalIgnoreCase));
+
+        if (quote is null)
+        {
+            throw new ConversionNotAvailableException($"No conversion available for {money.Currency} on {date:yyyy-MM-dd}");
+        }
+
+        return new EurConversionDto(
+            Math.Round(money.Amount / quote.Rate, 2),
+            quote.Rate,
+            quote.RateDate,
+            quote.IsStale,
+            quote.Provider);
+    }
+}

--- a/src/MyAccountingApp.Web/Models/Dtos.cs
+++ b/src/MyAccountingApp.Web/Models/Dtos.cs
@@ -68,6 +68,27 @@ public class ImportResultDto
     public int FilesProcessed { get; set; }
 }
 
+public class PositionValuationDto
+{
+    public string Symbol { get; set; } = string.Empty;
+    public string Currency { get; set; } = string.Empty;
+    public decimal NetQuantity { get; set; }
+    public decimal? MarketPrice { get; set; }
+    public decimal? UnrealizedGainLoss { get; set; }
+    public decimal? ValueEur { get; set; }
+    public decimal? UnrealizedGainLossEur { get; set; }
+    public decimal? Rate { get; set; }
+    public DateOnly? RateDate { get; set; }
+    public bool IsStale { get; set; }
+    public string? Provider { get; set; }
+}
+
+public class PositionValuationResponse
+{
+    public DateOnly AsOf { get; set; }
+    public List<PositionValuationDto> Positions { get; set; } = new();
+}
+
 public class ValidationError
 {
     public string Field { get; set; } = string.Empty;

--- a/src/MyAccountingApp.Web/Pages/Portfolio.razor
+++ b/src/MyAccountingApp.Web/Pages/Portfolio.razor
@@ -37,6 +37,13 @@ else
                 {
                     <strong>—</strong>
                 }
+                @if (_hasValuations)
+                {
+                    <text>&nbsp;|&nbsp; Value in EUR: <strong>@_totalValueEur.ToString("N2")</strong></text>
+                    <text>&nbsp;|&nbsp; Unrealized P&amp;L EUR:
+                        <strong class="@(_totalUnrealizedEur >= 0 ? "green--text" : "red--text")">@(_totalUnrealizedEur >= 0 ? "+" : "")@_totalUnrealizedEur.ToString("N2")</strong>
+                    </text>
+                }
             </MudText>
         </ToolBarContent>
         <ColGroup>
@@ -59,6 +66,15 @@ else
             <MudTh>Mkt Price</MudTh>
             <MudTh><MudTableSortLabel SortBy="new Func<PortfolioPositionDto, object>(p => p.UnrealizedGainLoss ?? 0)">Unrealized P&amp;L</MudTableSortLabel></MudTh>
             <MudTh><MudTableSortLabel SortBy="new Func<PortfolioPositionDto, object>(p => p.RealizedGainLoss)">Realized P&amp;L</MudTableSortLabel></MudTh>
+            @if (_hasValuations)
+            {
+                <MudTh>
+                    <MudTooltip Placement="Placement.Top">
+                        <ChildContent><span>Value in EUR (FX rate date in tooltip)</span></ChildContent>
+                        <TooltipContent><span>Market value converted to EUR using the rate for the selected date</span></TooltipContent>
+                    </MudTooltip>
+                </MudTh>
+            }
             <MudTh></MudTh>
         </HeaderContent>
         <RowTemplate>
@@ -100,6 +116,37 @@ else
                     @(context.RealizedGainLoss >= 0 ? "+" : "")@context.RealizedGainLoss.ToString("N2")
                 </span>
             </MudTd>
+            @if (_hasValuations)
+            {
+                <MudTd DataLabel="Value EUR">
+                    @{ PositionValuationDto? val = GetValuation(context.Symbol); }
+                    @if (val?.ValueEur is not null)
+                    {
+                        <MudTooltip Placement="Placement.Top">
+                            <ChildContent>
+                                <span class="px-1">@val.ValueEur.Value.ToString("N2") EUR</span>
+                            </ChildContent>
+                            <TooltipContent>
+                                <span>@context.NetQuantity.ToString("G") × @(context.MarketPrice?.ToString("N4")) @context.Currency
+                                    × @(val.Rate?.ToString("N4")) (@(val.RateDate?.ToString("yyyy-MM-dd"))) = @val.ValueEur.Value.ToString("N2") EUR</span>
+                            </TooltipContent>
+                        </MudTooltip>
+                        @if (val.IsStale)
+                        {
+                            <MudTooltip Placement="Placement.Top">
+                                <ChildContent>
+                                    <MudIcon Icon="@Icons.Material.Filled.WarningAmber" Color="Color.Warning" Size="Size.Small" Class="ml-1" />
+                                </ChildContent>
+                                <TooltipContent><span>Stale rate applied from @(val.RateDate?.ToString("yyyy-MM-dd"))</span></TooltipContent>
+                            </MudTooltip>
+                        }
+                    }
+                    else
+                    {
+                        <span>—</span>
+                    }
+                </MudTd>
+            }
             <MudTd>
                 <MudIconButton Icon="@(GetExpanded(context) ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
                                OnClick="@(() => ToggleExpanded(context))"
@@ -149,14 +196,18 @@ else
 
 @code {
     private List<PortfolioPositionDto> _positions = new();
+    private Dictionary<string, PositionValuationDto> _valuations = new();
     private bool _loading = true;
     private bool _refreshing;
     private bool _hasPrices;
+    private bool _hasValuations;
     private readonly HashSet<string> _expanded = new();
 
     private decimal _totalCostBasis;
     private decimal _totalRealized;
     private decimal _totalUnrealized;
+    private decimal _totalValueEur;
+    private decimal _totalUnrealizedEur;
 
     protected override async Task OnInitializedAsync()
     {
@@ -186,6 +237,7 @@ else
             HttpResponseMessage response = await Http.PostAsync("/api/portfolio/refresh-prices", null);
             _positions = await response.Content.ReadFromJsonAsync<List<PortfolioPositionDto>>() ?? new();
             _hasPrices = true;
+            await LoadValuationsAsync();
             ComputeTotals();
         }
         finally
@@ -194,11 +246,22 @@ else
         }
     }
 
+    private async Task LoadValuationsAsync()
+    {
+        PositionValuationResponse? valuation = await Http.GetFromJsonAsync<PositionValuationResponse>("/api/portfolio/valuation");
+        _valuations = valuation?.Positions.ToDictionary(p => p.Symbol) ?? new();
+        _hasValuations = true;
+    }
+
+    private PositionValuationDto? GetValuation(string symbol) => _valuations.GetValueOrDefault(symbol);
+
     private void ComputeTotals()
     {
         _totalCostBasis = _positions.Sum(p => p.TotalCostBasis);
         _totalRealized = _positions.Sum(p => p.RealizedGainLoss);
         _totalUnrealized = _positions.Sum(p => p.UnrealizedGainLoss ?? 0);
+        _totalValueEur = _valuations.Values.Sum(v => v.ValueEur ?? 0);
+        _totalUnrealizedEur = _valuations.Values.Sum(v => v.UnrealizedGainLossEur ?? 0);
     }
 
     private bool GetExpanded(PortfolioPositionDto pos) => _expanded.Contains(pos.Symbol);

--- a/tests/MyAccountingApp.Api.Tests/PortfolioEndpointsTests.cs
+++ b/tests/MyAccountingApp.Api.Tests/PortfolioEndpointsTests.cs
@@ -183,14 +183,55 @@ public class PortfolioEndpointsTests
         Assert.Equal(100m, position.GetProperty("marketPrice").GetDecimal());
     }
 
-    private static async Task SeedBuyAsync(HttpClient client)
+    [Fact]
+    public async Task Valuation_ShouldConvertNonEurPosition_WithRateAndRateDate()
+    {
+        CountingMarketPriceService.Reset();
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        await SeedBuyAsync(client, currency: "USD");
+
+        HttpResponseMessage response = await client.GetAsync("/api/portfolio/valuation?asOf=2026-08-11");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("2026-08-11", document.RootElement.GetProperty("asOf").GetString());
+        JsonElement position = Assert.Single(document.RootElement.GetProperty("positions").EnumerateArray());
+        Assert.Equal("USD", position.GetProperty("currency").GetString());
+        Assert.Equal(100m, position.GetProperty("marketPrice").GetDecimal());
+        Assert.Equal(181.82m, position.GetProperty("valueEur").GetDecimal());
+        Assert.Equal(45.45m, position.GetProperty("unrealizedGainLossEur").GetDecimal());
+        Assert.Equal(1.1m, position.GetProperty("rate").GetDecimal());
+        Assert.Equal("2026-08-11", position.GetProperty("rateDate").GetString());
+        Assert.False(position.GetProperty("isStale").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Valuation_ShouldUseIdentityRate_ForEurPosition()
+    {
+        CountingMarketPriceService.Reset();
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        await SeedBuyAsync(client);
+
+        HttpResponseMessage response = await client.GetAsync("/api/portfolio/valuation?asOf=2026-08-11");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement position = Assert.Single(document.RootElement.GetProperty("positions").EnumerateArray());
+        Assert.Equal("EUR", position.GetProperty("currency").GetString());
+        Assert.Equal(200m, position.GetProperty("valueEur").GetDecimal());
+        Assert.Equal(1m, position.GetProperty("rate").GetDecimal());
+    }
+
+    private static async Task SeedBuyAsync(HttpClient client, string currency = "EUR")
     {
         HttpResponseMessage response = await client.PostAsJsonAsync("/api/asset-transactions", new
         {
             date = new DateTime(2026, 1, 5),
             description = "Buy AAPL",
             amount = 150m,
-            currency = "EUR",
+            currency,
             category = "EXPENSE",
             symbol = "AAPL",
             quantity = 2m,

--- a/tests/MyAccountingApp.Application.Tests/Services/PositionValuationServiceTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/PositionValuationServiceTests.cs
@@ -1,0 +1,136 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+using MyAccountingApp.TestUtilities.Fakes;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class PositionValuationServiceTests
+{
+    private static AssetTransaction Buy(string symbol, string currency, decimal price, decimal quantity, DateTime date)
+    {
+        Money money = new(price * quantity, currency);
+        Transaction tx = new(
+            Guid.NewGuid(),
+            date,
+            $"Buy {symbol}",
+            money,
+            TransactionCategory.EXPENSE);
+        return new AssetTransaction(tx, symbol, quantity, AssetTransactionType.Buy);
+    }
+
+    private static PositionValuationService CreateService(FakePortfolioRepo repo, FakeApiQuotaManager quota)
+    {
+        FakeMarketPriceService priceService = new();
+        PositionEngine engine = new(repo, priceService);
+        FakeConversionRepository conversionRepo = new();
+        FakePendingConversionQueue queue = new();
+        CurrencyRateService rateService = new(conversionRepo, new FakeCurrencyConverter(), Currencies.EUR, quota, queue);
+        ToEurConverter converter = new(rateService);
+        return new PositionValuationService(repo, engine, converter);
+    }
+
+    [Fact]
+    public async Task GetValuationsAsync_ConvertsUsdPosition_WithRateAndRateDate()
+    {
+        FakePortfolioRepo repo = new();
+        repo.AddOrUpdate(Buy("AAPL", "USD", 150, 10, new DateTime(2024, 1, 15)));
+        PositionValuationService service = CreateService(repo, new FakeApiQuotaManager());
+
+        IReadOnlyList<PositionValuationDto> result = await service.GetValuationsAsync(new DateOnly(2023, 12, 1));
+
+        PositionValuationDto valuation = Assert.Single(result);
+        Assert.Equal("AAPL", valuation.Symbol);
+        Assert.Equal("USD", valuation.Currency);
+        Assert.Equal(10, valuation.NetQuantity);
+        Assert.Equal(150.25m, valuation.MarketPrice);
+        Assert.Equal(1365.91m, valuation.ValueEur);
+        Assert.Equal(2.50m, valuation.UnrealizedGainLoss);
+        Assert.Equal(2.27m, valuation.UnrealizedGainLossEur);
+        Assert.Equal(1.1m, valuation.Rate);
+        Assert.Equal(new DateOnly(2023, 12, 1), valuation.RateDate);
+        Assert.False(valuation.IsStale);
+    }
+
+    [Fact]
+    public async Task GetValuationsAsync_EurPosition_UsesIdentityRate()
+    {
+        FakePortfolioRepo repo = new();
+        repo.AddOrUpdate(Buy("BMW.DE", "EUR", 80.75m, 10, new DateTime(2024, 1, 15)));
+        PositionValuationService service = CreateService(repo, new FakeApiQuotaManager());
+
+        IReadOnlyList<PositionValuationDto> result = await service.GetValuationsAsync(new DateOnly(2023, 12, 1));
+
+        PositionValuationDto valuation = Assert.Single(result);
+        Assert.Equal("EUR", valuation.Currency);
+        Assert.Equal(807.50m, valuation.ValueEur);
+        Assert.Equal(1m, valuation.Rate);
+        Assert.False(valuation.IsStale);
+    }
+
+    [Fact]
+    public async Task GetValuationsAsync_MarksStale_WhenRateIsFallback()
+    {
+        FakePortfolioRepo repo = new();
+        repo.AddOrUpdate(Buy("AAPL", "USD", 150, 10, new DateTime(2024, 1, 15)));
+        PositionValuationService service = CreateService(repo, new FakeApiQuotaManager() { CanConsumeResult = false });
+
+        IReadOnlyList<PositionValuationDto> result = await service.GetValuationsAsync(new DateOnly(2023, 12, 1));
+
+        PositionValuationDto valuation = Assert.Single(result);
+        Assert.True(valuation.IsStale);
+        Assert.Equal(new DateOnly(2005, 12, 1), valuation.RateDate);
+    }
+
+    [Fact]
+    public async Task GetValuationsAsync_LeavesEurNull_WhenNoMarketPrice()
+    {
+        FakePortfolioRepo repo = new();
+        repo.AddOrUpdate(Buy("UNKNOWN", "USD", 10, 5, new DateTime(2024, 1, 15)));
+        PositionValuationService service = CreateService(repo, new FakeApiQuotaManager());
+
+        IReadOnlyList<PositionValuationDto> result = await service.GetValuationsAsync(new DateOnly(2023, 12, 1));
+
+        PositionValuationDto valuation = Assert.Single(result);
+        Assert.Null(valuation.MarketPrice);
+        Assert.Null(valuation.ValueEur);
+        Assert.Null(valuation.Rate);
+    }
+
+    [Fact]
+    public async Task GetValuationsAsync_ReturnsEmpty_WhenNoTransactions()
+    {
+        FakePortfolioRepo repo = new();
+        PositionValuationService service = CreateService(repo, new FakeApiQuotaManager());
+
+        IReadOnlyList<PositionValuationDto> result = await service.GetValuationsAsync(new DateOnly(2023, 12, 1));
+
+        Assert.Empty(result);
+    }
+
+    private sealed class FakePortfolioRepo : IPortfolioRepository
+    {
+        private readonly List<AssetTransaction> _transactions = new();
+
+        public void AddOrUpdate(AssetTransaction assetTransaction) =>
+            this._transactions.Add(assetTransaction);
+
+        public IEnumerable<AssetTransaction> GetAssetTransactions(string symbol) =>
+            this._transactions.Where(t => t.Symbol == symbol);
+
+        public IEnumerable<AssetTransaction> GetAllTransactions() =>
+            this._transactions;
+
+        public void Initialize(IEnumerable<AssetTransaction> transactions)
+        {
+            this._transactions.Clear();
+            this._transactions.AddRange(transactions);
+        }
+
+        public bool Delete(Guid transactionId) => true;
+        public int DeleteByYear(int year) => this._transactions.RemoveAll(t => t.Transaction.Date.Year == year);
+    }
+}

--- a/tests/MyAccountingApp.Application.Tests/Services/ToEurConverterTests.cs
+++ b/tests/MyAccountingApp.Application.Tests/Services/ToEurConverterTests.cs
@@ -1,0 +1,73 @@
+using MyAccountingApp.Application.DTOs;
+using MyAccountingApp.Application.Services;
+using MyAccountingApp.Domain.Entities;
+using MyAccountingApp.Domain.Enums;
+using MyAccountingApp.Domain.Exceptions;
+using MyAccountingApp.Domain.Interfaces;
+using MyAccountingApp.Domain.ValueObjects;
+using MyAccountingApp.TestUtilities.Fakes;
+
+namespace MyAccountingApp.Application.Tests.Services;
+
+public class ToEurConverterTests
+{
+    private static ToEurConverter CreateService(FakeApiQuotaManager quota)
+    {
+        FakeConversionRepository repo = new();
+        FakePendingConversionQueue queue = new();
+        CurrencyRateService rateService = new(repo, new FakeCurrencyConverter(), Currencies.EUR, quota, queue);
+        return new ToEurConverter(rateService);
+    }
+
+    [Fact]
+    public async Task ToEurAsync_ReturnsUnchanged_WhenCurrencyIsEur()
+    {
+        ToEurConverter converter = CreateService(new FakeApiQuotaManager());
+        Money money = new(123.45m, "EUR");
+
+        EurConversionDto result = await converter.ToEurAsync(money, new DateOnly(2026, 8, 11));
+
+        Assert.Equal(123.45m, result.AmountEur);
+        Assert.Equal(1m, result.Rate);
+        Assert.Equal(new DateOnly(2026, 8, 11), result.RateDate);
+        Assert.False(result.IsStale);
+        Assert.Equal("base", result.Provider);
+    }
+
+    [Fact]
+    public async Task ToEurAsync_DividesByRate_WhenNonEur()
+    {
+        ToEurConverter converter = CreateService(new FakeApiQuotaManager());
+        Money money = new(110m, "USD");
+
+        EurConversionDto result = await converter.ToEurAsync(money, new DateOnly(2023, 12, 1));
+
+        Assert.Equal(100m, result.AmountEur);
+        Assert.Equal(1.1m, result.Rate);
+        Assert.Equal(new DateOnly(2023, 12, 1), result.RateDate);
+        Assert.False(result.IsStale);
+    }
+
+    [Fact]
+    public async Task ToEurAsync_ExposesFallbackRateDate_WhenStale()
+    {
+        ToEurConverter converter = CreateService(new FakeApiQuotaManager() { CanConsumeResult = false });
+        Money money = new(110m, "USD");
+
+        EurConversionDto result = await converter.ToEurAsync(money, new DateOnly(2023, 12, 1));
+
+        Assert.Equal(100m, result.AmountEur);
+        Assert.Equal(1.1m, result.Rate);
+        Assert.Equal(new DateOnly(2005, 12, 1), result.RateDate);
+        Assert.True(result.IsStale);
+    }
+
+    [Fact]
+    public async Task ToEurAsync_Throws_WhenNoQuoteForCurrency()
+    {
+        ToEurConverter converter = CreateService(new FakeApiQuotaManager());
+        Money money = new(100m, "JPY");
+
+        await Assert.ThrowsAsync<ConversionNotAvailableException>(() => converter.ToEurAsync(money, new DateOnly(2023, 12, 1)));
+    }
+}


### PR DESCRIPTION
## F2 — Helper ToEur + valoracions EUR a la vista Portfolio

Segon PR de la Fase F. Apilat sobre `fix/fx-rate-date`.

### Canvis
- **`IToEurConverter.ToEurAsync(Money, DateOnly, ct)`** → `EurConversionDto` (AmountEur, Rate, RateDate, IsStale, Provider):
  - EUR → identitat (Rate 1, sense crida FX)
  - No EUR → quote de `GetFxQuotesAsync` (stale-safe, no corromp l'entitat cachejada); 404 propagat com `ConversionNotAvailableException`
- **`PositionValuationService`** + `GET /api/portfolio/valuation?asOf=` → valoració EUR de totes les posicions obertes amb rate i rateDate per símbol
- **UI Portfolio**: columna "Value EUR" (visible després de Refresh prices, preservant el disseny lazy de preus) amb tooltip `qty × price Curr × rate (rateDate) = N EUR`, icona ⚠ si el tipus és stale, i totals "Value in EUR" / "Unrealized P&L EUR" a la barra superior

### Tests (466 en total, tots verds)
- `ToEurConverterTests` (4): EUR identitat; USD divideix pel rate; stale exposa rateDate del fallback; moneda sense quote llança
- `PositionValuationServiceTests` (5): conversió USD amb rate/rateDate; EUR rate 1; stale marcat; sense preu de mercat → valor EUR null; sense transaccions → buit
- API (2): valoració USD (valueEur 181.82, rate 1.1, rateDate) i EUR (rate 1)

Mergejar **en ordre**: C1 → C2 → C3 → D1 → D2 → D3 → E1 → E2 → F1 → aquest.