### PR TITLE
feat(security): vault feature flag for dev, encrypted backups and settings security

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -86,11 +86,13 @@ docker compose up --build -d
 - Logs: mounted to `./logs/` (Serilog, 7-day retention)
 
 ## Security model (vault + localhost-first)
+- **Feature flag**: `Vault:Enabled` in `appsettings.json`. While developing, keep it `false`: the vault is off, data is stored plaintext, and no Setup/Unlock screens appear. Switch it to `true` when the product is consolidated and data should be encrypted. Until then, **fails open by design** — do not deploy with `Vault:Enabled=false` if you treat the backup/threat model as active.
 - **Encrypted at rest**: financial data is stored as `data/*.json.enc` (AES-GCM, 256-bit key derived with PBKDF2-SHA256). A reader with filesystem access cannot read the data without the password.
 - **Unlock required**: on first run the UI asks to create a vault (**Setup**, password ≥ 12 chars); after that, every start requires **Unlock**. While the vault is locked, all `/api/*` endpoints (except `/api/health` and `/api/auth/*`) return **401** and the UI shows the unlock screen.
+- **Encrypted backups**: while the vault is unlocked, `Download Backup` produces a `.bin` file encrypted with the vault key (`application/octet-stream`); restore decrypts it automatically and still accepts older plaintext `.json` backups. With the vault disabled the backup is plaintext JSON.
 - **Plaintext only in memory**: decrypted data lives in RAM only while unlocked; locking the vault clears both the derived key and the in-memory repositories.
 - **No password recovery**: if you forget the vault password and have no backup, the data is unrecoverable (by design).
-- **Migration**: on first unlock after upgrading, existing plaintext `data/*.json` files are encrypted in place and a `*.json.bak` copy is left behind — delete the `.bak` files once you have confirmed the migration worked (`.bak` files are plaintext).
+- **Migration**: on first unlock after upgrading, existing plaintext `data/*.json` files are encrypted in place and a `*.json.bak` copy is left behind — delete the `.bak` files once you have confirmed the migration worked (`.bak` files are plaintext, warned about in Settings → Security).
 - **Localhost-first**: the Docker port is bound to `127.0.0.1` only (`docker-compose.yml`). **Do not publish port 8080 beyond localhost** (no `0.0.0.0`/LAN/VPN): anyone who can reach the port can attempt to unlock the vault.
 - **Threat model**: a sibling/colleague with the same OS session who opens the browser on this machine can interact with the UI, but cannot read the data on disk. The remaining surface is the machine itself: while unlocked, a process running under the same user could read the plaintext from RAM. Single-user local app by design.
 

--- a/src/MyAccountingApp.Api/DependencyInjection.cs
+++ b/src/MyAccountingApp.Api/DependencyInjection.cs
@@ -28,7 +28,8 @@ public static class DependencyInjection
     {
         bool isDev = builder.Environment.IsDevelopment();
 
-        IVaultService vaultService = new VaultService("data");
+        bool vaultEnabled = builder.Configuration.GetValue<bool>("Vault:Enabled");
+        IVaultService vaultService = vaultEnabled ? new VaultService("data") : new DisabledVaultService();
         builder.Services.AddSingleton<IVaultService>(vaultService);
 
         builder.Services.AddCors(options =>

--- a/src/MyAccountingApp.Api/Endpoints/AuthEndpoints.cs
+++ b/src/MyAccountingApp.Api/Endpoints/AuthEndpoints.cs
@@ -14,6 +14,7 @@ public static class AuthEndpoints
         {
             return Results.Ok(new
             {
+                isEnabled = vault.IsEnabled,
                 isInitialized = vault.IsInitialized,
                 isUnlocked = vault.IsUnlocked,
             });
@@ -21,6 +22,11 @@ public static class AuthEndpoints
 
         app.MapPost($"{prefix}/auth/setup", (AuthRequest request, IVaultService vault) =>
         {
+            if (!vault.IsEnabled)
+            {
+                return Results.BadRequest(new { message = "The vault is disabled." });
+            }
+
             if (vault.IsInitialized)
             {
                 return Results.BadRequest(new { message = "Vault is already initialized." });
@@ -54,8 +60,12 @@ public static class AuthEndpoints
 
         app.MapPost($"{prefix}/auth/lock", (IVaultService vault, IVaultSessionListener sessionListener) =>
         {
-            vault.Lock();
-            sessionListener.OnLocked();
+            if (vault.IsInitialized)
+            {
+                vault.Lock();
+                sessionListener.OnLocked();
+            }
+
             return Results.Ok(new { success = true });
         });
     }

--- a/src/MyAccountingApp.Api/Endpoints/BackupEndpoints.cs
+++ b/src/MyAccountingApp.Api/Endpoints/BackupEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
+using MyAccountingApp.Core.Vault;
 using MyAccountingApp.Domain.Entities;
 using MyAccountingApp.Domain.Interfaces;
 
@@ -12,24 +13,41 @@ public static class BackupEndpoints
     {
         const string prefix = ApiEndpoints.ApiPrefix;
 
-        app.MapGet($"{prefix}/backup", (ITransactionRepository txRepo, IPortfolioRepository pfRepo, IOptionTransactionRepository optRepo) =>
+        app.MapGet($"{prefix}/backup", (IVaultService vault, ITransactionRepository txRepo, IPortfolioRepository pfRepo, IOptionTransactionRepository optRepo) =>
         {
             List<Transaction> transactions = txRepo.GetAll().ToList();
             List<AssetTransaction> assetTransactions = pfRepo.GetAllTransactions().ToList();
             List<OptionTransaction> optionTransactions = optRepo.GetAll().ToList();
             string json = JsonSerializer.Serialize(new { transactions, assetTransactions, optionTransactions }, new JsonSerializerOptions { WriteIndented = true });
-            byte[] bytes = Encoding.UTF8.GetBytes(json);
-            return Results.File(bytes, "application/json", $"myaccounting-backup-{DateTime.Now:yyyyMMdd}.json");
+
+            bool encrypted = vault.IsUnlocked;
+            byte[] payload = encrypted ? vault.Encrypt(Encoding.UTF8.GetBytes(json)) : Encoding.UTF8.GetBytes(json);
+            string fileName = $"myaccounting-backup-{DateTime.Now:yyyyMMdd}.{(encrypted ? "bin" : "json")}";
+            return Results.File(payload, encrypted ? "application/octet-stream" : "application/json", fileName);
         });
 
-        app.MapPost($"{prefix}/backup", async (HttpRequest request, ITransactionRepository txRepo, IPortfolioRepository pfRepo, IOptionTransactionRepository optRepo, ILogger<Program> logger) =>
+        app.MapPost($"{prefix}/backup", async (HttpRequest request, IVaultService vault, ITransactionRepository txRepo, IPortfolioRepository pfRepo, IOptionTransactionRepository optRepo, ILogger<Program> logger) =>
         {
-            using StreamReader reader = new(request.Body);
-            string body = await reader.ReadToEndAsync();
+            using MemoryStream ms = new();
+            await request.Body.CopyToAsync(ms);
+            byte[] bodyBytes = ms.ToArray();
+
+            byte[] payload = bodyBytes;
+            if (vault.IsUnlocked)
+            {
+                try
+                {
+                    payload = vault.Decrypt(bodyBytes);
+                }
+                catch
+                {
+                    // Not encrypted: accept plaintext backups, e.g. created while the vault was disabled.
+                }
+            }
 
             try
             {
-                var backup = JsonSerializer.Deserialize<BackupData>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                var backup = JsonSerializer.Deserialize<BackupData>(Encoding.UTF8.GetString(payload), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                 if (backup?.Transactions is null)
                 {
                     return Results.BadRequest(new { error = "Invalid backup file format: 'transactions' array is required" });

--- a/src/MyAccountingApp.Core/Vault/DisabledVaultService.cs
+++ b/src/MyAccountingApp.Core/Vault/DisabledVaultService.cs
@@ -1,0 +1,37 @@
+namespace MyAccountingApp.Core.Vault;
+
+/// <summary>
+/// Vault no-op used when the vault feature is disabled via configuration
+/// (e.g. while the product is in development). Repositories keep operating
+/// in plaintext mode, the API gate never triggers, and no auth screens are
+/// shown to the user.
+/// </summary>
+public class DisabledVaultService : IVaultService
+{
+    public bool IsEnabled => false;
+
+    public bool IsInitialized => false;
+
+    public bool IsUnlocked => false;
+
+    public void Initialize(string password)
+    {
+        throw new InvalidOperationException("The vault is disabled.");
+    }
+
+    public bool Unlock(string password) => false;
+
+    public void Lock()
+    {
+    }
+
+    public byte[] Encrypt(byte[] plaintext)
+    {
+        throw new InvalidOperationException("The vault is disabled.");
+    }
+
+    public byte[] Decrypt(byte[] ciphertext)
+    {
+        throw new InvalidOperationException("The vault is disabled.");
+    }
+}

--- a/src/MyAccountingApp.Core/Vault/IVaultService.cs
+++ b/src/MyAccountingApp.Core/Vault/IVaultService.cs
@@ -2,6 +2,7 @@
 
 public interface IVaultService
 {
+    bool IsEnabled { get; }
     bool IsInitialized { get; }
     bool IsUnlocked { get; }
     void Initialize(string password);

--- a/src/MyAccountingApp.Core/Vault/VaultService.cs
+++ b/src/MyAccountingApp.Core/Vault/VaultService.cs
@@ -12,10 +12,18 @@ public class VaultService : IVaultService
     private bool _isUnlocked;
 
     public VaultService(string dataDirectory)
+        : this(dataDirectory, enabled: true)
     {
+    }
+
+    public VaultService(string dataDirectory, bool enabled)
+    {
+        this.IsEnabled = enabled;
         Directory.CreateDirectory(dataDirectory);
         this._metaFilePath = Path.Combine(dataDirectory, "vault.meta");
     }
+
+    public bool IsEnabled { get; }
 
     public bool IsInitialized
     {

--- a/src/MyAccountingApp.Web/Layout/MainLayout.razor
+++ b/src/MyAccountingApp.Web/Layout/MainLayout.razor
@@ -37,6 +37,11 @@
         try
         {
             AuthStatusDto status = await Http.GetFromJsonAsync<AuthStatusDto>("/api/auth/status") ?? new AuthStatusDto();
+            if (!status.IsEnabled)
+            {
+                return;
+            }
+
             if (!status.IsInitialized)
             {
                 if (!IsOnAuthPage("/setup"))

--- a/src/MyAccountingApp.Web/Models/Dtos.cs
+++ b/src/MyAccountingApp.Web/Models/Dtos.cs
@@ -201,6 +201,7 @@ public class WithholdingTotalDto
 
 public class AuthStatusDto
 {
+    public bool IsEnabled { get; set; }
     public bool IsInitialized { get; set; }
     public bool IsUnlocked { get; set; }
 }

--- a/src/MyAccountingApp.Web/Pages/Settings.razor
+++ b/src/MyAccountingApp.Web/Pages/Settings.razor
@@ -12,8 +12,12 @@
 
 <MudPaper Class="pa-4 mb-4" Outlined="true">
     <MudText Typo="Typo.body2" Class="mb-4">
-        Download a full backup of all transactions and asset transactions as a JSON file.
+        Download a full backup of all transactions and asset transactions.
         Use the restore feature to reload the backup after a hard reset.
+        @if (_status.IsEnabled)
+        {
+            <text>The downloaded file is encrypted and can only be restored while the vault is unlocked.</text>
+        }
     </MudText>
 
     <MudButton Variant="Variant.Filled" Color="Color.Primary"
@@ -32,6 +36,56 @@
         <InputFile OnChange="@UploadBackup" />
     </div>
 </MudPaper>
+
+@if (_status.IsEnabled)
+{
+    <MudText Typo="Typo.h6" Class="mb-4">Security</MudText>
+
+    <MudPaper Class="pa-4 mb-4" Outlined="true">
+        <MudText Typo="Typo.body2" Class="mb-4">
+            @if (_status.IsInitialized)
+            {
+                <MudChip T="string" Size="Size.Small" Color="@(_status.IsUnlocked ? Color.Success : Color.Warning)" Variant="Variant.Outlined">
+                    @(_status.IsUnlocked ? "Unlocked" : "Locked")
+                </MudChip>
+                <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined">Encrypted at rest</MudChip>
+            }
+            else
+            {
+                <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">Vault not set up yet</MudChip>
+            }
+        </MudText>
+
+        @if (_status.IsInitialized)
+        {
+            <MudText Typo="Typo.body2" Class="mb-4">
+                All data is encrypted with your password before being written to disk, and backups downloaded from this page are encrypted too.
+            </MudText>
+
+            @if (_status.IsUnlocked)
+            {
+                <MudButton Variant="Variant.Outlined" Color="Color.Warning"
+                           OnClick="@LockVaultAsync" StartIcon="@Icons.Material.Filled.Lock">
+                    Lock vault
+                </MudButton>
+            }
+
+            <MudAlert Severity="Severity.Warning" Class="mt-4">
+                Old plaintext backup files (<code>data/*.bak</code>) are <strong>not encrypted</strong>.
+                Delete them to avoid leaving readable data on disk.
+            </MudAlert>
+        }
+        else
+        {
+            <MudText Typo="Typo.body2" Class="mb-4">
+                The vault is enabled but not initialized yet. Set up a password to start encrypting your data.
+            </MudText>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@GoToSetup" StartIcon="@Icons.Material.Filled.Key">
+                Set up vault
+            </MudButton>
+        }
+    </MudPaper>
+}
 
 <MudPaper Class="pa-4 mb-4" Outlined="true" Style="border-color: var(--mud-palette-error);">
     <MudText Typo="Typo.h6" GutterBottom="true" Color="Color.Error">Danger Zone</MudText>
@@ -133,7 +187,7 @@
             Currency conversions will not be deleted.
         </MudText>
         <MudText Class="mt-2" Typo="Typo.body2">
-            Prefer a backup of <code>data/transactions.json</code> and <code>data/portfolio.json</code> before continuing.
+            Use <strong>Download Backup</strong> above before continuing.
         </MudText>
     </DialogContent>
     <DialogActions>
@@ -179,6 +233,7 @@
 </MudDialog>
 
 @code {
+    private AuthStatusDto _status = new();
     private bool _isRestoring;
     private bool _isResetting;
     private string? _lastRestoreMessage;
@@ -197,6 +252,36 @@
     private int _deleteYearPreviewOptions;
     private bool _showDeleteAssetYearDialog;
     private int _deleteAssetYearPreviewAssets;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            _status = await Http.GetFromJsonAsync<AuthStatusDto>("/api/auth/status") ?? new AuthStatusDto();
+        }
+        catch
+        {
+            // API unreachable: the page renders with the default state.
+        }
+    }
+
+    private void GoToSetup()
+    {
+        Navigation.NavigateTo("/setup");
+    }
+
+    private async Task LockVaultAsync()
+    {
+        try
+        {
+            await Http.PostAsync("/api/auth/lock", null);
+            Navigation.NavigateTo("/unlock", forceLoad: true);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to lock vault: {ex.Message}", Severity.Error);
+        }
+    }
 
     private void DownloadBackup()
     {

--- a/src/MyAccountingApp.Web/Pages/Setup.razor
+++ b/src/MyAccountingApp.Web/Pages/Setup.razor
@@ -44,7 +44,11 @@ else
         try
         {
             AuthStatusDto status = await Http.GetFromJsonAsync<AuthStatusDto>("/api/auth/status") ?? new AuthStatusDto();
-            if (status.IsInitialized)
+            if (!status.IsEnabled)
+            {
+                Navigation.NavigateTo("/");
+            }
+            else if (status.IsInitialized)
             {
                 Navigation.NavigateTo(status.IsUnlocked ? "/" : "/unlock");
             }

--- a/src/MyAccountingApp.Web/Pages/Unlock.razor
+++ b/src/MyAccountingApp.Web/Pages/Unlock.razor
@@ -43,7 +43,11 @@ else
         try
         {
             AuthStatusDto status = await Http.GetFromJsonAsync<AuthStatusDto>("/api/auth/status") ?? new AuthStatusDto();
-            if (!status.IsInitialized)
+            if (!status.IsEnabled)
+            {
+                Navigation.NavigateTo("/");
+            }
+            else if (!status.IsInitialized)
             {
                 Navigation.NavigateTo("/setup");
             }

--- a/tests/MyAccountingApp.Api.Tests/BackupEncryptionTests.cs
+++ b/tests/MyAccountingApp.Api.Tests/BackupEncryptionTests.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using MyAccountingApp.Core.Vault;
+using Xunit;
+
+namespace MyAccountingApp.Api.Tests;
+
+public class BackupEncryptionTests
+{
+    [Fact]
+    public async Task Backup_ShouldBeEncrypted_WhenVaultIsUnlocked()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/auth/setup", new { password = "testpassword123" });
+        await client.PostAsJsonAsync("/api/transactions", new
+        {
+            date = DateTime.Today,
+            description = "Test transaction",
+            amount = 12.5m,
+            currency = "EUR",
+            category = "EXPENSE",
+        });
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/api/backup");
+
+        // Assert: binary payload, not plaintext JSON
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/octet-stream", response.Content.Headers.ContentType?.MediaType);
+        byte[] bytes = await response.Content.ReadAsByteArrayAsync();
+        string raw = Encoding.UTF8.GetString(bytes);
+        Assert.DoesNotContain("transactions", raw);
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<JsonElement>(raw));
+
+        // Act 2: the encrypted blob can be restored as-is
+        HttpResponseMessage restored = await client.PostAsync("/api/backup", new ByteArrayContent(bytes));
+        Assert.Equal(HttpStatusCode.OK, restored.StatusCode);
+        string? message = JsonDocument.Parse(await restored.Content.ReadAsStringAsync()).RootElement.GetProperty("message").GetString();
+        Assert.NotNull(message);
+        Assert.Contains("Restored 1 transactions", message);
+    }
+
+    [Fact]
+    public async Task Backup_ShouldStillAccept_PlaintextBackups_WhenVaultIsUnlocked()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/auth/setup", new { password = "testpassword123" });
+        const string body = """{"transactions":[],"assetTransactions":[],"optionTransactions":[]}""";
+
+        // Act: upload an old plaintext backup
+        HttpResponseMessage response = await client.PostAsync("/api/backup", new StringContent(body, Encoding.UTF8, "application/json"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Backup_ShouldReturn401_WhileVaultIsLocked()
+    {
+        // Arrange
+        using ApiWebApplicationFactory factory = new ApiWebApplicationFactory();
+        HttpClient client = factory.CreateClient();
+        await client.PostAsJsonAsync("/api/auth/setup", new { password = "testpassword123" });
+        await client.PostAsJsonAsync("/api/auth/lock", new { });
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("/api/backup");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private sealed class DisabledVaultFactory : ApiWebApplicationFactory
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IVaultService>();
+                services.AddSingleton<IVaultService>(new DisabledVaultService());
+            });
+        }
+    }
+
+    [Fact]
+    public async Task VaultDisabled_ShouldReportStatus_AndServeDataWithoutSetup()
+    {
+        // Arrange
+        using DisabledVaultFactory factory = new DisabledVaultFactory();
+        HttpClient client = factory.CreateClient();
+
+        // Act
+        HttpResponseMessage statusResp = await client.GetAsync("/api/auth/status");
+        HttpResponseMessage txResp = await client.GetAsync("/api/transactions");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, statusResp.StatusCode);
+        using (JsonDocument doc = JsonDocument.Parse(await statusResp.Content.ReadAsStringAsync()))
+        {
+            Assert.False(doc.RootElement.GetProperty("isEnabled").GetBoolean());
+        }
+
+        Assert.Equal(HttpStatusCode.OK, txResp.StatusCode); // no setup, no unlock needed
+    }
+}

--- a/tests/MyAccountingApp.Core.Tests/Vault/DisabledVaultServiceTests.cs
+++ b/tests/MyAccountingApp.Core.Tests/Vault/DisabledVaultServiceTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Text;
+using MyAccountingApp.Core.Vault;
+using Xunit;
+
+namespace MyAccountingApp.Core.Tests.Vault;
+
+public class DisabledVaultServiceTests
+{
+    [Fact]
+    public void DisabledVault_ShouldNeverBeInitializedOrUnlocked()
+    {
+        IVaultService vault = new DisabledVaultService();
+
+        Assert.False(vault.IsEnabled);
+        Assert.False(vault.IsInitialized);
+        Assert.False(vault.IsUnlocked);
+        Assert.False(vault.Unlock("anyPassword"));
+    }
+
+    [Fact]
+    public void DisabledVault_ShouldLockWithoutSideEffects()
+    {
+        IVaultService vault = new DisabledVaultService();
+        vault.Lock();
+        Assert.False(vault.IsUnlocked);
+    }
+
+    [Fact]
+    public void DisabledVault_ShouldThrow_OnInitialize()
+    {
+        IVaultService vault = new DisabledVaultService();
+        Assert.Throws<InvalidOperationException>(() => vault.Initialize("securePassword123"));
+    }
+
+    [Fact]
+    public void DisabledVault_ShouldThrow_OnEncryptAndDecrypt()
+    {
+        IVaultService vault = new DisabledVaultService();
+        byte[] data = Encoding.UTF8.GetBytes("test");
+        Assert.Throws<InvalidOperationException>(() => vault.Encrypt(data));
+        Assert.Throws<InvalidOperationException>(() => vault.Decrypt(data));
+    }
+}


### PR DESCRIPTION
## What
- **`Vault:Enabled` feature flag** (`appsettings.json`, default `false`): while developing, the vault is off — plaintext storage, no Setup/Unlock screens, nothing blocks. Set to `true` when consolidated to activate encryption, the 401 gate and the auth UI.
- **Encrypted backups**: with the vault active, `Download Backup` produces a `.bin` encrypted with the vault key; restore decrypts it automatically and still accepts older plaintext `.json` backups. While locked, `/api/backup` returns 401.
- **Settings → Security section**: vault status chips, Lock button, `.bak` plaintext warning; stale `data/*.json` references in the reset dialog replaced with "use Download Backup".
- Plus the vault UX already on this branch: unlock/setup screens, session listener reload on unlock, 401 handler fix (re-created from the earlier PR review).

## Tests
- `DisabledVaultServiceTests` (Core): no-op behavior, throws on Encrypt/Decrypt/Initialize.
- `BackupEncryptionTests` (API): encrypted round-trip, plaintext fallback, 401 while locked, status with flag off.
- Full suite: 311 tests green, build 0 warnings.

## Notes
- `Vault:Enabled` defaults to `false` (fails open) — flip to `true` once the product is consolidated.